### PR TITLE
HTTPRoute hostname routing failures

### DIFF
--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -32,7 +32,7 @@ const (
 
 	// HTTPRouteProgrammingRevisionValue is the value for the http route programming revision.
 	// Incremented when the controller programming steps are changed.
-	HTTPRouteProgrammingRevisionValue = "2"
+	HTTPRouteProgrammingRevisionValue = "3"
 )
 
 const ConfigRefGroup = "oke-gateway-api.gemyago.github.io"

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1323,6 +1323,39 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			assert.Equal(t, !checkResult, required)
 		})
 
+		t.Run("ProgrammingRequired/ProgrammingRevisionChanged", func(t *testing.T) {
+			deps := newMockDeps(t)
+			deps.ResourcesModel = newResourcesModel(resourcesModelDeps{
+				K8sClient:  deps.K8sClient,
+				RootLogger: diag.RootTestLogger(),
+			})
+			model := newHTTPRouteModel(deps)
+			controllerName, details := newIsProgrammingRequiredDetails()
+
+			if details.httpRoute.Annotations == nil {
+				details.httpRoute.Annotations = map[string]string{}
+			}
+			details.httpRoute.Annotations[HTTPRouteProgrammingRevisionAnnotation] = "2"
+			details.httpRoute.Status.Parents = []gatewayv1.RouteParentStatus{
+				{
+					ControllerName: controllerName,
+					ParentRef:      details.matchedRef,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.RouteConditionResolvedRefs),
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: details.httpRoute.Generation,
+						},
+					},
+				},
+			}
+
+			required, err := model.isProgrammingRequired(details)
+
+			require.NoError(t, err)
+			assert.True(t, required)
+		})
+
 		t.Run("ProgrammingRequired/ParentRefMismatch", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)

--- a/internal/app/mock_oci_load_balancer_routing_rules_mapper.go
+++ b/internal/app/mock_oci_load_balancer_routing_rules_mapper.go
@@ -134,6 +134,63 @@ func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteMatchesToCondition_C
 	return _c
 }
 
