### PR TITLE
Include HTTPRoute namespace in OCI listener policy rule names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ test.log
 .opencode/
 
 # We don't yet commit OpenSpec to the repo.
-.openspec/
+openspec/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ Environment notes:
 - `.envrc` sets `GOPATH` under `../go/<go-version>` and adds local `bin` to `PATH`
 - optional local overrides live in `.envrc.local`
 
+**Important**: Due to harness shell configuration, all shell commands should be run with `direnv exec . <command>`.
+
 ## Common Commands
 
 - Lint: `make lint`
@@ -85,14 +87,6 @@ Examples:
 - Linting is strict; avoid adding `//nolint` unless it is justified
 - Wrap errors with context, usually `fmt.Errorf("...: %w", err)`
 - Do not hardcode secrets, tenancy data, kubeconfigs, or OCI credentials
-- Prefer updating the smallest relevant config or package instead of duplicating behavior
-
-## Validation Before Finish
-
-For Go, config, Helm, Docker, or workflow changes, run the checks that match the files you touched:
-- Default: `make lint` and `make test`
-- If `build/scripts` changed: also run `make -C build test`
-- If only documentation changed: no code validation is required
 
 ## References
 
@@ -100,3 +94,25 @@ For Go, config, Helm, Docker, or workflow changes, run the checks that match the
 - Build details: `build/README.md`
 - Deploy details: `deploy/README.md`
 - HTTPS notes: `docs/https.md`
+
+## Task Completion Protocol
+
+### Coding Task Completion Protocol
+
+Apply this when any Go, YAML, config, or other code-related files changed.
+
+Always do all of the following before reporting completion:
+1. Run `direnv exec . make lint` and confirm no errors.
+2. Run `direnv exec . make test` and confirm all tests pass.
+3. Update this file if commands, workflows, or architecture changed.
+
+Report completion status:
+- Lint: ✓ no errors
+- Tests: ✓ all passing, coverage XX.XX%
+- AGENTS.md: ✓ updated / no changes needed
+
+### Non-Coding Task Completion Protocol
+
+For investigation or documentation-only work:
+- Summarize findings or actions taken.
+- Confirm any deliverables produced.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Environment notes:
 - `.envrc` sets `GOPATH` under `../go/<go-version>` and adds local `bin` to `PATH`
 - optional local overrides live in `.envrc.local`
 
