### PR TITLE
Add Helm install toggles

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,7 +24,7 @@ kubectl apply -n oke-gw -f manifests/examples/serverroutes.yaml
 
 ## Helm install options
 
-The chart installs both the CRD and the controller resources by default.
+The chart always installs the CRD. Controller resources are installed by default and can be disabled.
 
 ```sh
 # Install everything (default behavior)
@@ -33,10 +33,6 @@ helm install oke-gateway-api-controller ./helm/controller
 # Install only the CRD
 helm install oke-gateway-api-controller ./helm/controller \
   --set deployment.enabled=false
-
-# Install only the controller resources
-helm install oke-gateway-api-controller ./helm/controller \
-  --set crds.install=false
 ```
 
 ## OCI certificate example

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,23 @@ kubectl apply -n oke-gw -f manifests/examples/serverdeployment.yaml
 kubectl apply -n oke-gw -f manifests/examples/serverroutes.yaml
 ```
 
+## Helm install options
+
+The chart installs both the CRD and the controller resources by default.
+
+```sh
+# Install everything (default behavior)
+helm install oke-gateway-api-controller ./helm/controller
+
+# Install only the CRD
+helm install oke-gateway-api-controller ./helm/controller \
+  --set deployment.enabled=false
+
+# Install only the controller resources
+helm install oke-gateway-api-controller ./helm/controller \
+  --set crds.install=false
+```
+
 ## OCI certificate example
 
 Use these manifests when the HTTPS listener should reference an OCI Certificates Service

--- a/deploy/helm/controller/templates/clusterrole.yaml
+++ b/deploy/helm/controller/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -30,3 +31,4 @@ rules:
 - apiGroups: ["oke-gateway-api.gemyago.github.io"]
   resources: ["gateway-configs"]
   verbs: ["get", "list", "watch"]
+{{- end }}

--- a/deploy/helm/controller/templates/clusterrolebinding.yaml
+++ b/deploy/helm/controller/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +12,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "oke-gateway-api-controller.serviceAccountName" . }}
-  namespace: {{ include "oke-gateway-api-controller.namespace" . }} 
+  namespace: {{ include "oke-gateway-api-controller.namespace" . }}
+{{- end }}

--- a/deploy/helm/controller/templates/deployment.yaml
+++ b/deploy/helm/controller/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,3 +53,4 @@ spec:
         - name: oci-config-volume
           mountPath: "/etc/oci"
           readOnly: true
+{{- end }}

--- a/deploy/helm/controller/templates/gateway-config-crd.yaml
+++ b/deploy/helm/controller/templates/gateway-config-crd.yaml
@@ -1,8 +1,9 @@
-{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gateway-configs.oke-gateway-api.gemyago.github.io
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: oke-gateway-api.gemyago.github.io
   names:
@@ -34,4 +35,3 @@ spec:
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
-{{- end }}

--- a/deploy/helm/controller/templates/gateway-config-crd.yaml
+++ b/deploy/helm/controller/templates/gateway-config-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -33,3 +34,4 @@ spec:
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
+{{- end }}

--- a/deploy/helm/controller/templates/serviceaccount.yaml
+++ b/deploy/helm/controller/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.deployment.enabled .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +10,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end -}} 
+{{- end -}}

--- a/deploy/helm/controller/values.yaml
+++ b/deploy/helm/controller/values.yaml
@@ -8,6 +8,10 @@
 nameOverride: ""
 fullnameOverride: ""
 
+crds:
+  # Specifies whether CRDs should be installed with this chart
+  install: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -19,6 +23,9 @@ serviceAccount:
 
 # Deployment configuration
 deployment:
+  # Specifies whether the controller deployment resources should be installed
+  enabled: true
+
   image:
     repository: ghcr.io/gemyago/oke-gateway-api-controller
     pullPolicy: IfNotPresent
@@ -35,4 +42,4 @@ deployment:
   # Node selector, tolerations, and affinity settings can be added here if needed.
   nodeSelector: {}
   tolerations: []
-  affinity: {} 
+  affinity: {}

--- a/deploy/helm/controller/values.yaml
+++ b/deploy/helm/controller/values.yaml
@@ -8,10 +8,6 @@
 nameOverride: ""
 fullnameOverride: ""
 
-crds:
-  # Specifies whether CRDs should be installed with this chart
-  install: true
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
* Add Helm values to enable or disable CRD and controller resource installation
* Gate the CRD, deployment, RBAC, and service account templates behind those values
* Document the new install modes and verify local chart rendering for default, explicit true, and false overrides

Validation:
* `direnv exec . make lint`
* `direnv exec . make test` (currently fails in existing unrelated tests: OCI tenancy config in `cmd/controller/main_test.go` and HTTP middleware body semantics in `internal/api/http/middleware/recover_test.go`)