+// mapHTTPRouteHostnamesAndMatchesToCondition provides a mock function with given fields: hostnames, matches
+func (_m *MockociLoadBalancerRoutingRulesMapper) mapHTTPRouteHostnamesAndMatchesToCondition(hostnames []v1.Hostname, matches []v1.HTTPRouteMatch) (string, error) {
+	ret := _m.Called(hostnames, matches)
+
+	if len(ret) == 0 {
+		panic("no return value specified for mapHTTPRouteHostnamesAndMatchesToCondition")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]v1.Hostname, []v1.HTTPRouteMatch) (string, error)); ok {
+		return rf(hostnames, matches)
+	}
+	if rf, ok := ret.Get(0).(func([]v1.Hostname, []v1.HTTPRouteMatch) string); ok {
+		r0 = rf(hostnames, matches)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func([]v1.Hostname, []v1.HTTPRouteMatch) error); ok {
+		r1 = rf(hostnames, matches)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'mapHTTPRouteHostnamesAndMatchesToCondition'
+type MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call struct {
+	*mock.Call
+}
+
+// mapHTTPRouteHostnamesAndMatchesToCondition is a helper method to define mock.On call
+//   - hostnames []v1.Hostname
+//   - matches []v1.HTTPRouteMatch
+func (_e *MockociLoadBalancerRoutingRulesMapper_Expecter) mapHTTPRouteHostnamesAndMatchesToCondition(hostnames interface{}, matches interface{}) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
+	return &MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call{Call: _e.mock.On("mapHTTPRouteHostnamesAndMatchesToCondition", hostnames, matches)}
+}
+
+func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call) Run(run func(hostnames []v1.Hostname, matches []v1.HTTPRouteMatch)) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]v1.Hostname), args[1].([]v1.HTTPRouteMatch))
+	})
+	return _c
+}
+
+func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call) Return(_a0 string, _a1 error) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call) RunAndReturn(run func([]v1.Hostname, []v1.HTTPRouteMatch) (string, error)) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockociLoadBalancerRoutingRulesMapper creates a new instance of MockociLoadBalancerRoutingRulesMapper. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockociLoadBalancerRoutingRulesMapper(t interface {

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -675,7 +675,10 @@ func (m *ociLoadBalancerModelImpl) makeRoutingRule(
 		return ociBackendSetNameFromBackendRef(params.httpRoute, backendRef)
 	})
 
-	condition, err := m.routingRulesMapper.mapHTTPRouteMatchesToCondition(rule.Matches)
+	condition, err := m.routingRulesMapper.mapHTTPRouteHostnamesAndMatchesToCondition(
+		params.httpRoute.Spec.Hostnames,
+		rule.Matches,
+	)
 	if err != nil {
 		return loadbalancer.RoutingRule{}, fmt.Errorf("failed to map http route matches to condition: %w", err)
 	}

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -1446,7 +1446,8 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			expectedCondition := fake.Lorem().Sentence(10)
-			routingRulesMapper.EXPECT().mapHTTPRouteMatchesToCondition(
+			routingRulesMapper.EXPECT().mapHTTPRouteHostnamesAndMatchesToCondition(
+				httpRoute.Spec.Hostnames,
 				httpRoute.Spec.Rules[ruleIndex].Matches,
 			).Return(expectedCondition, nil).Once()
 
@@ -1526,7 +1527,8 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			expectedErr := errors.New(fake.Lorem().Sentence(10))
-			routingRulesMapper.EXPECT().mapHTTPRouteMatchesToCondition(
+			routingRulesMapper.EXPECT().mapHTTPRouteHostnamesAndMatchesToCondition(
+				httpRoute.Spec.Hostnames,
 				httpRoute.Spec.Rules[ruleIndex].Matches,
 			).Return("", expectedErr).Once()
 

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -1470,6 +1470,45 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			assert.Equal(t, expectedRule, actualRule)
 		})
 
+		t.Run("includes route hostname in routing rule condition", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			deps.RoutingRulesMapper = newOciLoadBalancerRoutingRulesMapper()
+			model := newOciLoadBalancerModel(deps)
+
+			hostname := gatewayv1.Hostname("auth-" + fake.Internet().Domain())
+			pathValue := "/"
+			backendRef := makeRandomBackendRef()
+			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(
+					gatewayv1.HTTPRouteRule{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
+									Value: &pathValue,
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef},
+					},
+				),
+			)
+			httpRoute.Spec.Hostnames = []gatewayv1.Hostname{hostname}
+
+			actualRule, err := model.makeRoutingRule(t.Context(), makeRoutingRuleParams{
+				httpRoute:          httpRoute,
+				httpRouteRuleIndex: 0,
+			})
+
+			require.NoError(t, err)
+			condition := lo.FromPtr(actualRule.Condition)
+			assert.Contains(t, condition, "all(")
+			assert.Contains(t, condition, "http.request.headers[(i 'host')]")
+			assert.Contains(t, condition, fmt.Sprintf("eq (i '%s')", hostname))
+			assert.Contains(t, condition, fmt.Sprintf("http.request.url.path sw '%s'", pathValue))
+		})
+
 		t.Run("fail when mapping matches to condition fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)

--- a/internal/app/oci_load_balancer_routing_rules.go
+++ b/internal/app/oci_load_balancer_routing_rules.go
@@ -54,6 +54,13 @@ type ociLoadBalancerRoutingRulesMapper interface {
 	// mapHTTPRouteMatchesToCondition translates a Gateway API HTTPRouteMatches
 	// to a list of OCI Load Balancer conditions as a string..
 	mapHTTPRouteMatchesToCondition(matches []gatewayv1.HTTPRouteMatch) (string, error)
+
+	// mapHTTPRouteHostnamesAndMatchesToCondition translates Gateway API hostnames and matches
+	// to an OCI Load Balancer routing policy condition.
+	mapHTTPRouteHostnamesAndMatchesToCondition(
+		hostnames []gatewayv1.Hostname,
+		matches []gatewayv1.HTTPRouteMatch,
+	) (string, error)
 }
 
 type ociLoadBalancerRoutingRulesMapperImpl struct{}
@@ -168,24 +175,61 @@ func mapRegexHeaderMatchToCondition(headerMatch gatewayv1.HTTPHeaderMatch) (stri
 func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteMatchesToCondition(
 	matches []gatewayv1.HTTPRouteMatch,
 ) (string, error) {
-	if len(matches) == 0 {
+	conditions, err := r.mapHTTPRouteMatchesToConditions(matches)
+	if err != nil {
+		return "", err
+	}
+	if len(conditions) == 0 {
 		return "", nil
+	}
+
+	return fmt.Sprintf("any(%s)", strings.Join(conditions, ", ")), nil
+}
+
+func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteMatchesToConditions(
+	matches []gatewayv1.HTTPRouteMatch,
+) ([]string, error) {
+	if len(matches) == 0 {
+		return nil, nil
 	}
 
 	var conditions []string
 	for _, match := range matches {
 		condition, err := r.mapHTTPRouteMatchToCondition(match)
 		if err != nil {
-			return "", err // Propagate error if any single match fails
+			return nil, err // Propagate error if any single match fails
 		}
 		if condition != "" {
 			conditions = append(conditions, condition)
 		}
 	}
 
-	if len(conditions) == 0 {
-		// TODO: Investigate if empty is possible, if no - return error here
-		return "", nil
+	return conditions, nil
+}
+
+func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteHostnamesAndMatchesToCondition(
+	hostnames []gatewayv1.Hostname,
+	matches []gatewayv1.HTTPRouteMatch,
+) (string, error) {
+	if len(hostnames) == 0 {
+		return r.mapHTTPRouteMatchesToCondition(matches)
+	}
+
+	matchConditions, err := r.mapHTTPRouteMatchesToConditions(matches)
+	if err != nil {
+		return "", err
+	}
+
+	conditions := make([]string, 0, len(hostnames)*max(1, len(matchConditions)))
+	for _, hostname := range hostnames {
+		hostCondition := fmt.Sprintf(`http.request.headers[(i 'host')] eq (i '%s')`, hostname)
+		if len(matchConditions) == 0 {
+			conditions = append(conditions, hostCondition)
+			continue
+		}
+		for _, matchCondition := range matchConditions {
+			conditions = append(conditions, "all("+hostCondition+", "+matchCondition+")")
+		}
 	}
 
 	return fmt.Sprintf("any(%s)", strings.Join(conditions, ", ")), nil

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -561,4 +561,87 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("mapHTTPRouteHostnamesAndMatchesToCondition", func(t *testing.T) {
+		t.Run("uses route matches when no hostnames are configured", func(t *testing.T) {
+			fake := faker.New()
+			pathValue := "/" + fake.Lorem().Word()
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
+				nil,
+				[]gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  lo.ToPtr(gatewayv1.PathMatchExact),
+							Value: &pathValue,
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("any(http.request.url.path eq '%s')", pathValue), actual)
+		})
+
+		t.Run("combines each hostname with each route match", func(t *testing.T) {
+			fake := faker.New()
+			host1 := gatewayv1.Hostname("auth-" + fake.Internet().Domain())
+			host2 := gatewayv1.Hostname("api-" + fake.Internet().Domain())
+			pathValue := "/" + fake.Lorem().Word()
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
+				[]gatewayv1.Hostname{host1, host2},
+				[]gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
+							Value: &pathValue,
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			want := fmt.Sprintf(
+				"any("+
+					"all(http.request.headers[(i 'host')] eq (i '%s'), http.request.url.path sw '%s'), "+
+					"all(http.request.headers[(i 'host')] eq (i '%s'), http.request.url.path sw '%s')"+
+					")",
+				host1,
+				pathValue,
+				host2,
+				pathValue,
+			)
+			assert.Equal(
+				t,
+				strings.Join(strings.Fields(want), " "),
+				strings.Join(strings.Fields(actual), " "),
+			)
+		})
+
+		t.Run("uses hostnames when matches are empty", func(t *testing.T) {
+			fake := faker.New()
+			host1 := gatewayv1.Hostname("auth-" + fake.Internet().Domain())
+			host2 := gatewayv1.Hostname("api-" + fake.Internet().Domain())
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
+				[]gatewayv1.Hostname{host1, host2},
+				nil,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				fmt.Sprintf(
+					"any(http.request.headers[(i 'host')] eq (i '%s'), http.request.headers[(i 'host')] eq (i '%s'))",
+					host1,
+					host2,
+				),
+				actual,
+			)
+		})
+	})
 }


### PR DESCRIPTION
#### Bug 1: Hostnames ignored In routing rules

This reproduces the routing collision.

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: app-a
  namespace: default
spec:
  hostnames:
    - auth.example.com
  parentRefs:
    - name: oke-alb-gateway
      sectionName: https
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
      backendRefs:
        - name: keycloak
          port: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: app-b
  namespace: default
spec:
  hostnames:
    - hls.example.com
  parentRefs:
    - name: oke-alb-gateway
      sectionName: https
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
      backendRefs:
        - name: mediamtx-hls
          port: 8888
```

Expected OCI routing policy should include host + path:

```
any(all(http.request.headers[(i 'host')] eq (i 'auth.example.com'), http.request.url.path sw '/'))
any(all(http.request.headers[(i 'host')] eq (i 'hls.example.com'), http.request.url.path sw '/'))
```

Broken behavior today: both routes produce only:

```
any(http.request.url.path sw '/')
```

#### Bug 2: Previously programmed routes do not reprogram

This reproduces stale OCI policy behavior after the controller logic is fixed.

Start with an already-programmed HTTPRoute created before the hostname fix:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: auth-route
  namespace: default
  annotations:
    oke-gateway-api.gemyago.github.io/http-route-programming-revision: "2"
spec:
  hostnames:
    - auth.example.com
  parentRefs:
    - name: oke-alb-gateway
      sectionName: https
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
      backendRefs:
        - name: keycloak
          port: 80
```

Its existing OCI rule was programmed as path-only:

```
any(http.request.url.path sw '/')
```

After deploying code that fixes hostname condition generation, the route still may not reprogram because the controller sees revision "2" and treats it as already programmed.

Expected fix: bump HTTPRouteProgrammingRevisionValue, for example from "2" to "3", so existing routes are reprocessed and rewritten with host-aware conditions.


#### Tests failing before fix
```yaml
hjames@hayden-desktop:~/Documents/oke-gateway-api$ APP_OCIAPI_NOOP=true APP_K8SAPI_NOOP=true go test ./internal/app -run 'Test(OciLoadBalancerModelImpl|HTTPRouteModelImpl)'
--- FAIL: TestHTTPRouteModelImpl (0.00s)
    --- FAIL: TestHTTPRouteModelImpl/isProgrammingRequired (0.00s)
        --- FAIL: TestHTTPRouteModelImpl/isProgrammingRequired/ProgrammingRequired/ProgrammingRevisionChanged (0.00s)
            httproute_model_test.go:1356: 
                	Error Trace:	/home/hjames/Documents/oke-gateway-api/internal/app/httproute_model_test.go:1356
                	Error:      	Should be true
                	Test:       	TestHTTPRouteModelImpl/isProgrammingRequired/ProgrammingRequired/ProgrammingRevisionChanged
--- FAIL: TestOciLoadBalancerModelImpl (0.01s)
    --- FAIL: TestOciLoadBalancerModelImpl/makeRoutingRule (0.00s)
        --- FAIL: TestOciLoadBalancerModelImpl/makeRoutingRule/includes_route_hostname_in_routing_rule_condition (0.00s)
            oci_load_balancer_model_test.go:1506: 
                	Error Trace:	/home/hjames/Documents/oke-gateway-api/internal/app/oci_load_balancer_model_test.go:1506
                	Error:      	"any(http.request.url.path sw '/')" does not contain "all("
                	Test:       	TestOciLoadBalancerModelImpl/makeRoutingRule/includes_route_hostname_in_routing_rule_condition
            oci_load_balancer_model_test.go:1507: 
                	Error Trace:	/home/hjames/Documents/oke-gateway-api/internal/app/oci_load_balancer_model_test.go:1507
                	Error:      	"any(http.request.url.path sw '/')" does not contain "http.request.headers[(i 'host')]"
                	Test:       	TestOciLoadBalancerModelImpl/makeRoutingRule/includes_route_hostname_in_routing_rule_condition
            oci_load_balancer_model_test.go:1508: 
                	Error Trace:	/home/hjames/Documents/oke-gateway-api/internal/app/oci_load_balancer_model_test.go:1508
                	Error:      	"any(http.request.url.path sw '/')" does not contain "eq (i 'auth-hmh.com')"
                	Test:       	TestOciLoadBalancerModelImpl/makeRoutingRule/includes_route_hostname_in_routing_rule_condition
FAIL
FAIL	github.com/gemyago/oke-gateway-api/internal/app	0.015s
FAIL

```

