### PR TITLE
Fix HTTP backend port update

### DIFF
--- a/internal/app/httpbackend_model.go
+++ b/internal/app/httpbackend_model.go
@@ -38,6 +38,11 @@ type identifyBackendsToUpdateResult struct {
 	drainingCount   int
 }
 
+type httpBackendAddressKey struct {
+	ipAddress string
+	port      int
+}
+
 // httpBackendModel defines the interface for managing OCI backend sets based on HTTPRoute definitions.
 type httpBackendModel interface {
 	// syncRouteEndpoints synchronizes the OCI Load Balancer Backend Sets associated with the
@@ -109,7 +114,7 @@ func (m *httpBackendModelImpl) identifyBackendsToUpdate(
 	ctx context.Context,
 	params identifyBackendsToUpdateParams,
 ) (identifyBackendsToUpdateResult, error) {
-	desiredBackendsMap := make(map[string]loadbalancer.BackendDetails)
+	desiredBackendsMap := make(map[httpBackendAddressKey]loadbalancer.BackendDetails)
 	var drainingCount int
 
 	for _, slice := range params.endpointSlices {
@@ -128,7 +133,10 @@ func (m *httpBackendModelImpl) identifyBackendsToUpdate(
 				drainingCount++
 			}
 
-			desiredBackendsMap[ipAddress] = loadbalancer.BackendDetails{
+			desiredBackendsMap[httpBackendAddressKey{
+				ipAddress: ipAddress,
+				port:      int(params.endpointPort),
+			}] = loadbalancer.BackendDetails{
 				Port:      new(int(params.endpointPort)),
 				IpAddress: &ipAddress,
 				Drain:     new(isDraining),
@@ -141,8 +149,11 @@ func (m *httpBackendModelImpl) identifyBackendsToUpdate(
 		lo.Filter(params.currentBackends, func(b loadbalancer.Backend, _ int) bool {
 			return b.IpAddress != nil
 		}),
-		func(b loadbalancer.Backend) (string, loadbalancer.Backend) {
-			return *b.IpAddress, b
+		func(b loadbalancer.Backend) (httpBackendAddressKey, loadbalancer.Backend) {
+			return httpBackendAddressKey{
+				ipAddress: *b.IpAddress,
+				port:      lo.FromPtr(b.Port),
+			}, b
 		},
 	)
 

--- a/internal/app/httpbackend_model_test.go
+++ b/internal/app/httpbackend_model_test.go
@@ -628,6 +628,42 @@ func TestHTTPBackendModel(t *testing.T) {
 			assert.Equal(t, expectedResult.drainingCount, result.drainingCount)
 		})
 
+		t.Run("port update", func(t *testing.T) {
+			model := newHTTPBackendModel(newMockDeps(t))
+			currentPort := 80
+			desiredPort := int32(8080)
+
+			endpoint := makeRandomEndpoint(randomEndpointWithConditionsOpt(new(true), new(false)))
+			currentBackends := []loadbalancer.Backend{
+				{
+					Name:      new("backend-port-update"),
+					IpAddress: &endpoint.Addresses[0],
+					Port:      new(currentPort),
+					Drain:     new(false),
+				},
+			}
+			endpointSlices := []discoveryv1.EndpointSlice{
+				{Endpoints: []discoveryv1.Endpoint{endpoint}},
+			}
+
+			result, err := model.identifyBackendsToUpdate(t.Context(), identifyBackendsToUpdateParams{
+				endpointPort:    desiredPort,
+				currentBackends: currentBackends,
+				endpointSlices:  endpointSlices,
+			})
+
+			require.NoError(t, err)
+			assert.True(t, result.updateRequired)
+			assert.ElementsMatch(t, []loadbalancer.BackendDetails{
+				{
+					IpAddress: &endpoint.Addresses[0],
+					Port:      new(int(desiredPort)),
+					Drain:     new(false),
+				},
+			}, result.updatedBackends)
+			assert.Equal(t, 0, result.drainingCount)
+		})
+
 		t.Run("drain status update - stop draining", func(t *testing.T) {
 			fake := faker.New()
 			model := newHTTPBackendModel(newMockDeps(t))


### PR DESCRIPTION
### HTTPRoute updates for ports are not being reconciled

#### Service and HTTPRoute manifests with port 80

```yaml
apiVersion: v1
kind: Service
metadata:
  name: keycloak
  namespace: demo
spec:
  selector:
    app: keycloak
  ports:
    - name: http
      port: 80
      targetPort: 80

apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: keycloak
  namespace: demo
spec:
  parentRefs:
    - name: public-gateway
  hostnames:
    - auth.example.com
  rules:
    - backendRefs:
        - name: keycloak
          port: 80
```

After the controller programs OCI, the backend set contains something like: 10.0.3.32:80

#### Change the app and routing to use 8080 while the pod IP remains the same:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: keycloak
  namespace: demo
spec:
  selector:
    app: keycloak
  ports:
    - name: http
      port: 8080
      targetPort: 8080

apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: keycloak
  namespace: demo
spec:
  parentRefs:
    - name: public-gateway
  hostnames:
    - auth.example.com
  rules:
    - backendRefs:
        - name: keycloak
          port: 8080
```
Expected OCI backend set: 10.0.3.32:8080
Buggy behavior: 10.0.3.32:80

The controller logs: Backend set already up-to-date, skipping update

#### Test failure before fix
```shell
Run make test
go install github.com/vladopajic/go-test-coverage/v2@latest
go: downloading github.com/vladopajic/go-test-coverage v1.0.1
go: downloading github.com/aws/aws-sdk-go v1.49.4
go: downloading golang.org/x/tools v0.26.0
go: downloading golang.org/x/sys v0.29.0
mkdir -p .cover
TZ=US/Alaska go test -shuffle=on -failfast -coverpkg=./internal/...,./cmd/... -coverprofile=.cover/profile.out -covermode=atomic ./...
ok  	github.com/gemyago/oke-gateway-api/cmd/controller	0.038s	coverage: 6.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/cmd/server	0.012s	coverage: 5.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http	0.010s	coverage: 1.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http/middleware	0.010s	coverage: 1.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http/server	0.012s	coverage: 2.9% of statements in ./internal/..., ./cmd/...
-test.shuffle 1780964020000129433
--- FAIL: TestHTTPBackendModel (0.00s)
    --- FAIL: TestHTTPBackendModel/identifyBackendsToUpdate (0.00s)
        --- FAIL: TestHTTPBackendModel/identifyBackendsToUpdate/port_update (0.00s)
            httpbackend_model_test.go:656: 
                	Error Trace:	/home/runner/work/oke-gateway-api/oke-gateway-api/internal/app/httpbackend_model_test.go:656
                	Error:      	Should be true
                	Test:       	TestHTTPBackendModel/identifyBackendsToUpdate/port_update
FAIL
coverage: 7.1% of statements in ./internal/..., ./cmd/...
FAIL	github.com/gemyago/oke-gateway-api/internal/app	0.033s
ok  	github.com/gemyago/oke-gateway-api/internal/config	0.012s	coverage: 1.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/di	0.011s	coverage: 0.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/diag	0.011s	coverage: 1.9% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/k8s	0.028s	coverage: 1.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/services	0.017s	coverage: 1.7% of statements in ./internal/..., ./cmd/...
	github.com/gemyago/oke-gateway-api/internal/services/k8sapi		coverage: 0.0% of statements
FAIL
make: *** [Makefile:38: .cover/profile.out] Error 1
```