### PR TITLE
Gateway TLS secret changes not causing reconcillation

### DIFF
--- a/internal/api/http/middleware/recover_test.go
+++ b/internal/api/http/middleware/recover_test.go
@@ -21,7 +21,12 @@ func TestRecover(t *testing.T) {
 	t.Run("should call next", func(t *testing.T) {
 		fake := faker.New()
 		nextCalled := true
-		wantNextStatus := 200 + rand.Intn(399)
+		bodyAllowedStatuses := []int{
+			http.StatusOK,
+			http.StatusCreated,
+			http.StatusAccepted,
+		}
+		wantNextStatus := bodyAllowedStatuses[rand.Intn(len(bodyAllowedStatuses))]
 		wantRes := map[string]any{
 			"key1": fake.UUID().V4(),
 			"key2": fake.UUID().V4(),

--- a/internal/app/gateway_controller.go
+++ b/internal/app/gateway_controller.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"go.uber.org/dig"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -38,6 +39,16 @@ func NewGatewayController(deps GatewayControllerDeps) *GatewayController {
 		resourcesModel: deps.ResourcesModel, // Initialize resourcesModel
 		gatewayModel:   deps.GatewayModel,
 	}
+}
+
+func isGatewayAccepted(gateway *gatewayv1.Gateway) bool {
+	condition := meta.FindStatusCondition(
+		gateway.Status.Conditions,
+		string(gatewayv1.GatewayConditionAccepted),
+	)
+	return condition != nil &&
+		condition.ObservedGeneration == gateway.Generation &&
+		condition.Status == v1.ConditionTrue
 }
 
 // processResourceError handles errors from resource programming operations.
@@ -84,11 +95,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req reconcile.Request
 		slog.Int64("generation", data.gateway.Generation),
 	)
 
-	if !r.resourcesModel.isConditionSet(isConditionSetParams{
-		resource:      &data.gateway,
-		conditions:    data.gateway.Status.Conditions,
-		conditionType: string(gatewayv1.GatewayConditionAccepted),
-	}) {
+	if !isGatewayAccepted(&data.gateway) {
 		if err = r.resourcesModel.setCondition(ctx, setConditionParams{
 			resource:      &data.gateway,
 			conditions:    &data.gateway.Status.Conditions,

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -33,6 +33,16 @@ func TestGatewayController(t *testing.T) {
 			RootLogger:     diag.RootTestLogger(),
 		}
 	}
+	markGatewayAccepted := func(gateway *gatewayv1.Gateway) {
+		gateway.Status.Conditions = append(gateway.Status.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.GatewayConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.GatewayReasonAccepted),
+			Message:            fmt.Sprintf("Gateway %s accepted by %s", gateway.Name, ControllerClassName),
+			ObservedGeneration: gateway.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+	}
 
 	t.Run("Reconcile", func(t *testing.T) {
 		t.Run("acceptAndProgram", func(t *testing.T) {
@@ -58,14 +68,6 @@ func TestGatewayController(t *testing.T) {
 					return true
 				})).
 				Return(true, nil).Once()
-
-			mockResourcesModel.EXPECT().
-				isConditionSet(isConditionSetParams{
-					resource:      gateway,
-					conditions:    gateway.Status.Conditions,
-					conditionType: string(gatewayv1.GatewayConditionAccepted),
-				}).
-				Return(false).Once()
 
 			mockResourcesModel.EXPECT().
 				setCondition(t.Context(), setConditionParams{
@@ -227,6 +229,7 @@ func TestGatewayController(t *testing.T) {
 		t.Run("handle porgramGateway errors", func(t *testing.T) {
 			fake := faker.New()
 			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
 
 			req := reconcile.Request{
 				NamespacedName: client.ObjectKey{
@@ -238,7 +241,6 @@ func TestGatewayController(t *testing.T) {
 			deps := newMockDeps(t)
 			controller := NewGatewayController(deps)
 
-			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
 
 			mockGatewayModel.EXPECT().
@@ -247,14 +249,6 @@ func TestGatewayController(t *testing.T) {
 					return true
 				})).
 				Return(true, nil).Once()
-
-			mockResourcesModel.EXPECT().
-				isConditionSet(isConditionSetParams{
-					resource:      gateway,
-					conditions:    gateway.Status.Conditions,
-					conditionType: string(gatewayv1.GatewayConditionAccepted),
-				}).
-				Return(true).Once()
 
 			mockGatewayModel.EXPECT().
 				isProgrammed(t.Context(), &resolvedGatewayDetails{
@@ -279,6 +273,7 @@ func TestGatewayController(t *testing.T) {
 		t.Run("handle program resourceStatusError", func(t *testing.T) {
 			fake := faker.New()
 			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
 
 			req := reconcile.Request{
 				NamespacedName: client.ObjectKey{
@@ -299,14 +294,6 @@ func TestGatewayController(t *testing.T) {
 					return true
 				})).
 				Return(true, nil).Once()
-
-			mockResourcesModel.EXPECT().
-				isConditionSet(isConditionSetParams{
-					resource:      gateway,
-					conditions:    gateway.Status.Conditions,
-					conditionType: string(gatewayv1.GatewayConditionAccepted),
-				}).
-				Return(true).Once()
 
 			mockGatewayModel.EXPECT().
 				isProgrammed(t.Context(), &resolvedGatewayDetails{
@@ -344,6 +331,7 @@ func TestGatewayController(t *testing.T) {
 		t.Run("handle set programmed condition error", func(t *testing.T) {
 			fake := faker.New()
 			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
 
 			req := reconcile.Request{
 				NamespacedName: client.ObjectKey{
@@ -355,7 +343,6 @@ func TestGatewayController(t *testing.T) {
 			deps := newMockDeps(t)
 			controller := NewGatewayController(deps)
 
-			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
 
 			mockGatewayModel.EXPECT().
@@ -364,14 +351,6 @@ func TestGatewayController(t *testing.T) {
 					return true
 				})).
 				Return(true, nil).Once()
-
-			mockResourcesModel.EXPECT().
-				isConditionSet(isConditionSetParams{
-					resource:      gateway,
-					conditions:    gateway.Status.Conditions,
-					conditionType: string(gatewayv1.GatewayConditionAccepted),
-				}).
-				Return(true).Once()
 
 			mockGatewayModel.EXPECT().
 				isProgrammed(t.Context(), &resolvedGatewayDetails{
@@ -400,6 +379,7 @@ func TestGatewayController(t *testing.T) {
 
 		t.Run("skip program when condition is already set", func(t *testing.T) {
 			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
 
 			req := reconcile.Request{
 				NamespacedName: client.ObjectKey{
@@ -411,7 +391,6 @@ func TestGatewayController(t *testing.T) {
 			deps := newMockDeps(t)
 			controller := NewGatewayController(deps)
 
-			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
 
 			mockGatewayModel.EXPECT().
@@ -420,14 +399,6 @@ func TestGatewayController(t *testing.T) {
 					return true
 				})).
 				Return(true, nil).Once()
-
-			mockResourcesModel.EXPECT().
-				isConditionSet(isConditionSetParams{
-					resource:      gateway,
-					conditions:    gateway.Status.Conditions,
-					conditionType: string(gatewayv1.GatewayConditionAccepted),
-				}).
-				Return(true).Once()
 
 			mockGatewayModel.EXPECT().
 				isProgrammed(t.Context(), &resolvedGatewayDetails{

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -9,12 +9,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/types"
 )
 
 func TestGatewayController(t *testing.T) {
@@ -432,6 +439,130 @@ func TestGatewayController(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("clears accepted false after previously missing TLS secret exists", func(t *testing.T) {
+			fakeData := faker.New()
+			scheme := runtime.NewScheme()
+			require.NoError(t, clientgoscheme.AddToScheme(scheme))
+			require.NoError(t, gatewayv1.Install(scheme))
+			require.NoError(t, types.AddKnownTypes(scheme))
+
+			secretName := "tls-" + fakeData.Internet().Slug()
+			configName := "config-" + fakeData.Internet().Slug()
+			loadBalancerID := fakeData.UUID().V4()
+			secretUID := apitypes.UID(fakeData.UUID().V4())
+			secretResourceVersion := fakeData.UUID().V4()
+
+			gateway := newRandomGateway(
+				randomGatewayWithListenersOpt(gatewayv1.Listener{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: gatewayv1.ObjectName(secretName)},
+						},
+					},
+				}),
+			)
+			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{
+					Group: ConfigRefGroup,
+					Kind:  ConfigRefKind,
+					Name:  configName,
+				},
+			}
+			gateway.Status.Conditions = []metav1.Condition{
+				{
+					Type:               string(gatewayv1.GatewayConditionAccepted),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(gatewayv1.GatewayReasonInvalidParameters),
+					Message:            fmt.Sprintf("referenced secret %s/%s not found", gateway.Namespace, secretName),
+					ObservedGeneration: gateway.Generation,
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Type:               string(gatewayv1.GatewayConditionProgrammed),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(gatewayv1.GatewayReasonProgrammed),
+					Message:            fmt.Sprintf("Gateway %s programmed by %s", gateway.Name, ControllerClassName),
+					ObservedGeneration: gateway.Generation,
+					LastTransitionTime: metav1.Now(),
+				},
+			}
+			gateway.Annotations = map[string]string{
+				GatewayProgrammingRevisionAnnotation:                         GatewayProgrammingRevisionValue,
+				GatewayUsedSecretsAnnotationPrefix + "/" + string(secretUID): secretResourceVersion,
+			}
+
+			gatewayClass := newRandomGatewayClass(
+				randomGatewayClassWithControllerNameOpt(ControllerClassName),
+			)
+			gateway.Spec.GatewayClassName = gatewayv1.ObjectName(gatewayClass.Name)
+
+			gatewayConfig := &types.GatewayConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: gateway.Namespace,
+				},
+				Spec: types.GatewayConfigSpec{
+					LoadBalancerID: loadBalancerID,
+				},
+			}
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            secretName,
+					Namespace:       gateway.Namespace,
+					UID:             secretUID,
+					ResourceVersion: secretResourceVersion,
+				},
+				Type: corev1.SecretTypeTLS,
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       []byte(fakeData.Lorem().Sentence(10)),
+					corev1.TLSPrivateKeyKey: []byte(fakeData.Lorem().Sentence(10)),
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&gatewayv1.Gateway{}).
+				WithObjects(gateway, gatewayClass, gatewayConfig, secret).
+				Build()
+
+			resourcesModel := newResourcesModel(resourcesModelDeps{
+				K8sClient:  k8sClient,
+				RootLogger: diag.RootTestLogger(),
+			})
+			gatewayModel := newGatewayModel(gatewayModelDeps{
+				K8sClient:            k8sClient,
+				ResourcesModel:       resourcesModel,
+				RootLogger:           diag.RootTestLogger(),
+				OciClient:            NewMockociLoadBalancerClient(t),
+				OciLoadBalancerModel: NewMockociLoadBalancerModel(t),
+			})
+			controller := NewGatewayController(GatewayControllerDeps{
+				K8sClient:      k8sClient,
+				ResourcesModel: resourcesModel,
+				GatewayModel:   gatewayModel,
+				RootLogger:     diag.RootTestLogger(),
+			})
+
+			result, err := controller.Reconcile(t.Context(), reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(gateway),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+
+			var updatedGateway gatewayv1.Gateway
+			require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(gateway), &updatedGateway))
+			accepted := meta.FindStatusCondition(
+				updatedGateway.Status.Conditions,
+				string(gatewayv1.GatewayConditionAccepted),
+			)
+			require.NotNil(t, accepted)
+			assert.Equal(t, metav1.ConditionTrue, accepted.Status)
 		})
 
 		t.Run("ignore irrelevant requests", func(t *testing.T) {

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -57,12 +57,7 @@ func httpRouteObjectPredicate() predicate.Funcs {
 func gatewaySecretPredicate() predicate.Funcs {
 	resourceVersionChanged := predicate.ResourceVersionChangedPredicate{}
 	return predicate.Funcs{
-		// We ignore create events. They're also happening when controller starts up
-		// which leads to duplicate reconciliations and just noise.
-		// We don't care when new secrets are created, currently if no secret
-		// the whole gateway reconciliation will fail. We may want to change this
-		// in the future and revisit this predicate.
-		CreateFunc: func(_ event.CreateEvent) bool { return false },
+		CreateFunc: func(_ event.CreateEvent) bool { return true },
 		UpdateFunc: resourceVersionChanged.Update,
 	}
 }

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -54,6 +54,19 @@ func httpRouteObjectPredicate() predicate.Funcs {
 	}
 }
 
+func gatewaySecretPredicate() predicate.Funcs {
+	resourceVersionChanged := predicate.ResourceVersionChangedPredicate{}
+	return predicate.Funcs{
+		// We ignore create events. They're also happening when controller starts up
+		// which leads to duplicate reconciliations and just noise.
+		// We don't care when new secrets are created, currently if no secret
+		// the whole gateway reconciliation will fail. We may want to change this
+		// in the future and revisit this predicate.
+		CreateFunc: func(_ event.CreateEvent) bool { return false },
+		UpdateFunc: resourceVersionChanged.Update,
+	}
+}
+
 // StartManager starts the controller manager.
 func StartManager(ctx context.Context, deps StartManagerDeps) error { // coverage-ignore -- challenging to test
 	logger := deps.RootLogger.WithGroup("k8s")
@@ -96,17 +109,7 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error { // coverag
 			Watches(
 				&corev1.Secret{},
 				handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapSecretToGateway),
-				builder.WithPredicates(predicate.And(
-					predicate.Funcs{
-						// We ignore create events. They're also happening when controller starts up
-						// which leads to duplicate reconciliations and just noise.
-						// We don't care when new secrets are created, currently if no secret
-						// the whole gateway reconciliation will fail. We may want to change this
-						// in the future and revisit this predicate.
-						CreateFunc: func(_ event.CreateEvent) bool { return false },
-					},
-					predicate.ResourceVersionChangedPredicate{},
-				)),
+				builder.WithPredicates(gatewaySecretPredicate()),
 			).
 			Watches(
 				&configtypes.GatewayConfig{},

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -3,7 +3,9 @@ package k8s
 import (
 	"testing"
 
+	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -30,5 +32,28 @@ func TestHTTPRouteObjectPredicate(t *testing.T) {
 		})
 
 		assert.True(t, result)
+	})
+}
+
+func TestStartManager(t *testing.T) {
+	t.Run("gatewaySecretPredicate", func(t *testing.T) {
+		t.Run("allows TLS Secret create events to reach Gateway mapping", func(t *testing.T) {
+			fake := faker.New()
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tls-" + fake.Internet().Slug(),
+					Namespace: "ns-" + fake.Internet().Slug(),
+				},
+				Type: corev1.SecretTypeTLS,
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       []byte(fake.Lorem().Sentence(10)),
+					corev1.TLSPrivateKeyKey: []byte(fake.Lorem().Sentence(10)),
+				},
+			}
+
+			result := gatewaySecretPredicate().Create(event.CreateEvent{Object: secret})
+
+			assert.True(t, result)
+		})
 	})
 }


### PR DESCRIPTION
### Gateway reconciliation bugs

#### Bug 1: Secret Create is ignored

Create the Gateway first. Do not create the Secret yet.

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: secret-create-ignored
  namespace: default
spec:
  gatewayClassName: oke-alb
  infrastructure:
    parametersRef:
      group: oke-gateway-api.gemyago.github.io
      kind: GatewayConfig
      name: existing-alb-config
  listeners:
    - name: https
      protocol: HTTPS
      port: 443
      tls:
        mode: Terminate
        certificateRefs:
          - kind: Secret
            name: create-later-cert
```

Then create the Secret:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: create-later-cert
  namespace: default
type: kubernetes.io/tls
data:
  tls.crt: <base64-cert>
  tls.key: <base64-key>
```

**Bug: the Gateway is not reconciled when the Secret is created, because Secret create events are filtered out.**


#### Bug 2: Accepted=False Is Not Cleared

This example assumes the Secret already exists before the Gateway is created, so it is not testing Secret creation.
Create the Secret first:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: existing-cert
  namespace: default
type: kubernetes.io/tls
data:
  tls.crt: <base64-cert>
  tls.key: <base64-key>
```

Create a Gateway that is invalid for some other reason, for example referencing a missing `GatewayConfig`:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: accepted-false-stuck
  namespace: default
spec:
  gatewayClassName: oke-alb
  infrastructure:
    parametersRef:
      group: oke-gateway-api.gemyago.github.io
      kind: GatewayConfig
      name: missing-config
  listeners:
    - name: https
      protocol: HTTPS
      port: 443
      tls:
        mode: Terminate
        certificateRefs:
          - kind: Secret
            name: existing-cert
```

The controller sets:

Accepted: False
reason: InvalidParameters
message: spec.infrastructure is pointing to a non-existent GatewayConfig

Now create the previously missing GatewayConfig:

```yaml
apiVersion: oke-gateway-api.gemyago.github.io/v1alpha1
kind: GatewayConfig
metadata:
  name: missing-config
  namespace: default
spec:
  loadBalancerId: ocid1.loadbalancer.oc1.iad.example
```

**Bug: the Gateway is reconciled because GatewayConfig changes are watched, but Accepted=False may remain stuck because the controller sees an Accepted condition for the current Gateway generation and does not replace it with Accepted=True.**


#### Test failure before fix applied

```shell
Run make test
go install github.com/vladopajic/go-test-coverage/v2@latest
go: downloading github.com/vladopajic/go-test-coverage v1.0.1
go: downloading github.com/aws/aws-sdk-go v1.49.4
go: downloading golang.org/x/tools v0.26.0
go: downloading golang.org/x/sys v0.29.0
mkdir -p .cover
TZ=US/Alaska go test -shuffle=on -failfast -coverpkg=./internal/...,./cmd/... -coverprofile=.cover/profile.out -covermode=atomic ./...
ok  	github.com/gemyago/oke-gateway-api/cmd/controller	0.041s	coverage: 6.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/cmd/server	0.015s	coverage: 5.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http	0.013s	coverage: 1.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http/middleware	0.015s	coverage: 1.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http/server	0.014s	coverage: 2.9% of statements in ./internal/..., ./cmd/...
-test.shuffle 1780957635507741666
--- FAIL: TestGatewayController (0.01s)
    --- FAIL: TestGatewayController/Reconcile (0.01s)
        --- FAIL: TestGatewayController/Reconcile/clears_accepted_false_after_previously_missing_TLS_secret_exists (0.00s)
            gateway_controller_test.go:565: 
                	Error Trace:	/home/runner/work/oke-gateway-api/oke-gateway-api/internal/app/gateway_controller_test.go:565
                	Error:      	Not equal: 
                	            	expected: "True"
                	            	actual  : "False"
                	            	
                	            	Diff:
                	            	--- Expected
                	            	+++ Actual
                	            	@@ -1,2 +1,2 @@
                	            	-(v1.ConditionStatus) (len=4) "True"
                	            	+(v1.ConditionStatus) (len=5) "False"
                	            	 
                	Test:       	TestGatewayController/Reconcile/clears_accepted_false_after_previously_missing_TLS_secret_exists
FAIL
coverage: 32.2% of statements in ./internal/..., ./cmd/...
FAIL	github.com/gemyago/oke-gateway-api/internal/app	0.071s
ok  	github.com/gemyago/oke-gateway-api/internal/config	0.016s	coverage: 1.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/di	0.013s	coverage: 0.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/diag	0.013s	coverage: 1.9% of statements in ./internal/..., ./cmd/...
-test.shuffle 1780957635531759815
--- FAIL: TestStartManager (0.00s)
    --- FAIL: TestStartManager/gatewaySecretPredicate (0.00s)
        --- FAIL: TestStartManager/gatewaySecretPredicate/allows_TLS_Secret_create_events_to_reach_Gateway_mapping (0.00s)
            start_manager_test.go:31: 
                	Error Trace:	/home/runner/work/oke-gateway-api/oke-gateway-api/internal/k8s/start_manager_test.go:31
                	Error:      	Should be true
                	Test:       	TestStartManager/gatewaySecretPredicate/allows_TLS_Secret_create_events_to_reach_Gateway_mapping
FAIL
coverage: 0.5% of statements in ./internal/..., ./cmd/...
FAIL	github.com/gemyago/oke-gateway-api/internal/k8s	0.041s
ok  	github.com/gemyago/oke-gateway-api/internal/services	0.014s	coverage: 1.7% of statements in ./internal/..., ./cmd/...
	github.com/gemyago/oke-gateway-api/internal/services/k8sapi		coverage: 0.0% of statements
ok  	github.com/gemyago/oke-gateway-api/internal/services/ociapi	0.027s	coverage: 3.4% of statements in ./internal/..., ./cmd/...
FAIL
make: *** [Makefile:38: .cover/profile.out] Error 1
Error: Process completed with exit code 2.
```