### PR TITLE
fix: HTTPRoute annotation change causes reconciliation

### DIFF
--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -44,10 +44,12 @@ type StartManagerDeps struct {
 func httpRouteObjectPredicate() predicate.Funcs {
 	generationChanged := predicate.GenerationChangedPredicate{}
 	labelChanged := predicate.LabelChangedPredicate{}
+	annotationChanged := predicate.AnnotationChangedPredicate{}
 	return predicate.Funcs{
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
 			return generationChanged.Update(updateEvent) ||
-				labelChanged.Update(updateEvent)
+				labelChanged.Update(updateEvent) ||
+				annotationChanged.Update(updateEvent)
 		},
 	}
 }

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -41,6 +41,17 @@ type StartManagerDeps struct {
 	ReconcileHTTPRoute    bool `name:"config.features.reconcileHTTPRoute"`
 }
 
+func httpRouteObjectPredicate() predicate.Funcs {
+	generationChanged := predicate.GenerationChangedPredicate{}
+	labelChanged := predicate.LabelChangedPredicate{}
+	return predicate.Funcs{
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			return generationChanged.Update(updateEvent) ||
+				labelChanged.Update(updateEvent)
+		},
+	}
+}
+
 // StartManager starts the controller manager.
 func StartManager(ctx context.Context, deps StartManagerDeps) error { // coverage-ignore -- challenging to test
 	logger := deps.RootLogger.WithGroup("k8s")
@@ -114,7 +125,7 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error { // coverag
 				&discoveryv1.EndpointSlice{},
 				handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapEndpointSliceToHTTPRoute),
 			).
-			WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})).
+			WithEventFilter(httpRouteObjectPredicate()).
 			Complete(wireupReconciler(deps.HTTPRouteCtrl, middlewares...)); err != nil {
 			return fmt.Errorf("failed to setup HTTPRoute controller: %w", err)
 		}

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -1,0 +1,34 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestHTTPRouteObjectPredicate(t *testing.T) {
+	t.Run("accepts annotation only updates", func(t *testing.T) {
+		oldRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "demo",
+				Name:       "api",
+				Generation: 1,
+				Annotations: map[string]string{
+					"example.com/reconcile": "before",
+				},
+			},
+		}
+		newRoute := oldRoute.DeepCopy()
+		newRoute.Annotations["example.com/reconcile"] = "after"
+
+		result := httpRouteObjectPredicate().Update(event.UpdateEvent{
+			ObjectOld: oldRoute,
+			ObjectNew: newRoute,
+		})
+
+		assert.True(t, result)
+	})
+}


### PR DESCRIPTION
### Changing annotation does not current cause reconciliation to occur.

#### Existing route:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: api
  namespace: demo
spec:
  parentRefs:
    - name: public-gateway
  hostnames:
    - api.example.com
  rules:
    - backendRefs:
        - name: api
          port: 8080
```

  You run:

```shell
kubectl annotate httproute api -n demo example.com/reconcile-at="$(date +%s)" --overwrite
```

Kubernetes updates .metadata.annotations, but .metadata.generation does not change because spec did not change.

#### Current controller behavior

HTTPRoute update event happens
GenerationChangedPredicate = false
LabelChangedPredicate = false
event is filtered out
Reconcile is never called

#### Expected behavior

HTTPRoute update event happens
AnnotationChangedPredicate = true
HTTPRoute is enqueued
Controller runs reconcile for demo/api


#### Test failure before fix
```shell
Run make test
go install github.com/vladopajic/go-test-coverage/v2@latest
go: downloading github.com/vladopajic/go-test-coverage v1.0.1
go: downloading github.com/aws/aws-sdk-go v1.49.4
go: downloading golang.org/x/tools v0.26.0
go: downloading golang.org/x/sys v0.29.0
mkdir -p .cover
TZ=US/Alaska go test -shuffle=on -failfast -coverpkg=./internal/...,./cmd/... -coverprofile=.cover/profile.out -covermode=atomic ./...
ok  	github.com/gemyago/oke-gateway-api/cmd/controller	0.041s	coverage: 6.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/cmd/server	0.019s	coverage: 5.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http	0.013s	coverage: 1.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http/middleware	0.015s	coverage: 1.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/api/http/server	0.015s	coverage: 2.9% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/app	0.131s	coverage: 58.1% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/config	0.017s	coverage: 1.4% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/di	0.014s	coverage: 0.8% of statements in ./internal/..., ./cmd/...
ok  	github.com/gemyago/oke-gateway-api/internal/diag	0.013s	coverage: 1.9% of statements in ./internal/..., ./cmd/...
-test.shuffle 1780979481623568859
--- FAIL: TestHTTPRouteObjectPredicate (0.00s)
    --- FAIL: TestHTTPRouteObjectPredicate/accepts_annotation_only_updates (0.00s)
        start_manager_test.go:32: 
            	Error Trace:	/home/runner/work/oke-gateway-api/oke-gateway-api/internal/k8s/start_manager_test.go:32
            	Error:      	Should be true
            	Test:       	TestHTTPRouteObjectPredicate/accepts_annotation_only_updates
FAIL
coverage: 0.6% of statements in ./internal/..., ./cmd/...
FAIL	github.com/gemyago/oke-gateway-api/internal/k8s	0.038s
ok  	github.com/gemyago/oke-gateway-api/internal/services	0.019s	coverage: 1.7% of statements in ./internal/..., ./cmd/...
	github.com/gemyago/oke-gateway-api/internal/services/k8sapi		coverage: 0.0% of statements
ok  	github.com/gemyago/oke-gateway-api/internal/services/ociapi	0.030s	coverage: 3.4% of statements in ./internal/..., ./cmd/...
FAIL
make: *** [Makefile:38: .cover/profile.out] Error 1
```
