### PR TITLE
Fix OCI resource name truncation panic

### DIFF
--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -2332,6 +2332,33 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 			ociListerPolicyRuleName(otherRoute, index),
 		)
 	})
+
+	t.Run("truncates generated name at crash boundary", func(t *testing.T) {
+		fake := faker.New()
+		rule := makeRandomHTTPRouteRule()
+		index := 0
+		namespace := fake.Numerify("#################")
+		routeName := fake.Numerify("############################")
+		route := makeRandomHTTPRoute(
+			randomHTTPRouteWithNamespaceOpt(namespace),
+			randomHTTPRouteWithNameOpt(routeName),
+			randomHTTPRouteWithRulesOpt(rule),
+		)
+
+		unsanitizedInput := fmt.Sprintf(
+			"p%04d_%08x_%s",
+			index,
+			crc32.ChecksumIEEE([]byte(ociListenerPolicyRuleIdentity(index, namespace, routeName))),
+			strings.Join([]string{namespace, routeName}, "_"),
+		)
+		require.Len(t, unsanitizedInput, 61)
+
+		require.NotPanics(t, func() {
+			got := ociListerPolicyRuleName(route, index)
+			assert.Len(t, got, maxListenerPolicyNameLength)
+			assert.False(t, invalidCharsForPolicyNamePattern.MatchString(got))
+		})
+	})
 }
 
 func Test_ociBackendSetNameFromBackendRef(t *testing.T) {

--- a/internal/services/ociapi/oci_resources.go
+++ b/internal/services/ociapi/oci_resources.go
@@ -61,6 +61,10 @@ func ConstructOCIResourceName(originalName string, config OCIResourceNameConfig)
 		}
 		originalLength := len(resultingName)
 		hashStarts := originalLength/ociResourceNameHashPartDivider - len(hash)/ociResourceNameHashPartDivider
+		maxHashStart := config.MaxLength - len(hash)
+		if hashStarts > maxHashStart {
+			hashStarts = (maxHashStart + 1) / ociResourceNameHashPartDivider
+		}
 		hashEnds := hashStarts + len(hash)
 		remainingLength := config.MaxLength - hashEnds
 		resultingName = resultingName[:hashStarts] + hash + resultingName[originalLength-remainingLength:]

--- a/internal/services/ociapi/oci_resources_test.go
+++ b/internal/services/ociapi/oci_resources_test.go
@@ -95,6 +95,27 @@ func TestConstructOCIResourceName(t *testing.T) {
 			require.True(t, sanitized)
 		})
 
+		t.Run("with limit clamps hash position when centered hash exceeds limit", func(t *testing.T) {
+			input := services.RandomString(61 + rand.IntN(20))
+			wantHash := services.RandomString(8)
+			wantMaxLength := 32
+			wantAvailableLength := wantMaxLength - len(wantHash)
+			wantPrefixLength := (wantAvailableLength + 1) / 2
+			wantSuffixLength := wantAvailableLength - wantPrefixLength
+			wantResult := input[:wantPrefixLength] + wantHash + input[len(input)-wantSuffixLength:]
+
+			got := ConstructOCIResourceName(input, OCIResourceNameConfig{
+				MaxLength: wantMaxLength,
+				hashFunc: func(hashInput string) string {
+					assert.Equal(t, input, hashInput)
+					return wantHash
+				},
+			})
+
+			require.Equal(t, wantResult, got)
+			assert.Len(t, got, wantMaxLength)
+		})
+
 		t.Run("with limit no sanitize fixed cases", func(t *testing.T) {
 			type testCase struct {
 				input string


### PR DESCRIPTION
## Summary
- clamp OCI resource-name hash placement when original-centered truncation cannot fit within the max length
- preserve a balanced prefix/suffix around the hash for names in the crash range
- add regressions for the 61-byte listener policy rule name shape from the panic

## Verification
- direnv exec . go test ./internal/services/ociapi ./internal/app -run 'TestConstructOCIResourceName|Test_ociListerPolicyRuleName'\n- direnv exec . make lint\n- direnv exec . make test