### PR TITLE
Fix Helm CRD lifecycle handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ If you touch deployment assets:
 Release versioning:
 - Helm chart `version` tracks the controller release without a leading `v`.
 - Helm chart `appVersion` tracks the controller release tag with the leading `v`.
+- Helm CRDs live under `deploy/helm/controller/crds`; keep them as plain manifests so they can be applied with `kubectl` and installed by Helm via the `crds/` mechanism.
 
 ## Safe Local Runs
 

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -13,9 +13,6 @@ func TestMain(t *testing.T) {
 
 	t.Run("start", func(t *testing.T) {
 		t.Run("should initialize app", func(t *testing.T) {
-			t.Setenv("APP_K8SAPI_NOOP", "true")
-			t.Setenv("APP_OCIAPI_NOOP", "true")
-
 			rootCmd := setupCommands()
 			rootCmd.SetArgs([]string{"start", "--noop", "--logs-file", "../../test.log"})
 			require.NoError(t, rootCmd.Execute())

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -13,6 +13,9 @@ func TestMain(t *testing.T) {
 
 	t.Run("start", func(t *testing.T) {
 		t.Run("should initialize app", func(t *testing.T) {
+			t.Setenv("APP_K8SAPI_NOOP", "true")
+			t.Setenv("APP_OCIAPI_NOOP", "true")
+
 			rootCmd := setupCommands()
 			rootCmd.SetArgs([]string{"start", "--noop", "--logs-file", "../../test.log"})
 			require.NoError(t, rootCmd.Execute())

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,8 +10,8 @@ make tools
 ## Install example resources
 
 ```sh
-# Install CRDs directly from the helm chart
-kubectl apply -f helm/controller/templates/gateway-config-crd.yaml
+# Install CRDs directly from the Helm chart
+kubectl apply -f helm/controller/crds/gateway-config-crd.yaml
 
 # Actualize load balancer OCID in the gatewayconfig prior to applying
 kubectl apply -n oke-gw -f manifests/examples/gatewayconfig.yaml
@@ -24,7 +24,10 @@ kubectl apply -n oke-gw -f manifests/examples/serverroutes.yaml
 
 ## Helm install options
 
-The chart always installs the CRD. Controller resources are installed by default and can be disabled.
+The chart packages the `GatewayConfig` CRD in `crds/`, so Helm installs it on first install
+without treating it like a regular templated resource. Helm does not upgrade or delete CRDs from
+that directory, so apply [helm/controller/crds/gateway-config-crd.yaml](./helm/controller/crds/gateway-config-crd.yaml)
+manually when the CRD changes.
 
 ```sh
 # Install everything (default behavior)
@@ -33,6 +36,10 @@ helm install oke-gateway-api-controller ./helm/controller
 # Install only the CRD
 helm install oke-gateway-api-controller ./helm/controller \
   --set deployment.enabled=false
+
+# Install only the controller when the CRD is already managed separately
+helm install oke-gateway-api-controller ./helm/controller \
+  --skip-crds
 ```
 
 ## OCI certificate example

--- a/deploy/helm/controller/crds/gateway-config-crd.yaml
+++ b/deploy/helm/controller/crds/gateway-config-crd.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gateway-configs.oke-gateway-api.gemyago.github.io
-  annotations:
-    "helm.sh/resource-policy": keep
 spec:
   group: oke-gateway-api.gemyago.github.io
   names:


### PR DESCRIPTION
* Move the GatewayConfig CRD into Helm's crds/ directory so upgrades do not treat it as a templated release resource
* Update deploy docs for direct CRD apply and controller-only installs that use --skip-crds
* Fix the controller startup noop test to force OCI and Kubernetes clients into noop mode