### PR TITLE
feat: support OCI certificate IDs for ALB gateways

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,21 @@ kubectl apply -n oke-gw -f manifests/examples/serverdeployment.yaml
 kubectl apply -n oke-gw -f manifests/examples/serverroutes.yaml
 ```
 
+## OCI certificate example
+
+Use these manifests when the HTTPS listener should reference an OCI Certificates Service
+certificate created outside Kubernetes, such as by Terraform. The `https` listener intentionally
+does not set `tls.certificateRefs`; the certificate OCID is set with the listener TLS option
+`oci.oraclecloud.com/certificate-ocid`.
+
+```sh
+kubectl apply -n oke-gw -f manifests/examples/gatewayconfig.yaml
+kubectl apply -n oke-gw -f manifests/examples/gatewayclass.yaml
+kubectl apply -n oke-gw -f manifests/examples/gateway-https-oci-certificate.yaml
+kubectl apply -n oke-gw -f manifests/examples/serverdeployment.yaml
+kubectl apply -n oke-gw -f manifests/examples/serverroutes.yaml
+```
+
 ## Publish helm chart
 
 Helm chart is built and published automatically with each release. Steps below are for local testing. Run the following from deploy directory.

--- a/deploy/manifests/examples/gateway-https-oci-certificate.yaml
+++ b/deploy/manifests/examples/gateway-https-oci-certificate.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: oke-gateway-oci-certificate
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        options:
+          oci.oraclecloud.com/certificate-ocid: ocid1.certificate.oc1..exampleuniqueID

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -11,6 +11,9 @@ const (
 	// GatewayUsedSecretsAnnotationPrefix is extended with each secret full name and stores the secret revision.
 	GatewayUsedSecretsAnnotationPrefix = "secrets.oke-gateway-api.gemyago.github.io"
 
+	// ListenerTLSOptionOCICertificateOCID configures an existing OCI Certificates Service certificate for a listener.
+	ListenerTLSOptionOCICertificateOCID = "oci.oraclecloud.com/certificate-ocid"
+
 	// HTTPRouteProgrammingRevisionAnnotation is the annotation for the http route programming revision.
 	// The revision may be incremented if additional programming steps are introduced by the controller.
 	HTTPRouteProgrammingRevisionAnnotation = "oke-gateway-api.gemyago.github.io/http-route-programming-revision"

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -18,6 +18,66 @@ import (
 	"github.com/gemyago/oke-gateway-api/internal/types"
 )
 
+func listenerOCICertificateOCID(listener gatewayv1.Listener) string {
+	if listener.TLS == nil || listener.TLS.Options == nil {
+		return ""
+	}
+	return string(listener.TLS.Options[gatewayv1.AnnotationKey(ListenerTLSOptionOCICertificateOCID)])
+}
+
+func gatewayCertificateIDsByListener(gateway gatewayv1.Gateway) map[string]string {
+	result := make(map[string]string)
+	for _, listener := range gateway.Spec.Listeners {
+		if certificateID := listenerOCICertificateOCID(listener); certificateID != "" {
+			result[string(listener.Name)] = certificateID
+		}
+	}
+	return result
+}
+
+func validateGatewayCertificateOptions(gateway gatewayv1.Gateway) error {
+	for _, listener := range gateway.Spec.Listeners {
+		certificateID := listenerOCICertificateOCID(listener)
+		if certificateID == "" {
+			continue
+		}
+		if listener.Protocol != gatewayv1.HTTPSProtocolType {
+			return &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionAccepted),
+				reason:        string(gatewayv1.GatewayReasonInvalidParameters),
+				message: fmt.Sprintf(
+					"listener %s option %s can only be used with HTTPS listeners",
+					listener.Name,
+					ListenerTLSOptionOCICertificateOCID,
+				),
+			}
+		}
+		if listener.TLS.Mode != nil && *listener.TLS.Mode != gatewayv1.TLSModeTerminate {
+			return &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionAccepted),
+				reason:        string(gatewayv1.GatewayReasonInvalidParameters),
+				message: fmt.Sprintf(
+					"listener %s option %s can only be used with Terminate TLS mode",
+					listener.Name,
+					ListenerTLSOptionOCICertificateOCID,
+				),
+			}
+		}
+		if len(listener.TLS.CertificateRefs) > 0 {
+			return &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionAccepted),
+				reason:        string(gatewayv1.GatewayReasonInvalidParameters),
+				message: fmt.Sprintf(
+					"listener %s option %s cannot be used together with listener.tls.certificateRefs",
+					listener.Name,
+					ListenerTLSOptionOCICertificateOCID,
+				),
+			}
+		}
+	}
+	return nil
+}
+
 type resolvedGatewayDetails struct {
 	gateway      gatewayv1.Gateway
 	gatewayClass gatewayv1.GatewayClass
@@ -113,6 +173,10 @@ func (m *gatewayModelImpl) resolveReconcileRequest(
 		return false, fmt.Errorf("failed to get GatewayConfig %s: %w", configName, err)
 	}
 
+	if err := validateGatewayCertificateOptions(receiver.gateway); err != nil {
+		return false, err
+	}
+
 	if err := m.populateGatewaySecrets(ctx, receiver); err != nil {
 		return false, err
 	}
@@ -122,46 +186,75 @@ func (m *gatewayModelImpl) resolveReconcileRequest(
 	return true, nil
 }
 
-func (m *gatewayModelImpl) populateGatewaySecrets(ctx context.Context, receiver *resolvedGatewayDetails) error {
+func (m *gatewayModelImpl) populateGatewaySecrets(
+	ctx context.Context,
+	receiver *resolvedGatewayDetails,
+) error {
 	receiver.gatewaySecrets = make(map[string]corev1.Secret)
-
 	for _, listener := range receiver.gateway.Spec.Listeners {
-		if listener.TLS == nil || len(listener.TLS.CertificateRefs) == 0 {
+		if listenerOCICertificateOCID(listener) != "" {
 			continue
 		}
-
-		for _, certRef := range listener.TLS.CertificateRefs {
-			secretName := string(certRef.Name)
-			secretNamespace := receiver.gateway.Namespace
-			if certRef.Namespace != nil {
-				secretNamespace = string(*certRef.Namespace)
-			}
-
-			fullSecretName := secretNamespace + "/" + secretName
-
-			if _, exists := receiver.gatewaySecrets[fullSecretName]; exists {
-				continue
-			}
-
-			var secret corev1.Secret
-			if err := m.client.Get(ctx, apitypes.NamespacedName{
-				Name:      secretName,
-				Namespace: secretNamespace,
-			}, &secret); err != nil {
-				if apierrors.IsNotFound(err) {
-					return &resourceStatusError{
-						conditionType: string(gatewayv1.GatewayConditionAccepted),
-						reason:        string(gatewayv1.GatewayReasonInvalidParameters),
-						message:       fmt.Sprintf("referenced secret %s not found", fullSecretName),
-					}
-				}
-				return fmt.Errorf("failed to get secret %s: %w", fullSecretName, err)
-			}
-
-			receiver.gatewaySecrets[fullSecretName] = secret
+		if populateErr := m.populateGatewayListenerSecrets(ctx, receiver, listener); populateErr != nil {
+			return populateErr
 		}
 	}
 
+	return nil
+}
+
+func (m *gatewayModelImpl) populateGatewayListenerSecrets(
+	ctx context.Context,
+	receiver *resolvedGatewayDetails,
+	listener gatewayv1.Listener,
+) error {
+	if listener.TLS == nil || len(listener.TLS.CertificateRefs) == 0 {
+		return nil
+	}
+
+	for _, certRef := range listener.TLS.CertificateRefs {
+		secretName := string(certRef.Name)
+		secretNamespace := receiver.gateway.Namespace
+		if certRef.Namespace != nil {
+			secretNamespace = string(*certRef.Namespace)
+		}
+
+		if err := m.populateGatewaySecret(ctx, receiver, secretNamespace, secretName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *gatewayModelImpl) populateGatewaySecret(
+	ctx context.Context,
+	receiver *resolvedGatewayDetails,
+	secretNamespace string,
+	secretName string,
+) error {
+	fullSecretName := secretNamespace + "/" + secretName
+	if _, exists := receiver.gatewaySecrets[fullSecretName]; exists {
+		return nil
+	}
+
+	var secret corev1.Secret
+	getErr := m.client.Get(ctx, apitypes.NamespacedName{
+		Name:      secretName,
+		Namespace: secretNamespace,
+	}, &secret)
+	if getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			return &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionAccepted),
+				reason:        string(gatewayv1.GatewayReasonInvalidParameters),
+				message:       fmt.Sprintf("referenced secret %s not found", fullSecretName),
+			}
+		}
+		return fmt.Errorf("failed to get secret %s: %w", fullSecretName, getErr)
+	}
+
+	receiver.gatewaySecrets[fullSecretName] = secret
 	return nil
 }
 
@@ -217,6 +310,7 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 			knownListeners:        response.LoadBalancer.Listeners,
 			knownRoutingPolicies:  response.LoadBalancer.RoutingPolicies,
 			listenerCertificates:  reconcileListenersCertificatesResult.certificatesByListener[listenerName],
+			listenerCertificateID: reconcileListenersCertificatesResult.certificateIDsByListener[listenerName],
 			defaultBackendSetName: *defaultBackendSet.Name,
 			listenerSpec:          &listener,
 		}

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1286,3 +1286,172 @@ func TestGatewayModelImpl(t *testing.T) {
 		})
 	})
 }
+
+func TestGatewayCertificateOptionsValidation(t *testing.T) {
+	makeGateway := func(listeners ...gatewayv1.Listener) gatewayv1.Gateway {
+		return gatewayv1.Gateway{
+			Spec: gatewayv1.GatewaySpec{Listeners: listeners},
+		}
+	}
+	withOCICertificateOption := func(listener gatewayv1.Listener, certificateID string) gatewayv1.Listener {
+		listener.TLS = &gatewayv1.GatewayTLSConfig{
+			Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				gatewayv1.AnnotationKey(ListenerTLSOptionOCICertificateOCID): gatewayv1.AnnotationValue(certificateID),
+			},
+		}
+		return listener
+	}
+	withTLSMode := func(listener gatewayv1.Listener, mode gatewayv1.TLSModeType) gatewayv1.Listener {
+		listener.TLS.Mode = &mode
+		return listener
+	}
+	httpsListener := gatewayv1.Listener{
+		Name:     "https",
+		Protocol: gatewayv1.HTTPSProtocolType,
+		Port:     443,
+	}
+
+	t.Run("accepts OCI certificate option without certificateRefs", func(t *testing.T) {
+		err := validateGatewayCertificateOptions(makeGateway(
+			withOCICertificateOption(httpsListener, "ocid1.certificate.oc1..test"),
+		))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts OCI certificate option with terminate TLS mode", func(t *testing.T) {
+		err := validateGatewayCertificateOptions(makeGateway(
+			withTLSMode(
+				withOCICertificateOption(httpsListener, "ocid1.certificate.oc1..test"),
+				gatewayv1.TLSModeTerminate,
+			),
+		))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts multiple OCI certificate options for different listeners", func(t *testing.T) {
+		adminListener := gatewayv1.Listener{
+			Name:     "admin-https",
+			Protocol: gatewayv1.HTTPSProtocolType,
+			Port:     8443,
+		}
+
+		err := validateGatewayCertificateOptions(makeGateway(
+			withOCICertificateOption(httpsListener, "ocid1.certificate.oc1..public"),
+			withOCICertificateOption(adminListener, "ocid1.certificate.oc1..admin"),
+		))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects certificate option on non TLS listener", func(t *testing.T) {
+		err := validateGatewayCertificateOptions(makeGateway(withOCICertificateOption(gatewayv1.Listener{
+			Name:     "http",
+			Protocol: gatewayv1.HTTPProtocolType,
+			Port:     80,
+		}, "ocid1.certificate.oc1..test")))
+
+		require.ErrorContains(t, err, "can only be used with HTTPS listeners")
+	})
+
+	t.Run("rejects certificate option on TLS listener", func(t *testing.T) {
+		err := validateGatewayCertificateOptions(makeGateway(withOCICertificateOption(gatewayv1.Listener{
+			Name:     "tls",
+			Protocol: gatewayv1.TLSProtocolType,
+			Port:     443,
+		}, "ocid1.certificate.oc1..test")))
+
+		require.ErrorContains(t, err, "can only be used with HTTPS listeners")
+	})
+
+	t.Run("rejects certificate option with passthrough TLS mode", func(t *testing.T) {
+		err := validateGatewayCertificateOptions(makeGateway(
+			withTLSMode(
+				withOCICertificateOption(httpsListener, "ocid1.certificate.oc1..test"),
+				gatewayv1.TLSModePassthrough,
+			),
+		))
+
+		require.ErrorContains(t, err, "can only be used with Terminate TLS mode")
+	})
+
+	t.Run("rejects conflict with certificateRefs", func(t *testing.T) {
+		listener := withOCICertificateOption(httpsListener, "ocid1.certificate.oc1..test")
+		listener.TLS.CertificateRefs = []gatewayv1.SecretObjectReference{{Name: "tls-secret"}}
+
+		err := validateGatewayCertificateOptions(makeGateway(listener))
+
+		require.ErrorContains(t, err, "cannot be used together with listener.tls.certificateRefs")
+	})
+
+	t.Run("skips secret population for OCI certificate listeners", func(t *testing.T) {
+		model := &gatewayModelImpl{client: NewMockk8sClient(t)}
+		details := resolvedGatewayDetails{
+			gateway: makeGateway(withOCICertificateOption(httpsListener, "ocid1.certificate.oc1..test")),
+		}
+
+		err := model.populateGatewaySecrets(t.Context(), &details)
+
+		require.NoError(t, err)
+		assert.Empty(t, details.gatewaySecrets)
+	})
+
+	t.Run("does not reload duplicate certificateRefs", func(t *testing.T) {
+		model := &gatewayModelImpl{client: NewMockk8sClient(t)}
+		listener := httpsListener
+		listener.TLS = &gatewayv1.GatewayTLSConfig{
+			CertificateRefs: []gatewayv1.SecretObjectReference{
+				{Name: "tls-secret"},
+				{Name: "tls-secret"},
+			},
+		}
+		details := resolvedGatewayDetails{
+			gateway: makeGateway(listener),
+		}
+		details.gateway.Namespace = "gateway-ns"
+		secret := makeRandomSecret(
+			randomSecretWithNameOpt("tls-secret"),
+			randomSecretWithTLSDataOpt(),
+		)
+		secret.Namespace = details.gateway.Namespace
+
+		mockClient, _ := model.client.(*Mockk8sClient)
+		setupClientGet(t, mockClient, apitypes.NamespacedName{
+			Namespace: details.gateway.Namespace,
+			Name:      secret.Name,
+		}, secret).Once()
+
+		err := model.populateGatewaySecrets(t.Context(), &details)
+
+		require.NoError(t, err)
+		assert.Len(t, details.gatewaySecrets, 1)
+	})
+
+	t.Run("returns generic secret lookup errors", func(t *testing.T) {
+		model := &gatewayModelImpl{client: NewMockk8sClient(t)}
+		listener := httpsListener
+		listener.TLS = &gatewayv1.GatewayTLSConfig{
+			CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-secret"}},
+		}
+		details := resolvedGatewayDetails{
+			gateway: makeGateway(listener),
+		}
+		details.gateway.Namespace = "gateway-ns"
+		wantErr := errors.New("k8s unavailable")
+
+		mockClient, _ := model.client.(*Mockk8sClient)
+		mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{
+				Namespace: details.gateway.Namespace,
+				Name:      "tls-secret",
+			}, mock.Anything).
+			Return(wantErr).
+			Once()
+
+		err := model.populateGatewaySecrets(t.Context(), &details)
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to get secret gateway-ns/tls-secret")
+	})
+}

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,7 +19,7 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/dig"
 	corev1 "k8s.io/api/core/v1"
-	types "k8s.io/apimachinery/pkg/types"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
@@ -52,6 +53,7 @@ type reconcileHTTPListenerParams struct {
 	knownListeners        map[string]loadbalancer.Listener
 	knownRoutingPolicies  map[string]loadbalancer.RoutingPolicy
 	listenerCertificates  []loadbalancer.Certificate
+	listenerCertificateID string
 	defaultBackendSetName string
 	listenerSpec          *gatewayv1.Listener
 }
@@ -68,6 +70,9 @@ type reconcileListenersCertificatesResult struct {
 
 	// List of certificates by listener name
 	certificatesByListener map[string][]loadbalancer.Certificate
+
+	// List of OCI Certificates Service certificate IDs by listener name.
+	certificateIDsByListener map[string]string
 }
 
 type makeRoutingRuleParams struct {
@@ -219,86 +224,174 @@ func (m *ociLoadBalancerModelImpl) reconcileListenersCertificates(
 
 	resultingCertificates := maps.Clone(params.knownCertificates)
 	listenerCertificates := make(map[string][]loadbalancer.Certificate)
+	certificateIDsByListener := gatewayCertificateIDsByListener(*params.gateway)
 
 	for _, listenerSpec := range params.gateway.Spec.Listeners {
-		if listenerSpec.TLS == nil {
+		if _, usesOCICertificate := certificateIDsByListener[string(listenerSpec.Name)]; usesOCICertificate {
 			continue
 		}
-
-		listenerName := string(listenerSpec.Name)
-
-		for _, ref := range listenerSpec.TLS.CertificateRefs {
-			secret := corev1.Secret{}
-			ns := lo.Ternary(ref.Namespace != nil, string(lo.FromPtr(ref.Namespace)), params.gateway.Namespace)
-			err := m.k8sClient.Get(ctx, types.NamespacedName{
-				Name:      string(ref.Name),
-				Namespace: ns,
-			}, &secret)
-			if err != nil {
-				return reconcileListenersCertificatesResult{}, fmt.Errorf("failed to get secret %s: %w", ref.Name, err)
-			}
-
-			certName := ociCertificateNameFromSecret(secret)
-			if cert, ok := resultingCertificates[certName]; ok {
-				m.logger.DebugContext(ctx, "Certificate already exists, skipping",
-					slog.String("loadBalancerId", params.loadBalancerID),
-					slog.String("listenerName", listenerName),
-					slog.String("certificateName", certName),
-					slog.String("secretName", secret.Name),
-					slog.String("secretNamespace", secret.Namespace),
-					slog.String("secretVersion", secret.ResourceVersion),
-				)
-				listenerCertificates[listenerName] = append(listenerCertificates[listenerName], cert)
-				continue
-			}
-
-			m.logger.InfoContext(ctx, "Creating certificate",
-				slog.String("loadBalancerId", params.loadBalancerID),
-				slog.String("listenerName", listenerName),
-				slog.String("certificateName", certName),
-				slog.String("secretName", secret.Name),
-				slog.String("secretNamespace", secret.Namespace),
-				slog.String("secretVersion", secret.ResourceVersion),
-			)
-
-			certCreateDetails := loadbalancer.CreateCertificateDetails{
-				CertificateName:   &certName,
-				PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
-				PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
-			}
-			createRes, err := m.ociClient.CreateCertificate(ctx, loadbalancer.CreateCertificateRequest{
-				LoadBalancerId:           &params.loadBalancerID,
-				CreateCertificateDetails: certCreateDetails,
-			})
-			if err != nil {
-				return reconcileListenersCertificatesResult{}, fmt.Errorf(
-					"failed to create certificate %s: %w",
-					certName,
-					err,
-				)
-			}
-
-			if err = m.workRequestsWatcher.WaitFor(ctx, *createRes.OpcWorkRequestId); err != nil {
-				return reconcileListenersCertificatesResult{}, fmt.Errorf(
-					"failed to wait for certificate %s: %w",
-					certName,
-					err,
-				)
-			}
-
-			cert := loadbalancer.Certificate{
-				CertificateName:   &certName,
-				PublicCertificate: certCreateDetails.PublicCertificate,
-			}
-			resultingCertificates[certName] = cert
-			listenerCertificates[listenerName] = append(listenerCertificates[listenerName], cert)
+		certs, reconcileErr := m.reconcileListenerSecretCertificates(ctx, listenerSecretCertificatesParams{
+			loadBalancerID:        params.loadBalancerID,
+			gatewayNamespace:      params.gateway.Namespace,
+			listenerSpec:          listenerSpec,
+			resultingCertificates: resultingCertificates,
+		})
+		if reconcileErr != nil {
+			return reconcileListenersCertificatesResult{}, reconcileErr
+		}
+		if len(certs) > 0 {
+			listenerCertificates[string(listenerSpec.Name)] = certs
 		}
 	}
 
 	return reconcileListenersCertificatesResult{
-		reconciledCertificates: resultingCertificates,
-		certificatesByListener: listenerCertificates,
+		reconciledCertificates:   resultingCertificates,
+		certificatesByListener:   listenerCertificates,
+		certificateIDsByListener: certificateIDsByListener,
 	}, nil
+}
+
+type listenerSecretCertificatesParams struct {
+	loadBalancerID        string
+	gatewayNamespace      string
+	listenerSpec          gatewayv1.Listener
+	resultingCertificates map[string]loadbalancer.Certificate
+}
+
+func (m *ociLoadBalancerModelImpl) reconcileListenerSecretCertificates(
+	ctx context.Context,
+	params listenerSecretCertificatesParams,
+) ([]loadbalancer.Certificate, error) {
+	if params.listenerSpec.TLS == nil {
+		return nil, nil
+	}
+
+	certificates := make([]loadbalancer.Certificate, 0, len(params.listenerSpec.TLS.CertificateRefs))
+	seenRefs := make(map[apitypes.NamespacedName]struct{}, len(params.listenerSpec.TLS.CertificateRefs))
+	for _, ref := range params.listenerSpec.TLS.CertificateRefs {
+		refName := certificateRefNamespacedName(params.gatewayNamespace, ref)
+		if _, exists := seenRefs[refName]; exists {
+			continue
+		}
+		seenRefs[refName] = struct{}{}
+
+		cert, err := m.reconcileListenerSecretCertificate(ctx, params, ref)
+		if err != nil {
+			return nil, err
+		}
+		certificates = append(certificates, cert)
+	}
+
+	return certificates, nil
+}
+
+func (m *ociLoadBalancerModelImpl) reconcileListenerSecretCertificate(
+	ctx context.Context,
+	params listenerSecretCertificatesParams,
+	ref gatewayv1.SecretObjectReference,
+) (loadbalancer.Certificate, error) {
+	secret, err := m.getListenerCertificateSecret(ctx, params.gatewayNamespace, ref)
+	if err != nil {
+		return loadbalancer.Certificate{}, err
+	}
+
+	certName := ociCertificateNameFromSecret(secret)
+	if cert, ok := params.resultingCertificates[certName]; ok {
+		m.logCertificateAlreadyExists(ctx, params.loadBalancerID, params.listenerSpec.Name, certName, secret)
+		return cert, nil
+	}
+
+	cert, err := m.createListenerCertificate(ctx, params.loadBalancerID, params.listenerSpec.Name, certName, secret)
+	if err != nil {
+		return loadbalancer.Certificate{}, err
+	}
+	params.resultingCertificates[certName] = cert
+	return cert, nil
+}
+
+func (m *ociLoadBalancerModelImpl) getListenerCertificateSecret(
+	ctx context.Context,
+	gatewayNamespace string,
+	ref gatewayv1.SecretObjectReference,
+) (corev1.Secret, error) {
+	secret := corev1.Secret{}
+	err := m.k8sClient.Get(ctx, certificateRefNamespacedName(gatewayNamespace, ref), &secret)
+	if err != nil {
+		return corev1.Secret{}, fmt.Errorf("failed to get secret %s: %w", ref.Name, err)
+	}
+	return secret, nil
+}
+
+func certificateRefNamespacedName(
+	gatewayNamespace string,
+	ref gatewayv1.SecretObjectReference,
+) apitypes.NamespacedName {
+	return apitypes.NamespacedName{
+		Name:      string(ref.Name),
+		Namespace: lo.Ternary(ref.Namespace != nil, string(lo.FromPtr(ref.Namespace)), gatewayNamespace),
+	}
+}
+
+func (m *ociLoadBalancerModelImpl) createListenerCertificate(
+	ctx context.Context,
+	loadBalancerID string,
+	listenerName gatewayv1.SectionName,
+	certName string,
+	secret corev1.Secret,
+) (loadbalancer.Certificate, error) {
+	m.logger.InfoContext(ctx, "Creating certificate",
+		slog.String("loadBalancerId", loadBalancerID),
+		slog.String("listenerName", string(listenerName)),
+		slog.String("certificateName", certName),
+		slog.String("secretName", secret.Name),
+		slog.String("secretNamespace", secret.Namespace),
+		slog.String("secretVersion", secret.ResourceVersion),
+	)
+
+	certCreateDetails := loadbalancer.CreateCertificateDetails{
+		CertificateName:   &certName,
+		PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
+		PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
+	}
+	createRes, createErr := m.ociClient.CreateCertificate(ctx, loadbalancer.CreateCertificateRequest{
+		LoadBalancerId:           &loadBalancerID,
+		CreateCertificateDetails: certCreateDetails,
+	})
+	if createErr != nil {
+		return loadbalancer.Certificate{}, fmt.Errorf("failed to create certificate %s: %w", certName, createErr)
+	}
+	if createRes.OpcWorkRequestId == nil {
+		return loadbalancer.Certificate{}, fmt.Errorf(
+			"failed to create certificate %s: missing work request id",
+			certName,
+		)
+	}
+
+	if err := m.workRequestsWatcher.WaitFor(ctx, *createRes.OpcWorkRequestId); err != nil {
+		return loadbalancer.Certificate{}, fmt.Errorf("failed to wait for certificate %s: %w", certName, err)
+	}
+
+	return loadbalancer.Certificate{
+		CertificateName:   &certName,
+		PublicCertificate: certCreateDetails.PublicCertificate,
+	}, nil
+}
+
+func (m *ociLoadBalancerModelImpl) logCertificateAlreadyExists(
+	ctx context.Context,
+	loadBalancerID string,
+	listenerName gatewayv1.SectionName,
+	certName string,
+	secret corev1.Secret,
+) {
+	m.logger.DebugContext(ctx, "Certificate already exists, skipping",
+		slog.String("loadBalancerId", loadBalancerID),
+		slog.String("listenerName", string(listenerName)),
+		slog.String("certificateName", certName),
+		slog.String("secretName", secret.Name),
+		slog.String("secretNamespace", secret.Namespace),
+		slog.String("secretVersion", secret.ResourceVersion),
+	)
 }
 
 func (m *ociLoadBalancerModelImpl) reconcileListenerRoutingPolicy(
@@ -369,7 +462,22 @@ func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
 	}
 
 	var sslConfig *loadbalancer.SslConfigurationDetails
-	if params.listenerSpec.TLS != nil {
+	if params.listenerCertificateID != "" {
+		sslConfig = &loadbalancer.SslConfigurationDetails{
+			CertificateIds: []string{params.listenerCertificateID},
+		}
+	} else if params.listenerSpec.TLS != nil {
+		if len(params.listenerCertificates) == 0 {
+			return &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionAccepted),
+				reason:        string(gatewayv1.GatewayReasonInvalidParameters),
+				message: fmt.Sprintf(
+					"listener %s requires certificateRefs or %s TLS option",
+					listenerName,
+					ListenerTLSOptionOCICertificateOCID,
+				),
+			}
+		}
 		cert := params.listenerCertificates[0]
 
 		sslConfig = &loadbalancer.SslConfigurationDetails{
@@ -933,13 +1041,21 @@ func makeOciListenerUpdateDetails(
 		params.existingListenerData.SslConfiguration.CertificateName != nil {
 		existingCertName = *params.existingListenerData.SslConfiguration.CertificateName
 	}
+	existingCertIDs := normalizeCertificateIDs(nil)
+	if params.existingListenerData.SslConfiguration != nil {
+		existingCertIDs = normalizeCertificateIDs(params.existingListenerData.SslConfiguration.CertificateIds)
+	}
 
 	newCertName := ""
 	if params.sslConfig != nil && params.sslConfig.CertificateName != nil {
 		newCertName = *params.sslConfig.CertificateName
 	}
+	newCertIDs := normalizeCertificateIDs(nil)
+	if params.sslConfig != nil {
+		newCertIDs = normalizeCertificateIDs(params.sslConfig.CertificateIds)
+	}
 
-	if existingCertName != newCertName {
+	if existingCertName != newCertName || !slices.Equal(existingCertIDs, newCertIDs) {
 		hasChanges = true
 	}
 
@@ -954,6 +1070,13 @@ func makeOciListenerUpdateDetails(
 		RoutingPolicyName:     new(expectedPolicyName),
 		SslConfiguration:      params.sslConfig,
 	}, true
+}
+
+func normalizeCertificateIDs(certificateIDs []string) []string {
+	if len(certificateIDs) == 0 {
+		return nil
+	}
+	return certificateIDs
 }
 
 type ociLoadBalancerModelDeps struct {

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -786,6 +787,36 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			err := model.reconcileHTTPListener(t.Context(), params)
 			require.NoError(t, err)
+		})
+
+		t.Run("fails when https listener has no certificate source", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			routingPolicyName := string(gwListener.Name) + "_policy"
+
+			params := reconcileHTTPListenerParams{
+				loadBalancerID: faker.New().UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					routingPolicyName: makeRandomOCIRoutingPolicy(),
+				},
+				defaultBackendSetName: faker.New().UUID().V4(),
+				listenerSpec:          &gwListener,
+			}
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			var statusErr *resourceStatusError
+			require.ErrorAs(t, err, &statusErr)
+			assert.Equal(t, string(gatewayv1.GatewayConditionAccepted), statusErr.conditionType)
+			assert.Equal(t, string(gatewayv1.GatewayReasonInvalidParameters), statusErr.reason)
+			assert.Contains(
+				t,
+				statusErr.message,
+				"requires certificateRefs or oci.oraclecloud.com/certificate-ocid TLS option",
+			)
 		})
 
 		t.Run("when routing policy exists", func(t *testing.T) {
@@ -2162,6 +2193,518 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 	})
 }
 
+func TestOciLoadBalancerModelOCICertificateIDs(t *testing.T) {
+	withOCICertificateOption := func(listener gatewayv1.Listener, certificateID string) gatewayv1.Listener {
+		listener.TLS = &gatewayv1.GatewayTLSConfig{
+			Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				gatewayv1.AnnotationKey(ListenerTLSOptionOCICertificateOCID): gatewayv1.AnnotationValue(certificateID),
+			},
+		}
+		return listener
+	}
+
+	t.Run("reconcileListenersCertificates returns OCI certificate IDs without reading secrets", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		gateway := gatewayv1.Gateway{
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{withOCICertificateOption(gatewayv1.Listener{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+				}, "ocid1.certificate.oc1..test")},
+			},
+		}
+
+		result, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+			loadBalancerID:    faker.New().UUID().V4(),
+			gateway:           &gateway,
+			knownCertificates: map[string]loadbalancer.Certificate{},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, result.certificatesByListener)
+		assert.Empty(t, result.reconciledCertificates)
+		assert.Equal(t, "ocid1.certificate.oc1..test", result.certificateIDsByListener["https"])
+	})
+
+	t.Run("reconcileListenersCertificates supports mixed OCI IDs and Kubernetes Secrets", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		secretListener := gatewayv1.Listener{
+			Name:     "secret-https",
+			Protocol: gatewayv1.HTTPSProtocolType,
+			Port:     8443,
+			TLS: &gatewayv1.GatewayTLSConfig{
+				CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "secret-cert"}},
+			},
+		}
+		ociListener := gatewayv1.Listener{
+			Name:     "oci-https",
+			Protocol: gatewayv1.HTTPSProtocolType,
+			Port:     443,
+		}
+		ociListener = withOCICertificateOption(ociListener, "ocid1.certificate.oc1..test")
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gateway-ns"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{secretListener, ociListener},
+			},
+		}
+		secret := makeRandomSecret()
+		secret.Namespace = gateway.Namespace
+		secret.Name = "secret-cert"
+		certName := ociCertificateNameFromSecret(secret)
+		knownCertificate := makeRandomOCICertificate()
+
+		k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		setupClientGet(t, k8sClient, types.NamespacedName{
+			Namespace: gateway.Namespace,
+			Name:      secret.Name,
+		}, secret).Once()
+
+		result, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+			loadBalancerID: faker.New().UUID().V4(),
+			gateway:        &gateway,
+			knownCertificates: map[string]loadbalancer.Certificate{
+				certName: knownCertificate,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ocid1.certificate.oc1..test", result.certificateIDsByListener["oci-https"])
+		assert.Equal(t, []loadbalancer.Certificate{knownCertificate}, result.certificatesByListener["secret-https"])
+		assert.Equal(t, map[string]loadbalancer.Certificate{certName: knownCertificate}, result.reconciledCertificates)
+	})
+
+	t.Run("reconcileListenersCertificates deduplicates listener certificateRefs", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gateway-ns"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "tls-secret"},
+							{Name: "tls-secret"},
+						},
+					},
+				}},
+			},
+		}
+		secret := makeRandomSecret(
+			randomSecretWithNameOpt("tls-secret"),
+			randomSecretWithTLSDataOpt(),
+		)
+		secret.Namespace = gateway.Namespace
+		certName := ociCertificateNameFromSecret(secret)
+		knownCertificate := makeRandomOCICertificate()
+
+		k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		setupClientGet(t, k8sClient, types.NamespacedName{
+			Namespace: gateway.Namespace,
+			Name:      secret.Name,
+		}, secret).Once()
+
+		result, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+			loadBalancerID: faker.New().UUID().V4(),
+			gateway:        &gateway,
+			knownCertificates: map[string]loadbalancer.Certificate{
+				certName: knownCertificate,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []loadbalancer.Certificate{knownCertificate}, result.certificatesByListener["https"])
+	})
+
+	t.Run("reconcileListenersCertificates returns Kubernetes Secret lookup errors", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gateway-ns"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-secret"}},
+					},
+				}},
+			},
+		}
+		wantErr := errors.New("k8s unavailable")
+		k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		k8sClient.EXPECT().
+			Get(t.Context(), types.NamespacedName{
+				Namespace: gateway.Namespace,
+				Name:      "tls-secret",
+			}, mock.Anything).
+			Return(wantErr).
+			Once()
+
+		_, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+			loadBalancerID:    faker.New().UUID().V4(),
+			gateway:           &gateway,
+			knownCertificates: map[string]loadbalancer.Certificate{},
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to get secret tls-secret")
+	})
+
+	t.Run("reconcileListenersCertificates returns OCI certificate create errors", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gateway-ns"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-secret"}},
+					},
+				}},
+			},
+		}
+		secret := makeRandomSecret(
+			randomSecretWithNameOpt("tls-secret"),
+			randomSecretWithTLSDataOpt(),
+		)
+		secret.Namespace = gateway.Namespace
+		loadBalancerID := faker.New().UUID().V4()
+		certName := ociCertificateNameFromSecret(secret)
+		wantErr := errors.New("create failed")
+
+		k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		setupClientGet(t, k8sClient, types.NamespacedName{
+			Namespace: gateway.Namespace,
+			Name:      secret.Name,
+		}, secret).Once()
+
+		ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+		ociLoadBalancerClient.EXPECT().
+			CreateCertificate(t.Context(), loadbalancer.CreateCertificateRequest{
+				LoadBalancerId: &loadBalancerID,
+				CreateCertificateDetails: loadbalancer.CreateCertificateDetails{
+					CertificateName:   &certName,
+					PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
+					PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
+				},
+			}).
+			Return(loadbalancer.CreateCertificateResponse{}, wantErr).
+			Once()
+
+		_, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+			loadBalancerID:    loadBalancerID,
+			gateway:           &gateway,
+			knownCertificates: map[string]loadbalancer.Certificate{},
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to create certificate")
+	})
+
+	t.Run("reconcileListenersCertificates returns OCI work request wait errors", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gateway-ns"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-secret"}},
+					},
+				}},
+			},
+		}
+		secret := makeRandomSecret(
+			randomSecretWithNameOpt("tls-secret"),
+			randomSecretWithTLSDataOpt(),
+		)
+		secret.Namespace = gateway.Namespace
+		loadBalancerID := faker.New().UUID().V4()
+		workRequestID := faker.New().UUID().V4()
+		certName := ociCertificateNameFromSecret(secret)
+		wantErr := errors.New("wait failed")
+
+		k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		setupClientGet(t, k8sClient, types.NamespacedName{
+			Namespace: gateway.Namespace,
+			Name:      secret.Name,
+		}, secret).Once()
+
+		ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+		ociLoadBalancerClient.EXPECT().
+			CreateCertificate(t.Context(), loadbalancer.CreateCertificateRequest{
+				LoadBalancerId: &loadBalancerID,
+				CreateCertificateDetails: loadbalancer.CreateCertificateDetails{
+					CertificateName:   &certName,
+					PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
+					PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
+				},
+			}).
+			Return(loadbalancer.CreateCertificateResponse{OpcWorkRequestId: &workRequestID}, nil).
+			Once()
+		workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(wantErr).Once()
+
+		_, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+			loadBalancerID:    loadBalancerID,
+			gateway:           &gateway,
+			knownCertificates: map[string]loadbalancer.Certificate{},
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to wait for certificate")
+	})
+
+	t.Run("reconcileListenersCertificates returns missing OCI work request id errors", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gateway-ns"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-secret"}},
+					},
+				}},
+			},
+		}
+		secret := makeRandomSecret(
+			randomSecretWithNameOpt("tls-secret"),
+			randomSecretWithTLSDataOpt(),
+		)
+		secret.Namespace = gateway.Namespace
+		loadBalancerID := faker.New().UUID().V4()
+		certName := ociCertificateNameFromSecret(secret)
+
+		k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		setupClientGet(t, k8sClient, types.NamespacedName{
+			Namespace: gateway.Namespace,
+			Name:      secret.Name,
+		}, secret).Once()
+
+		ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+		ociLoadBalancerClient.EXPECT().
+			CreateCertificate(t.Context(), loadbalancer.CreateCertificateRequest{
+				LoadBalancerId: &loadBalancerID,
+				CreateCertificateDetails: loadbalancer.CreateCertificateDetails{
+					CertificateName:   &certName,
+					PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
+					PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
+				},
+			}).
+			Return(loadbalancer.CreateCertificateResponse{}, nil).
+			Once()
+
+		_, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+			loadBalancerID:    loadBalancerID,
+			gateway:           &gateway,
+			knownCertificates: map[string]loadbalancer.Certificate{},
+		})
+
+		require.ErrorContains(t, err, "missing work request id")
+	})
+
+	t.Run("make listener update details detects OCI certificate IDs", func(t *testing.T) {
+		listener := gatewayv1.Listener{
+			Name:     "https",
+			Protocol: gatewayv1.HTTPSProtocolType,
+			Port:     443,
+		}
+		sslConfig := &loadbalancer.SslConfigurationDetails{
+			CertificateIds: []string{"ocid1.certificate.oc1..test"},
+		}
+
+		details, changed := makeOciListenerUpdateDetails(makeOciListenerUpdateDetailsParams{
+			existingListenerData: loadbalancer.Listener{
+				Protocol:              new("HTTP"),
+				Port:                  new(443),
+				DefaultBackendSetName: new("default"),
+				RoutingPolicyName:     new("https_policy"),
+				SslConfiguration: &loadbalancer.SslConfiguration{
+					CertificateIds: []string{"ocid1.certificate.oc1..old"},
+				},
+			},
+			listenerName:          "https",
+			listenerSpec:          &listener,
+			defaultBackendSetName: "default",
+			sslConfig:             sslConfig,
+		})
+
+		assert.True(t, changed)
+		assert.Equal(t, []string{"ocid1.certificate.oc1..test"}, details.SslConfiguration.CertificateIds)
+	})
+
+	t.Run("reconcileHTTPListener configures OCI certificate IDs", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		listener := gatewayv1.Listener{
+			Name:     "https",
+			Protocol: gatewayv1.HTTPSProtocolType,
+			Port:     443,
+		}
+		params := reconcileHTTPListenerParams{
+			loadBalancerID: faker.New().UUID().V4(),
+			knownListeners: map[string]loadbalancer.Listener{
+				"https": {
+					Name:                  new("https"),
+					Protocol:              new("HTTP"),
+					Port:                  new(443),
+					DefaultBackendSetName: new("default"),
+					RoutingPolicyName:     new("https_policy"),
+				},
+			},
+			knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+				"https_policy": {},
+			},
+			listenerCertificateID: "ocid1.certificate.oc1..test",
+			defaultBackendSetName: "default",
+			listenerSpec:          &listener,
+		}
+		ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+		watcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+		workRequestID := faker.New().UUID().V4()
+
+		ociLoadBalancerClient.EXPECT().UpdateListener(t.Context(), loadbalancer.UpdateListenerRequest{
+			LoadBalancerId: new(params.loadBalancerID),
+			ListenerName:   new("https"),
+			UpdateListenerDetails: loadbalancer.UpdateListenerDetails{
+				Protocol:              new("HTTP"),
+				Port:                  new(443),
+				DefaultBackendSetName: new("default"),
+				RoutingPolicyName:     new("https_policy"),
+				SslConfiguration: &loadbalancer.SslConfigurationDetails{
+					CertificateIds: []string{"ocid1.certificate.oc1..test"},
+				},
+			},
+		}).Return(loadbalancer.UpdateListenerResponse{OpcWorkRequestId: new(workRequestID)}, nil)
+		watcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil)
+
+		err := model.reconcileHTTPListener(t.Context(), params)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("reconcileHTTPListener returns OCI certificate ID update errors", func(t *testing.T) {
+		deps := ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           NewMockociLoadBalancerClient(t),
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		}
+		model := newOciLoadBalancerModel(deps)
+		listener := gatewayv1.Listener{
+			Name:     "https",
+			Protocol: gatewayv1.HTTPSProtocolType,
+			Port:     443,
+		}
+		params := reconcileHTTPListenerParams{
+			loadBalancerID: faker.New().UUID().V4(),
+			knownListeners: map[string]loadbalancer.Listener{
+				"https": {
+					Name:                  new("https"),
+					Protocol:              new("HTTP"),
+					Port:                  new(443),
+					DefaultBackendSetName: new("default"),
+					RoutingPolicyName:     new("https_policy"),
+				},
+			},
+			knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+				"https_policy": {},
+			},
+			listenerCertificateID: "ocid1.certificate.oc1..test",
+			defaultBackendSetName: "default",
+			listenerSpec:          &listener,
+		}
+		ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+		wantErr := errors.New(faker.New().Lorem().Sentence(10))
+
+		ociLoadBalancerClient.EXPECT().UpdateListener(t.Context(), loadbalancer.UpdateListenerRequest{
+			LoadBalancerId: new(params.loadBalancerID),
+			ListenerName:   new("https"),
+			UpdateListenerDetails: loadbalancer.UpdateListenerDetails{
+				Protocol:              new("HTTP"),
+				Port:                  new(443),
+				DefaultBackendSetName: new("default"),
+				RoutingPolicyName:     new("https_policy"),
+				SslConfiguration: &loadbalancer.SslConfigurationDetails{
+					CertificateIds: []string{"ocid1.certificate.oc1..test"},
+				},
+			},
+		}).Return(loadbalancer.UpdateListenerResponse{}, wantErr)
+
+		err := model.reconcileHTTPListener(t.Context(), params)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, wantErr)
+	})
+}
+
 func Test_ociListerPolicyRuleName(t *testing.T) {
 	makeExpectedName := func(ruleIndex int, nameParts ...string) string {
 		unsanitizedInput := fmt.Sprintf(
@@ -2536,6 +3079,7 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 	makeSslConfigFromDetails := func(details *loadbalancer.SslConfigurationDetails) *loadbalancer.SslConfiguration {
 		return &loadbalancer.SslConfiguration{
 			CertificateName: details.CertificateName,
+			CertificateIds:  details.CertificateIds,
 		}
 	}
 
@@ -2739,6 +3283,38 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 					SslConfiguration:      nil,
 				},
 				wantOk: true,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+			sslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateIds: []string{},
+			}
+
+			return testCase{
+				name: "empty certificate IDs match nil certificate IDs",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+						SslConfiguration: &loadbalancer.SslConfiguration{
+							CertificateIds: nil,
+						},
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+					sslConfig:             sslConfig,
+				},
+				want:   loadbalancer.UpdateListenerDetails{},
+				wantOk: false,
 			}
 		},
 	}


### PR DESCRIPTION
### Support OCI certificate IDs on ALB gateways

This adds support for using preexisting OCI Certificates Service certificates for TLS on an OCI application load balancer. Certificate OCIDs are configured on the standard Gateway listener TLS options field instead of requiring Kubernetes TLS Secrets.

#### Gateway listener TLS option

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: oke-gateway-oci-certificate
spec:
  gatewayClassName: oke-gateway-api
  infrastructure:
    parametersRef:
      group: oke-gateway-api.gemyago.github.io
      kind: GatewayConfig
      name: oke-gateway-config-oci-certificate
  listeners:
    - name: https
      port: 443
      protocol: HTTPS
      tls:
        mode: Terminate
        options:
          oci.oraclecloud.com/certificate-ocid: ocid1.certificate.oc1..exampleuniqueID
```