### PR TITLE
fix: reconcile gateways on gatewayconfig changes

### DIFF
--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -17,6 +17,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
+	configtypes "github.com/gemyago/oke-gateway-api/internal/types"
 )
 
 const httpRouteBackendServiceIndexKey = ".metadata.backendRefs.serviceName" // Virtual field name, indexed
@@ -261,6 +262,50 @@ func (m *WatchesModel) MapEndpointSliceToHTTPRoute(ctx context.Context, obj clie
 			"Queueing HTTPRoute for reconciliation due to EndpointSlice change",
 			slog.String("httpRoute", client.ObjectKeyFromObject(&route).String()),
 			slog.String("endpointSlice", client.ObjectKeyFromObject(epSlice).String()),
+		)
+	}
+
+	return requests
+}
+
+// MapGatewayConfigToGateway maps GatewayConfig events to Gateway reconcile requests.
+// Its signature matches handler.MapFunc.
+func (m *WatchesModel) MapGatewayConfigToGateway(ctx context.Context, obj client.Object) []reconcile.Request {
+	config, ok := obj.(*configtypes.GatewayConfig)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-GatewayConfig object", slog.Any("object", obj))
+		return nil
+	}
+
+	var gatewayList gatewayv1.GatewayList
+	if err := m.k8sClient.List(ctx, &gatewayList, client.InNamespace(config.Namespace)); err != nil {
+		m.logger.ErrorContext(ctx, "Failed to list Gateways for GatewayConfig change",
+			slog.String("gatewayConfig", client.ObjectKeyFromObject(config).String()),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for _, gateway := range gatewayList.Items {
+		if gateway.DeletionTimestamp != nil ||
+			gateway.Annotations == nil ||
+			gateway.Annotations[ControllerClassName] != "true" ||
+			gateway.Spec.Infrastructure == nil ||
+			gateway.Spec.Infrastructure.ParametersRef == nil ||
+			gateway.Spec.Infrastructure.ParametersRef.Name != config.Name {
+			continue
+		}
+
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&gateway)})
+		m.logger.InfoContext(ctx,
+			"Queueing Gateway for reconciliation due to GatewayConfig change",
+			slog.String("gateway", client.ObjectKeyFromObject(&gateway).String()),
+			slog.String("gatewayConfig", client.ObjectKeyFromObject(config).String()),
+			slog.String("resourceVersion", gateway.ResourceVersion),
+			slog.Int64("generation", gateway.Generation),
+			slog.String("gatewayConfigResourceVersion", config.ResourceVersion),
+			slog.Int64("gatewayConfigGeneration", config.Generation),
 		)
 	}
 

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
 	"github.com/gemyago/oke-gateway-api/internal/services/k8sapi"
+	configtypes "github.com/gemyago/oke-gateway-api/internal/types"
 )
 
 func withRelevantGatewayClass(gw *gatewayv1.Gateway) {
@@ -757,6 +758,95 @@ func TestWatchesModel(t *testing.T) {
 
 			result := model.MapSecretToGateway(t.Context(), &corev1.Service{})
 			require.Nil(t, result)
+		})
+	})
+	t.Run("MapGatewayConfigToGateway", func(t *testing.T) {
+		t.Run("maps GatewayConfig changes to referencing Gateways", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			config := &configtypes.GatewayConfig{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "edge-config"},
+			}
+			now := metav1.Now()
+			gateways := []gatewayv1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "iot",
+						Name:        "edge",
+						Annotations: map[string]string{ControllerClassName: "true"},
+					},
+					Spec: gatewayv1.GatewaySpec{
+						Infrastructure: &gatewayv1.GatewayInfrastructure{
+							ParametersRef: &gatewayv1.LocalParametersReference{
+								Name: "edge-config",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "not-managed"},
+					Spec: gatewayv1.GatewaySpec{
+						Infrastructure: &gatewayv1.GatewayInfrastructure{
+							ParametersRef: &gatewayv1.LocalParametersReference{
+								Name: "edge-config",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "other"},
+					Spec: gatewayv1.GatewaySpec{
+						Infrastructure: &gatewayv1.GatewayInfrastructure{
+							ParametersRef: &gatewayv1.LocalParametersReference{
+								Name: "other-config",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "missing-ref"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "iot",
+						Name:              "deleting",
+						DeletionTimestamp: &now,
+					},
+					Spec: gatewayv1.GatewaySpec{
+						Infrastructure: &gatewayv1.GatewayInfrastructure{
+							ParametersRef: &gatewayv1.LocalParametersReference{
+								Name: "edge-config",
+							},
+						},
+					},
+				},
+			}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.GatewayList{}, client.InNamespace("iot")).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf(gateways))
+					return nil
+				})
+
+			require.Equal(t, []reconcile.Request{
+				{NamespacedName: apitypes.NamespacedName{Namespace: "iot", Name: "edge"}},
+			}, model.MapGatewayConfigToGateway(t.Context(), config))
+			require.Nil(t, model.MapGatewayConfigToGateway(t.Context(), &corev1.Service{}))
+		})
+
+		t.Run("handles Gateway list errors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			config := &configtypes.GatewayConfig{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "edge-config"},
+			}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.GatewayList{}, client.InNamespace("iot")).
+				Return(errors.New("gateway list failed"))
+
+			require.Nil(t, model.MapGatewayConfigToGateway(t.Context(), config))
 		})
 	})
 }

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -20,6 +20,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/app"
+	configtypes "github.com/gemyago/oke-gateway-api/internal/types"
 )
 
 // StartManagerDeps contains the dependencies for the controller manager.
@@ -93,6 +94,11 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error { // coverag
 					},
 					predicate.ResourceVersionChangedPredicate{},
 				)),
+			).
+			Watches(
+				&configtypes.GatewayConfig{},
+				handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGatewayConfigToGateway),
+				builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 			).
 			Complete(wireupReconciler(deps.GatewayCtrl, middlewares...)); err != nil {
 			return fmt.Errorf("failed to setup Gateway controller: %w", err)


### PR DESCRIPTION
### Reconcile Gateway on GatewayConfig changes

This change updates the controller watches so changes to `GatewayConfig` resources enqueue the `Gateways` that reference them for reconciliation.

Previously, updating a GatewayConfig could leave existing Gateways unchanged until some other watched resource caused a reconcile. With this change, the controller indexes Gateways by their referenced GatewayConfig and maps GatewayConfig create/update/delete events back to affected Gateways.

This makes configuration changes apply predictably without requiring users to manually touch the Gateway.