### PR TITLE
Sync Helm chart version with app version

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -67,8 +67,7 @@ jobs:
             --title "Release ${{ github.event.inputs.release_name }}" \
             --body "This PR prepares the release ${{ github.event.inputs.release_name }}.
             Changes include:
-            - Updated chart version
-            - Updated app version" \
+            - Synced chart version with app version" \
             --head "$BRANCH_NAME" \
             --base main \
             --draft)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ If you touch build scripts:
 If you touch deployment assets:
 - Install Helm locally: `make -C deploy tools`
 
+Release versioning:
+- Helm chart `version` tracks the controller release without a leading `v`.
+- Helm chart `appVersion` tracks the controller release tag with the leading `v`.
+
 ## Safe Local Runs
 
 Use `--noop` for startup checks unless the task explicitly requires real Kubernetes or OCI calls.

--- a/build/scripts/set-chart-version.sh
+++ b/build/scripts/set-chart-version.sh
@@ -7,7 +7,7 @@ usage() {
   echo "Usage: $0 --chart-file <path> --app-version <version> [--noop] [--commit]"
   echo "Options:"
   echo "  --chart-file <path>       Path to the Chart.yaml file (e.g., deploy/helm/controller/Chart.yaml)"
-  echo "  --app-version <version>   Version to set as appVersion (e.g., main, v1.2.3, feature/xyz)"
+  echo "  --app-version <version>   Release version to set as appVersion (e.g., v1.2.3)"
   echo "  --noop                    Show what would be changed without making changes"
   echo "  --commit                  Commit changes after updating"
   echo "  -h, --help                Show this help message"
@@ -74,22 +74,14 @@ echo "Current chart version (before update):"
 grep -E '^version: ' "$CHART_FILE"
 grep -E '^appVersion: ' "$CHART_FILE"
 
-# Read current version and increment patch version
-current_version=$(grep -E '^version: ' "$CHART_FILE" | cut -d' ' -f2 | tr -d '"')
+# Helm chart versions must be SemVer and cannot include a leading "v".
+new_version="${APP_VERSION#v}"
 
-# Ensure current_version is in a valid format like x.y.z
-if ! echo "$current_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-    echo "Error: Current version '$current_version' is not in a valid x.y.z format."
-    echo "To prevent partial updates, please ensure Chart.yaml versions are standard before running."
+if ! echo "$new_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+    echo "Error: App version '$APP_VERSION' does not resolve to a valid Helm chart version."
+    echo "Expected a release version like v1.2.3 or v1.2.3-rc.1."
     exit 1
 fi
-
-# Increment patch version (e.g., 0.1.0 -> 0.1.1)
-major=$(echo "$current_version" | cut -d. -f1)
-minor=$(echo "$current_version" | cut -d. -f2)
-patch=$(echo "$current_version" | cut -d. -f3)
-new_patch=$((patch + 1))
-new_version="${major}.${minor}.${new_patch}"
 
 echo ""
 echo "Changes that would be made:"
@@ -97,7 +89,7 @@ echo "  New appVersion: $APP_VERSION"
 echo "  New version: $new_version"
 
 if [[ "$COMMIT" == "true" ]]; then
-  commit_msg="chore: update chart version to $new_version and appVersion to $APP_VERSION"
+  commit_msg="chore: sync chart version $new_version with appVersion $APP_VERSION"
   if [[ "$NOOP" == "true" ]]; then
     echo ""
     echo "Commit message that would be used:"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,7 +24,9 @@ kubectl apply -n oke-gw -f manifests/examples/serverroutes.yaml
 
 ## Publish helm chart
 
-Helm chart is built and published automatically with each release. Steps below are for local testing. Run the following from deploy directory:
+Helm chart is built and published automatically with each release. Steps below are for local testing. Run the following from deploy directory.
+
+Release tooling keeps the chart `version` in sync with `appVersion`, without the leading `v`.
 
 ```sh
 # Login to ghcr registry (assuming you have gh cli configured)
@@ -39,4 +41,3 @@ CHART_VERSION=$(helm show chart helm/controller/ | grep 'version:' | cut -d' ' -
 # Push the chart to the registry
 helm push tmp/oke-gateway-api-controller-${CHART_VERSION}.tgz oci://ghcr.io/gemyago/helm-charts
 ```
-

--- a/deploy/helm/controller/Chart.yaml
+++ b/deploy/helm/controller/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm chart for the OKE Gateway API Controller
 
 type: application
 
-# Patch version is incremented automatically with each release.
+# Chart version tracks appVersion without the leading "v".
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.0.7"
+version: "0.3.2"
 
 # Set automatically to the release version by release tool.
 appVersion: "v0.3.2"


### PR DESCRIPTION
## Summary
- derive Helm chart version from the release appVersion by stripping a leading v
- update the checked-in chart metadata so version 0.3.2 matches appVersion v0.3.2
- document the release versioning convention in deploy docs and AGENTS.md

## Validation
- direnv exec . make -C build test
- direnv exec . make lint
- direnv exec . make test