-**Important**: Due to harness shell configuration, all shell commands should be run with `direnv exec . <command>`.
+**Important**: Due to harness shell configuration, project related shell commands should be run with `direnv exec . <command>`.
 
 ## Common Commands
 

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1020,7 +1020,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run("program with previously programmed annotations", func(t *testing.T) {
+		t.Run("program with previously programmed annotations passes stale rules for cleanup", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newHTTPRouteModel(deps)
 
@@ -1030,15 +1030,16 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			// Create HTTP route with multiple rules
 			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithNamespaceOpt(fmt.Sprintf("ns_%d", rand.IntN(1000))),
+				randomHTTPRouteWithNameOpt(fmt.Sprintf("rt_%d", rand.IntN(1000))),
 				randomHTTPRouteWithRulesOpt(
 					makeRandomHTTPRouteRule(),
 					makeRandomHTTPRouteRule(),
 				),
 			)
 			wantPreviousRules := []string{
-				"rule1-" + faker.Word(),
-				"rule2-" + faker.Word(),
-				"rule3-" + faker.Word(),
+				fmt.Sprintf("p0000_%s", httpRoute.Name),
+				fmt.Sprintf("p0001_%s", httpRoute.Name),
 			}
 			httpRoute.Annotations = map[string]string{
 				HTTPRouteProgrammedPolicyRulesAnnotation: strings.Join(wantPreviousRules, ","),
@@ -1076,6 +1077,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			expectedRules := make([]loadbalancer.RoutingRule, 0, len(httpRoute.Spec.Rules))
 			for i := range httpRoute.Spec.Rules {
 				rule := makeRandomOCIRoutingRule()
+				rule.Name = lo.ToPtr(ociListerPolicyRuleName(httpRoute, i))
 				expectedRules = append(expectedRules, rule)
 
 				ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"log/slog"
 	"maps"
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
@@ -833,18 +835,32 @@ var invalidCharsForPolicyNamePattern = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 // Names should also be sortable, so we're using a 4 digit index.
 func ociListerPolicyRuleName(route gatewayv1.HTTPRoute, ruleIndex int) string {
 	rule := route.Spec.Rules[ruleIndex]
+	nameParts := []string{route.Namespace, route.Name}
 
-	var resultingName string
 	if rule.Name != nil {
-		resultingName = fmt.Sprintf("p%04d_%s_%s_%s", ruleIndex, route.Namespace, route.Name, string(*rule.Name))
-	} else {
-		resultingName = fmt.Sprintf("p%04d_%s_%s", ruleIndex, route.Namespace, route.Name)
+		nameParts = append(nameParts, string(*rule.Name))
 	}
+
+	resultingName := fmt.Sprintf(
+		"p%04d_%08x_%s",
+		ruleIndex,
+		crc32.ChecksumIEEE([]byte(ociListenerPolicyRuleIdentity(ruleIndex, nameParts...))),
+		strings.Join(nameParts, "_"),
+	)
 
 	return ociapi.ConstructOCIResourceName(resultingName, ociapi.OCIResourceNameConfig{
 		MaxLength:           maxListenerPolicyNameLength,
 		InvalidCharsPattern: invalidCharsForPolicyNamePattern,
 	})
+}
+
+func ociListenerPolicyRuleIdentity(ruleIndex int, nameParts ...string) string {
+	var result strings.Builder
+	result.WriteString(strconv.Itoa(ruleIndex))
+	for _, part := range nameParts {
+		result.WriteString(fmt.Sprintf(":%d:%s", len(part), part))
+	}
+	return result.String()
 }
 
 // ociBackendSetName returns the name of the backend set for the route.

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -832,18 +832,13 @@ var invalidCharsForPolicyNamePattern = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 // It's expected that the rule name is unique within the listener policy for every route.
 // Names should also be sortable, so we're using a 4 digit index.
 func ociListerPolicyRuleName(route gatewayv1.HTTPRoute, ruleIndex int) string {
-	// TODO: This may probably need to have namespace
-	// Also check if namespace is populated in the route if it's not in the spec
-	// Also mention in docs that policy is per listener and rules for different
-	// services best to have something unique like host matching
-
 	rule := route.Spec.Rules[ruleIndex]
 
 	var resultingName string
 	if rule.Name != nil {
-		resultingName = fmt.Sprintf("p%04d_%s_%s", ruleIndex, route.Name, string(*rule.Name))
+		resultingName = fmt.Sprintf("p%04d_%s_%s_%s", ruleIndex, route.Namespace, route.Name, string(*rule.Name))
 	} else {
-		resultingName = fmt.Sprintf("p%04d_%s", ruleIndex, route.Name)
+		resultingName = fmt.Sprintf("p%04d_%s_%s", ruleIndex, route.Namespace, route.Name)
 	}
 
 	return ociapi.ConstructOCIResourceName(resultingName, ociapi.OCIResourceNameConfig{

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -2119,26 +2119,29 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 			index := rand.IntN(len(fewRules))
 
 			route := makeRandomHTTPRoute(
-				randomHTTPRouteWithNameOpt("route_"+faker.Word()),
+				randomHTTPRouteWithNamespaceOpt(fmt.Sprintf("ns_%d", rand.IntN(1000))),
+				randomHTTPRouteWithNameOpt(fmt.Sprintf("rt_%d", rand.IntN(1000))),
 				randomHTTPRouteWithRulesOpt(fewRules...),
 			)
 			return testCase{
 				name:      "unnamed rule",
 				route:     route,
 				ruleIndex: index,
-				want:      fmt.Sprintf("p%04d_%s", index, route.Name),
+				want:      fmt.Sprintf("p%04d_%s_%s", index, route.Namespace, route.Name),
 			}
 		},
 		func() testCase {
 			rule := makeRandomHTTPRouteRule()
 			index := 0
 
-			unsanitizedParentName := fmt.Sprintf("route-%d-!#:-rule", rand.IntN(1000))
+			unsanitizedNamespace := fmt.Sprintf("ns-%d!", rand.IntN(1000))
+			unsanitizedParentName := fmt.Sprintf("rt-%d!", rand.IntN(1000))
 			route := makeRandomHTTPRoute(
 				randomHTTPRouteWithRulesOpt(rule),
+				randomHTTPRouteWithNamespaceOpt(unsanitizedNamespace),
 				randomHTTPRouteWithNameOpt(unsanitizedParentName),
 			)
-			unsanitizedInput := fmt.Sprintf("p%04d_%s", index, unsanitizedParentName)
+			unsanitizedInput := fmt.Sprintf("p%04d_%s_%s", index, unsanitizedNamespace, unsanitizedParentName)
 			want := ociapi.ConstructOCIResourceName(unsanitizedInput, ociapi.OCIResourceNameConfig{
 				MaxLength:           32,
 				InvalidCharsPattern: invalidCharsForPolicyNamePattern,
@@ -2152,7 +2155,7 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 			}
 		},
 		func() testCase {
-			ruleName := "rl_" + faker.Word()
+			ruleName := fmt.Sprintf("rl_%d", rand.IntN(1000))
 			fewRules := []gatewayv1.HTTPRouteRule{
 				makeRandomHTTPRouteRule(),
 
@@ -2164,14 +2167,15 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 			fewRules[index].Name = lo.ToPtr(gatewayv1.SectionName(ruleName))
 
 			route := makeRandomHTTPRoute(
-				randomHTTPRouteWithNameOpt("rt_"+faker.Word()),
+				randomHTTPRouteWithNamespaceOpt(fmt.Sprintf("ns_%d", rand.IntN(1000))),
+				randomHTTPRouteWithNameOpt(fmt.Sprintf("rt_%d", rand.IntN(1000))),
 				randomHTTPRouteWithRulesOpt(fewRules...),
 			)
 			return testCase{
 				name:      "named rule",
 				route:     route,
 				ruleIndex: index,
-				want:      fmt.Sprintf("p%04d_%s_%s", index, route.Name, ruleName),
+				want:      fmt.Sprintf("p%04d_%s_%s_%s", index, route.Namespace, route.Name, ruleName),
 			}
 		},
 		func() testCase {
@@ -2181,12 +2185,15 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 			rule.Name = lo.ToPtr(gatewayv1.SectionName(unsanitizedRuleName))
 			index := 0
 
-			unsanitizedParentName := fmt.Sprintf("route-%d-!#:-rule", rand.IntN(1000))
+			unsanitizedNamespace := fmt.Sprintf("ns-%d!", rand.IntN(1000))
+			unsanitizedParentName := fmt.Sprintf("rt-%d!", rand.IntN(1000))
 			route := makeRandomHTTPRoute(
 				randomHTTPRouteWithRulesOpt(rule),
+				randomHTTPRouteWithNamespaceOpt(unsanitizedNamespace),
 				randomHTTPRouteWithNameOpt(unsanitizedParentName),
 			)
-			unsanitizedInput := fmt.Sprintf("p%04d_%s_%s", index, unsanitizedParentName, unsanitizedRuleName)
+			unsanitizedInput := fmt.Sprintf("p%04d_%s_%s_%s",
+				index, unsanitizedNamespace, unsanitizedParentName, unsanitizedRuleName)
 			want := ociapi.ConstructOCIResourceName(unsanitizedInput, ociapi.OCIResourceNameConfig{
 				MaxLength:           32,
 				InvalidCharsPattern: invalidCharsForPolicyNamePattern,
@@ -2208,6 +2215,33 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+
+	t.Run("same route name in different namespace", func(t *testing.T) {
+		rule := makeRandomHTTPRouteRule()
+		index := 0
+		routeName := "route_" + faker.Word()
+		namespace := "ns_" + faker.Word()
+		otherNamespace := "other_ns_" + faker.Word()
+		for otherNamespace == namespace {
+			otherNamespace = "other_ns_" + faker.Word()
+		}
+
+		route := makeRandomHTTPRoute(
+			randomHTTPRouteWithNamespaceOpt(namespace),
+			randomHTTPRouteWithNameOpt(routeName),
+			randomHTTPRouteWithRulesOpt(rule),
+		)
+		otherRoute := makeRandomHTTPRoute(
+			randomHTTPRouteWithNamespaceOpt(otherNamespace),
+			randomHTTPRouteWithNameOpt(routeName),
+			randomHTTPRouteWithRulesOpt(rule),
+		)
+
+		assert.NotEqual(t,
+			ociListerPolicyRuleName(route, index),
+			ociListerPolicyRuleName(otherRoute, index),
+		)
+	})
 }
 
 func Test_ociBackendSetNameFromBackendRef(t *testing.T) {

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -3,9 +3,11 @@ package app
 import (
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"maps"
 	"math/rand/v2"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
@@ -2099,6 +2101,19 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 }
 
 func Test_ociListerPolicyRuleName(t *testing.T) {
+	makeExpectedName := func(ruleIndex int, nameParts ...string) string {
+		unsanitizedInput := fmt.Sprintf(
+			"p%04d_%08x_%s",
+			ruleIndex,
+			crc32.ChecksumIEEE([]byte(ociListenerPolicyRuleIdentity(ruleIndex, nameParts...))),
+			strings.Join(nameParts, "_"),
+		)
+		return ociapi.ConstructOCIResourceName(unsanitizedInput, ociapi.OCIResourceNameConfig{
+			MaxLength:           maxListenerPolicyNameLength,
+			InvalidCharsPattern: invalidCharsForPolicyNamePattern,
+		})
+	}
+
 	type testCase struct {
 		name      string
 		route     gatewayv1.HTTPRoute
@@ -2127,7 +2142,7 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 				name:      "unnamed rule",
 				route:     route,
 				ruleIndex: index,
-				want:      fmt.Sprintf("p%04d_%s_%s", index, route.Namespace, route.Name),
+				want:      makeExpectedName(index, route.Namespace, route.Name),
 			}
 		},
 		func() testCase {
@@ -2141,17 +2156,11 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 				randomHTTPRouteWithNamespaceOpt(unsanitizedNamespace),
 				randomHTTPRouteWithNameOpt(unsanitizedParentName),
 			)
-			unsanitizedInput := fmt.Sprintf("p%04d_%s_%s", index, unsanitizedNamespace, unsanitizedParentName)
-			want := ociapi.ConstructOCIResourceName(unsanitizedInput, ociapi.OCIResourceNameConfig{
-				MaxLength:           32,
-				InvalidCharsPattern: invalidCharsForPolicyNamePattern,
-			})
-
 			return testCase{
 				name:      "sanitized unnamed rule",
 				route:     route,
 				ruleIndex: index,
-				want:      want,
+				want:      makeExpectedName(index, unsanitizedNamespace, unsanitizedParentName),
 			}
 		},
 		func() testCase {
@@ -2175,7 +2184,7 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 				name:      "named rule",
 				route:     route,
 				ruleIndex: index,
-				want:      fmt.Sprintf("p%04d_%s_%s_%s", index, route.Namespace, route.Name, ruleName),
+				want:      makeExpectedName(index, route.Namespace, route.Name, ruleName),
 			}
 		},
 		func() testCase {
@@ -2192,18 +2201,11 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 				randomHTTPRouteWithNamespaceOpt(unsanitizedNamespace),
 				randomHTTPRouteWithNameOpt(unsanitizedParentName),
 			)
-			unsanitizedInput := fmt.Sprintf("p%04d_%s_%s_%s",
-				index, unsanitizedNamespace, unsanitizedParentName, unsanitizedRuleName)
-			want := ociapi.ConstructOCIResourceName(unsanitizedInput, ociapi.OCIResourceNameConfig{
-				MaxLength:           32,
-				InvalidCharsPattern: invalidCharsForPolicyNamePattern,
-			})
-
 			return testCase{
 				name:      "sanitized named rule",
 				route:     route,
 				ruleIndex: index,
-				want:      want,
+				want:      makeExpectedName(index, unsanitizedNamespace, unsanitizedParentName, unsanitizedRuleName),
 			}
 		},
 	}
@@ -2234,6 +2236,30 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 		otherRoute := makeRandomHTTPRoute(
 			randomHTTPRouteWithNamespaceOpt(otherNamespace),
 			randomHTTPRouteWithNameOpt(routeName),
+			randomHTTPRouteWithRulesOpt(rule),
+		)
+
+		assert.NotEqual(t,
+			ociListerPolicyRuleName(route, index),
+			ociListerPolicyRuleName(otherRoute, index),
+		)
+	})
+
+	t.Run("sanitized namespace and route name boundaries remain unique", func(t *testing.T) {
+		rule := makeRandomHTTPRouteRule()
+		index := 0
+		namePartA := faker.Word()
+		namePartB := faker.Word()
+		namePartC := faker.Word()
+
+		route := makeRandomHTTPRoute(
+			randomHTTPRouteWithNamespaceOpt(fmt.Sprintf("%s-%s", namePartA, namePartB)),
+			randomHTTPRouteWithNameOpt(namePartC),
+			randomHTTPRouteWithRulesOpt(rule),
+		)
+		otherRoute := makeRandomHTTPRoute(
+			randomHTTPRouteWithNamespaceOpt(namePartA),
+			randomHTTPRouteWithNameOpt(fmt.Sprintf("%s-%s", namePartB, namePartC)),
 			randomHTTPRouteWithRulesOpt(rule),
 		)
 


### PR DESCRIPTION
- Prefix OCI listener policy rule names with the HTTPRoute namespace so routes with the same name in different namespaces no longer collide on a shared listener policy.
- Update `ociListerPolicyRuleName` and unit tests, including a case for identical route names across namespaces.
- Align the HTTPRoute programming test with deterministic rule names when verifying stale-rule cleanup.
- Document `direnv exec .` for shell commands and add task completion protocols in AGENTS.md.
- Fix `.gitignore` to ignore `openspec/` instead of `.openspec/`.

## Test plan
- [ ] `direnv exec . make lint`
- [ ] `direnv exec . make test`
- [ ] Verify two HTTPRoutes with the same name in different namespaces produce distinct OCI listener policy rule names