### PR TITLE
OCI drift detection

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,7 +43,7 @@ helm install oke-gateway-api-controller ./helm/controller \
 
 # Enable periodic OCI drift reconciliation
 helm install oke-gateway-api-controller ./helm/controller \
-  --set reconcile.driftInterval=5m
+  --set reconcile.drift-interval=5m
 ```
 
 ## OCI certificate example

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,6 +40,10 @@ helm install oke-gateway-api-controller ./helm/controller \
 # Install only the controller when the CRD is already managed separately
 helm install oke-gateway-api-controller ./helm/controller \
   --skip-crds
+
+# Enable periodic OCI drift reconciliation
+helm install oke-gateway-api-controller ./helm/controller \
+  --set reconcile.driftInterval=5m
 ```
 
 ## OCI certificate example

--- a/deploy/helm/controller/templates/deployment.yaml
+++ b/deploy/helm/controller/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: OCI_CONFIG_FILE
           value: /etc/oci/config
         - name: APP_RECONCILE_DRIFT_INTERVAL
-          value: {{ .Values.reconcile.driftInterval | quote }}
+          value: {{ index .Values.reconcile "drift-interval" | quote }}
         volumeMounts:
         - name: oci-config-volume
           mountPath: "/etc/oci"

--- a/deploy/helm/controller/templates/deployment.yaml
+++ b/deploy/helm/controller/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
         env:
         - name: OCI_CONFIG_FILE
           value: /etc/oci/config
+        - name: APP_RECONCILE_DRIFT_INTERVAL
+          value: {{ .Values.reconcile.driftInterval | quote }}
         volumeMounts:
         - name: oci-config-volume
           mountPath: "/etc/oci"

--- a/deploy/helm/controller/values.yaml
+++ b/deploy/helm/controller/values.yaml
@@ -10,7 +10,7 @@ fullnameOverride: ""
 
 reconcile:
   # Periodic OCI drift reconciliation interval. Use 0s to disable.
-  driftInterval: 0s
+  drift-interval: 0s
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/deploy/helm/controller/values.yaml
+++ b/deploy/helm/controller/values.yaml
@@ -8,6 +8,10 @@
 nameOverride: ""
 fullnameOverride: ""
 
+reconcile:
+  # Periodic OCI drift reconciliation interval. Use 0s to disable.
+  driftInterval: 0s
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -16,6 +16,9 @@ const (
 	// GatewayUsedSecretsAnnotationPrefix is extended with each secret full name and stores the secret revision.
 	GatewayUsedSecretsAnnotationPrefix = "secrets.oke-gateway-api.gemyago.github.io"
 
+	// GatewayProgrammedCertificatesAnnotation stores OCI certificate names programmed by the controller.
+	GatewayProgrammedCertificatesAnnotation = "oke-gateway-api.gemyago.github.io/gateway-programmed-certificates"
+
 	// ListenerTLSOptionOCICertificateOCID configures an existing OCI Certificates Service certificate for a listener.
 	ListenerTLSOptionOCICertificateOCID = "oci.oraclecloud.com/certificate-ocid"
 
@@ -33,7 +36,7 @@ const (
 
 	// GatewayProgrammingRevisionValue is the value for the gateway programming revision.
 	// Incremented when the controller programming steps are changed.
-	GatewayProgrammingRevisionValue = "1"
+	GatewayProgrammingRevisionValue = "2"
 
 	// NetworkLoadBalancerGatewayProgrammingRevisionAnnotation is the annotation for the L4 gateway programming revision.
 	// The revision may be incremented if additional NLB programming steps are introduced by the controller.

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -23,7 +23,7 @@ const (
 	// The revision may be incremented if additional programming steps are introduced by the controller.
 	HTTPRouteProgrammingRevisionAnnotation = "oke-gateway-api.gemyago.github.io/http-route-programming-revision"
 
-	// HTTPRouteProgrammedPolicyRulesAnnotation is a comma-separated list of load balancer listener policy rule names.
+	// HTTPRouteProgrammedPolicyRulesAnnotation is a comma-separated list of load balancer listener/policy rule names.
 	// The value is set by the controller when the http route is programmed.
 	HTTPRouteProgrammedPolicyRulesAnnotation = "oke-gateway-api.gemyago.github.io/http-route-programmed-lb-policy-rules"
 
@@ -70,7 +70,7 @@ const (
 
 	// HTTPRouteProgrammingRevisionValue is the value for the http route programming revision.
 	// Incremented when the controller programming steps are changed.
-	HTTPRouteProgrammingRevisionValue = "3"
+	HTTPRouteProgrammingRevisionValue = "4"
 )
 
 const ConfigRefGroup = "oke-gateway-api.gemyago.github.io"

--- a/internal/app/drift_reconcile.go
+++ b/internal/app/drift_reconcile.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const minimumDriftRequeueInterval = time.Minute
+const maxDriftRequeueJitterRatio = 10
+
+func driftRequeue(interval time.Duration) reconcile.Result {
+	if interval <= 0 {
+		return reconcile.Result{}
+	}
+	if interval < minimumDriftRequeueInterval {
+		interval = minimumDriftRequeueInterval
+	}
+	jitter := interval / maxDriftRequeueJitterRatio
+	if jitter > 0 {
+		interval += time.Duration(time.Now().UnixNano() % int64(jitter+1))
+	}
+	return reconcile.Result{RequeueAfter: interval}
+}

--- a/internal/app/drift_reconcile_test.go
+++ b/internal/app/drift_reconcile_test.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestDriftRequeue(t *testing.T) {
+	t.Run("returns empty result when interval is disabled", func(t *testing.T) {
+		assert.Equal(t, reconcile.Result{}, driftRequeue(0))
+		assert.Equal(t, reconcile.Result{}, driftRequeue(-time.Second))
+	})
+
+	t.Run("returns requeue after when interval is enabled", func(t *testing.T) {
+		interval := 5 * time.Minute
+
+		assertDriftRequeue(t, driftRequeue(interval), interval)
+	})
+
+	t.Run("enforces minimum positive interval", func(t *testing.T) {
+		assertDriftRequeue(t, driftRequeue(time.Second), minimumDriftRequeueInterval)
+	})
+}
+
+func assertDriftRequeue(t *testing.T, result reconcile.Result, interval time.Duration) {
+	t.Helper()
+
+	assert.GreaterOrEqual(t, result.RequeueAfter, interval)
+	assert.LessOrEqual(t, result.RequeueAfter, interval+interval/maxDriftRequeueJitterRatio)
+}

--- a/internal/app/gateway_controller.go
+++ b/internal/app/gateway_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.uber.org/dig"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -19,6 +20,7 @@ type GatewayController struct {
 	logger         *slog.Logger
 	resourcesModel resourcesModel
 	gatewayModel   gatewayModel
+	driftInterval  time.Duration
 }
 
 // GatewayControllerDeps contains the dependencies for the GatewayController.
@@ -29,6 +31,7 @@ type GatewayControllerDeps struct {
 	K8sClient      k8sClient
 	ResourcesModel resourcesModel
 	GatewayModel   gatewayModel
+	DriftInterval  time.Duration `name:"config.reconcile.driftInterval"`
 }
 
 // NewGatewayController creates a new GatewayController.
@@ -38,6 +41,7 @@ func NewGatewayController(deps GatewayControllerDeps) *GatewayController {
 		logger:         deps.RootLogger.WithGroup("gateway-controller"),
 		resourcesModel: deps.ResourcesModel, // Initialize resourcesModel
 		gatewayModel:   deps.GatewayModel,
+		driftInterval:  deps.DriftInterval,
 	}
 }
 
@@ -75,7 +79,7 @@ func (r *GatewayController) processResourceError(
 			slog.String("gateway", gateway.GetName()),
 			slog.String("reason", reasonErr.Error()),
 		)
-		return reconcile.Result{}, nil
+		return driftRequeue(r.driftInterval), nil
 	}
 	return reconcile.Result{}, fmt.Errorf("failed to program Gateway %s: %w", gateway.Name, err)
 }
@@ -115,7 +119,8 @@ func (r *GatewayController) Reconcile(ctx context.Context, req reconcile.Request
 		}
 	}
 
-	if !r.gatewayModel.isProgrammed(ctx, &data) {
+	programmed := r.gatewayModel.isProgrammed(ctx, &data)
+	if !programmed || r.driftInterval > 0 {
 		r.logger.DebugContext(ctx, "Programming gateway",
 			slog.Any("req", req),
 			slog.String("resourceVersion", data.gateway.ResourceVersion),
@@ -148,5 +153,5 @@ func (r *GatewayController) Reconcile(ctx context.Context, req reconcile.Request
 		)
 	}
 
-	return reconcile.Result{}, nil
+	return driftRequeue(r.driftInterval), nil
 }

--- a/internal/app/gateway_controller.go
+++ b/internal/app/gateway_controller.go
@@ -31,7 +31,7 @@ type GatewayControllerDeps struct {
 	K8sClient      k8sClient
 	ResourcesModel resourcesModel
 	GatewayModel   gatewayModel
-	DriftInterval  time.Duration `name:"config.reconcile.driftInterval"`
+	DriftInterval  time.Duration `name:"config.reconcile.drift-interval"`
 }
 
 // NewGatewayController creates a new GatewayController.

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -575,6 +575,12 @@ func TestGatewayController(t *testing.T) {
 			gateway.Annotations = map[string]string{
 				GatewayProgrammingRevisionAnnotation:                         GatewayProgrammingRevisionValue,
 				GatewayUsedSecretsAnnotationPrefix + "/" + string(secretUID): secretResourceVersion,
+				GatewayProgrammedCertificatesAnnotation: fmt.Sprintf(
+					"%s-%s-rev-%s",
+					gateway.Namespace,
+					secretName,
+					secretResourceVersion,
+				),
 			}
 
 			gatewayClass := newRandomGatewayClass(

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
@@ -328,6 +329,66 @@ func TestGatewayController(t *testing.T) {
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 
+		t.Run("returns drift requeue for program resourceStatusError when drift is enabled", func(t *testing.T) {
+			fake := faker.New()
+			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
+			driftInterval := 23 * time.Minute
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: gateway.Namespace,
+					Name:      gateway.Name,
+				},
+			}
+
+			deps := newMockDeps(t)
+			deps.DriftInterval = driftInterval
+			controller := NewGatewayController(deps)
+
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).Once()
+
+			mockGatewayModel.EXPECT().
+				isProgrammed(t.Context(), &resolvedGatewayDetails{
+					gateway: *gateway,
+				}).
+				Return(false).Once()
+
+			wantErr := &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionProgrammed),
+				reason:        fake.Lorem().Word(),
+				message:       fake.Lorem().Sentence(10),
+			}
+
+			mockGatewayModel.EXPECT().
+				programGateway(t.Context(), mock.Anything).
+				Return(wantErr).Once()
+
+			mockResourcesModel.EXPECT().
+				setCondition(t.Context(), setConditionParams{
+					resource:      gateway,
+					conditions:    &gateway.Status.Conditions,
+					conditionType: wantErr.conditionType,
+					status:        metav1.ConditionFalse,
+					reason:        wantErr.reason,
+					message:       wantErr.message,
+				}).
+				Return(nil).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assertDriftRequeue(t, result, driftInterval)
+		})
+
 		t.Run("handle set programmed condition error", func(t *testing.T) {
 			fake := faker.New()
 			gateway := newRandomGateway()
@@ -410,6 +471,55 @@ func TestGatewayController(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("programs already programmed gateway when drift interval is enabled", func(t *testing.T) {
+			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
+			driftInterval := 7 * time.Minute
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: gateway.Namespace,
+					Name:      gateway.Name,
+				},
+			}
+
+			deps := newMockDeps(t)
+			deps.DriftInterval = driftInterval
+			controller := NewGatewayController(deps)
+
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).Once()
+
+			mockGatewayModel.EXPECT().
+				isProgrammed(t.Context(), &resolvedGatewayDetails{
+					gateway: *gateway,
+				}).
+				Return(true).Once()
+
+			mockGatewayModel.EXPECT().
+				programGateway(t.Context(), &resolvedGatewayDetails{
+					gateway: *gateway,
+				}).
+				Return(nil).Once()
+
+			mockGatewayModel.EXPECT().
+				setProgrammed(t.Context(), &resolvedGatewayDetails{
+					gateway: *gateway,
+				}).
+				Return(nil).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assertDriftRequeue(t, result, driftInterval)
 		})
 
 		t.Run("clears accepted false after previously missing TLS secret exists", func(t *testing.T) {

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
+	"sort"
+	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
@@ -259,6 +262,43 @@ func (m *gatewayModelImpl) populateGatewaySecret(
 	return nil
 }
 
+func programmedCertificateNamesFromSecrets(gatewaySecrets map[string]corev1.Secret) []string {
+	names := make([]string, 0, len(gatewaySecrets))
+	for _, secret := range gatewaySecrets {
+		names = append(names, ociCertificateNameFromSecret(secret))
+	}
+	return normalizeProgrammedCertificateNames(names)
+}
+
+func programmedGatewayCertificatesAnnotation(certNames []string) string {
+	return strings.Join(normalizeProgrammedCertificateNames(certNames), ",")
+}
+
+func parseProgrammedGatewayCertificatesAnnotation(annotationValue string) []string {
+	if annotationValue == "" {
+		return nil
+	}
+
+	certNames := strings.Split(annotationValue, ",")
+	for idx := range certNames {
+		certNames[idx] = strings.TrimSpace(certNames[idx])
+	}
+	return normalizeProgrammedCertificateNames(certNames)
+}
+
+func normalizeProgrammedCertificateNames(certNames []string) []string {
+	normalized := make([]string, 0, len(certNames))
+	for _, certName := range certNames {
+		if certName == "" {
+			continue
+		}
+		normalized = append(normalized, certName)
+	}
+
+	sort.Strings(normalized)
+	return slices.Compact(normalized)
+}
+
 func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGatewayDetails) error {
 	loadBalancerID := data.config.Spec.LoadBalancerID
 	m.logger.DebugContext(ctx, "Fetching OCI Load Balancer details",
@@ -338,9 +378,14 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 	}
 
 	if err = m.ociLoadBalancerModel.removeUnusedCertificates(ctx, removeUnusedCertificatesParams{
-		loadBalancerID:       loadBalancerID,
-		listenerCertificates: reconcileListenersCertificatesResult.certificatesByListener,
-		knownCertificates:    response.LoadBalancer.Certificates,
+		loadBalancerID: loadBalancerID,
+		previouslyProgrammedCertificates: parseProgrammedGatewayCertificatesAnnotation(
+			data.gateway.Annotations[GatewayProgrammedCertificatesAnnotation],
+		),
+		desiredCertificates: certificateNamesFromListenerCertificates(
+			reconcileListenersCertificatesResult.certificatesByListener,
+		),
+		knownCertificates: response.LoadBalancer.Certificates,
 	}); err != nil {
 		return fmt.Errorf("failed to remove unused certificates: %w", err)
 	}
@@ -366,6 +411,9 @@ func gatewayStatusAddressesFromLoadBalancer(lb *loadbalancer.LoadBalancer) []gat
 func (m *gatewayModelImpl) isProgrammed(_ context.Context, data *resolvedGatewayDetails) bool {
 	annotations := map[string]string{
 		GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
+		GatewayProgrammedCertificatesAnnotation: programmedGatewayCertificatesAnnotation(
+			programmedCertificateNamesFromSecrets(data.gatewaySecrets),
+		),
 	}
 
 	// Include secrets annotations in the check
@@ -388,6 +436,9 @@ func (m *gatewayModelImpl) isProgrammed(_ context.Context, data *resolvedGateway
 func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGatewayDetails) error {
 	annotations := map[string]string{
 		GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
+		GatewayProgrammedCertificatesAnnotation: programmedGatewayCertificatesAnnotation(
+			programmedCertificateNamesFromSecrets(data.gatewaySecrets),
+		),
 	}
 
 	if len(data.gatewaySecrets) > 0 {

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"go.uber.org/dig"
 	corev1 "k8s.io/api/core/v1"
@@ -271,6 +273,14 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 
 	response, err := m.ociClient.GetLoadBalancer(ctx, request)
 	if err != nil {
+		if serviceErr, ok := common.IsServiceError(err); ok &&
+			serviceErr.GetHTTPStatusCode() == http.StatusNotFound {
+			return &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionProgrammed),
+				reason:        string(gatewayv1.GatewayReasonPending),
+				message:       fmt.Sprintf("referenced OCI Load Balancer %s not found", loadBalancerID),
+			}
+		}
 		return fmt.Errorf("failed to get OCI Load Balancer %s: %w", loadBalancerID, err)
 	}
 	data.loadBalancer = &response.LoadBalancer

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -855,6 +855,9 @@ func TestGatewayModelImpl(t *testing.T) {
 			gateway := newRandomGateway(
 				randomGatewayWithRandomListenersOpt(),
 			)
+			gateway.Annotations = map[string]string{
+				GatewayProgrammedCertificatesAnnotation: "previous-cert",
+			}
 			loadBalancer := makeRandomOCILoadBalancer(
 				randomOCILoadBalancerWithRandomBackendSetsOpt(),
 				randomOCILoadBalancerWithRandomPoliciesOpt(),
@@ -928,9 +931,10 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			loadBalancerModel.EXPECT().
 				removeUnusedCertificates(t.Context(), removeUnusedCertificatesParams{
-					loadBalancerID:       config.Spec.LoadBalancerID,
-					listenerCertificates: certificatesByListener,
-					knownCertificates:    loadBalancer.Certificates,
+					loadBalancerID:                   config.Spec.LoadBalancerID,
+					previouslyProgrammedCertificates: []string{"previous-cert"},
+					desiredCertificates:              certificateNamesFromListenerCertificates(certificatesByListener),
+					knownCertificates:                loadBalancer.Certificates,
 				}).
 				Return(nil).
 				NotBefore(removeCall.Call)
@@ -1231,7 +1235,8 @@ func TestGatewayModelImpl(t *testing.T) {
 					reason:        string(gatewayv1.GatewayReasonProgrammed),
 					message:       fmt.Sprintf("Gateway %s programmed by %s", data.gateway.Name, ControllerClassName),
 					annotations: map[string]string{
-						GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
+						GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
+						GatewayProgrammedCertificatesAnnotation: "",
 					},
 				},
 			).Return(nil)
@@ -1265,6 +1270,8 @@ func TestGatewayModelImpl(t *testing.T) {
 				secretUID := string(secret.UID)
 				expectedAnnotations[GatewayUsedSecretsAnnotationPrefix+"/"+secretUID] = secret.ResourceVersion
 			}
+			expectedAnnotations[GatewayProgrammedCertificatesAnnotation] =
+				programmedGatewayCertificatesAnnotation(programmedCertificateNamesFromSecrets(gatewaySecretsMap))
 
 			data := &resolvedGatewayDetails{
 				gateway:        *gateway,
@@ -1334,7 +1341,8 @@ func TestGatewayModelImpl(t *testing.T) {
 					conditions:    data.gateway.Status.Conditions,
 					conditionType: string(gatewayv1.GatewayConditionProgrammed),
 					annotations: map[string]string{
-						GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
+						GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
+						GatewayProgrammedCertificatesAnnotation: "",
 					},
 				},
 			).Return(true)
@@ -1361,7 +1369,8 @@ func TestGatewayModelImpl(t *testing.T) {
 					conditions:    data.gateway.Status.Conditions,
 					conditionType: string(gatewayv1.GatewayConditionProgrammed),
 					annotations: map[string]string{
-						GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
+						GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
+						GatewayProgrammedCertificatesAnnotation: "",
 					},
 				},
 			).Return(false)
@@ -1390,6 +1399,8 @@ func TestGatewayModelImpl(t *testing.T) {
 				secretUID := string(secret.UID)
 				expectedAnnotations[GatewayUsedSecretsAnnotationPrefix+"/"+secretUID] = secret.ResourceVersion
 			}
+			expectedAnnotations[GatewayProgrammedCertificatesAnnotation] =
+				programmedGatewayCertificatesAnnotation(programmedCertificateNamesFromSecrets(gatewaySecretsMap))
 
 			data := &resolvedGatewayDetails{
 				gateway:        *gateway,
@@ -1411,6 +1422,39 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			mockResourcesModel.AssertExpectations(t)
 		})
+	})
+}
+
+func TestProgrammedGatewayCertificatesAnnotation(t *testing.T) {
+	t.Run("normalizes annotation values", func(t *testing.T) {
+		got := programmedGatewayCertificatesAnnotation([]string{
+			"kora-cert-rev-2",
+			"",
+			"kora-cert-rev-1",
+			"kora-cert-rev-2",
+		})
+
+		assert.Equal(t, "kora-cert-rev-1,kora-cert-rev-2", got)
+	})
+
+	t.Run("parses annotation values", func(t *testing.T) {
+		got := parseProgrammedGatewayCertificatesAnnotation(" cert-b,,cert-a, cert-b ")
+
+		assert.Equal(t, []string{"cert-a", "cert-b"}, got)
+	})
+
+	t.Run("maps secrets to certificate names", func(t *testing.T) {
+		secretA := makeRandomSecret()
+		secretB := makeRandomSecret()
+		got := programmedCertificateNamesFromSecrets(map[string]corev1.Secret{
+			secretA.Namespace + "/" + secretA.Name: secretA,
+			secretB.Namespace + "/" + secretB.Name: secretB,
+		})
+
+		assert.ElementsMatch(t, []string{
+			ociCertificateNameFromSecret(secretA),
+			ociCertificateNameFromSecret(secretB),
+		}, got)
 	})
 }
 

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -23,6 +23,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
 	"github.com/gemyago/oke-gateway-api/internal/types"
 )
 
@@ -972,6 +973,39 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			require.Error(t, err)
 			require.ErrorIs(t, err, wantErr)
+		})
+		t.Run("returns programmed false status error when OCI Load Balancer is not found", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			config := makeRandomGatewayConfig()
+			gateway := newRandomGateway(
+				randomGatewayWithRandomListenersOpt(),
+			)
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(
+					loadbalancer.GetLoadBalancerResponse{},
+					ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(404)),
+				)
+
+			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  config,
+			})
+
+			var statusErr *resourceStatusError
+			require.ErrorAs(t, err, &statusErr)
+			assert.Equal(t, string(gatewayv1.GatewayConditionProgrammed), statusErr.conditionType)
+			assert.Equal(t, string(gatewayv1.GatewayReasonPending), statusErr.reason)
+			assert.Equal(t,
+				fmt.Sprintf("referenced OCI Load Balancer %s not found", config.Spec.LoadBalancerID),
+				statusErr.message,
+			)
 		})
 		t.Run("failed to reconcile default backend set", func(t *testing.T) {
 			fake := faker.New()

--- a/internal/app/httpbackend_model.go
+++ b/internal/app/httpbackend_model.go
@@ -254,6 +254,9 @@ func (m *httpBackendModelImpl) syncRouteBackendRefEndpoints(
 	if err != nil {
 		return fmt.Errorf("failed to update backend set %s: %w", backendSetName, err)
 	}
+	if ociUpdateResp.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to update backend set %s: missing work request id", backendSetName)
+	}
 
 	err = m.workRequestsWatcher.WaitFor(ctx, *ociUpdateResp.OpcWorkRequestId)
 	if err != nil {

--- a/internal/app/httpbackend_model_test.go
+++ b/internal/app/httpbackend_model_test.go
@@ -570,6 +570,35 @@ func TestHTTPBackendModel(t *testing.T) {
 					mockOciClient.EXPECT().UpdateBackendSet(t.Context(), mock.Anything).
 						Return(loadbalancer.UpdateBackendSetResponse{}, wantErr)
 				},
+				"update backend set missing work request id": func(
+					deps httpBackendModelDeps,
+					_ types.GatewayConfig,
+					_ gatewayv1.HTTPRoute,
+					backendRef gatewayv1.HTTPBackendRef,
+					backendSet loadbalancer.BackendSet,
+					_ error,
+				) {
+					mockOciClient, _ := deps.OciLoadBalancerClient.(*MockociLoadBalancerClient)
+					mockOciClient.EXPECT().GetBackendSet(t.Context(), mock.Anything).
+						Return(loadbalancer.GetBackendSetResponse{BackendSet: backendSet}, nil)
+					mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+					mockK8sClient.EXPECT().List(
+						t.Context(),
+						mock.Anything,
+						client.MatchingLabels{
+							discoveryv1.LabelServiceName: string(backendRef.BackendObjectReference.Name),
+						},
+						client.InNamespace(string(lo.FromPtr(backendRef.BackendObjectReference.Namespace))),
+					).Return(nil)
+					mockSelf, _ := deps.self.(*MockhttpBackendModel)
+					mockSelf.EXPECT().identifyBackendsToUpdate(t.Context(), mock.Anything).
+						Return(identifyBackendsToUpdateResult{
+							updateRequired:  true,
+							updatedBackends: makeFewRandomOCIBackendDetails(),
+						}, nil)
+					mockOciClient.EXPECT().UpdateBackendSet(t.Context(), mock.Anything).
+						Return(loadbalancer.UpdateBackendSetResponse{}, nil)
+				},
 				"wait for update": func(
 					deps httpBackendModelDeps,
 					_ types.GatewayConfig,
@@ -621,7 +650,11 @@ func TestHTTPBackendModel(t *testing.T) {
 						backendRef: backendRef,
 					})
 
-					require.ErrorIs(t, err, wantErr)
+					if name == "update backend set missing work request id" {
+						require.ErrorContains(t, err, "missing work request id")
+					} else {
+						require.ErrorIs(t, err, wantErr)
+					}
 				})
 			}
 		})

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.uber.org/dig"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -15,6 +16,7 @@ type HTTPRouteController struct {
 	logger           *slog.Logger
 	httpRouteModel   httpRouteModel
 	httpBackendModel httpBackendModel
+	driftInterval    time.Duration
 }
 
 // HTTPRouteControllerDeps contains the dependencies for the HTTPRouteController.
@@ -24,6 +26,7 @@ type HTTPRouteControllerDeps struct {
 	RootLogger       *slog.Logger
 	HTTPRouteModel   httpRouteModel
 	HTTPBackendModel httpBackendModel
+	DriftInterval    time.Duration `name:"config.reconcile.driftInterval"`
 }
 
 // NewHTTPRouteController creates a new HTTPRouteController.
@@ -32,6 +35,7 @@ func NewHTTPRouteController(deps HTTPRouteControllerDeps) *HTTPRouteController {
 		logger:           deps.RootLogger.WithGroup("httproute-controller"),
 		httpRouteModel:   deps.HTTPRouteModel,
 		httpBackendModel: deps.HTTPBackendModel,
+		driftInterval:    deps.DriftInterval,
 	}
 }
 
@@ -164,5 +168,5 @@ func (r *HTTPRouteController) Reconcile(ctx context.Context, req reconcile.Reque
 
 	r.logger.InfoContext(ctx, fmt.Sprintf("Reconciled HTTProute %s", req.NamespacedName))
 
-	return reconcile.Result{}, nil
+	return driftRequeue(r.driftInterval), nil
 }

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -26,7 +26,7 @@ type HTTPRouteControllerDeps struct {
 	RootLogger       *slog.Logger
 	HTTPRouteModel   httpRouteModel
 	HTTPBackendModel httpBackendModel
-	DriftInterval    time.Duration `name:"config.reconcile.driftInterval"`
+	DriftInterval    time.Duration `name:"config.reconcile.drift-interval"`
 }
 
 // NewHTTPRouteController creates a new HTTPRouteController.

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
@@ -438,6 +439,53 @@ func TestHTTPRouteController(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("ProgrammingNotRequiredWithDriftInterval", func(t *testing.T) {
+			fake := faker.New()
+			driftInterval := 13 * time.Minute
+			deps := newMockDeps(t)
+			deps.DriftInterval = driftInterval
+			controller := NewHTTPRouteController(deps)
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: fake.Internet().Domain(),
+					Name:      fake.Lorem().Word(),
+				},
+			}
+
+			wantResolvedData := resolvedRouteDetails{
+				httpRoute: makeRandomHTTPRoute(),
+				gatewayDetails: resolvedGatewayDetails{
+					gateway: *newRandomGateway(),
+					config:  makeRandomGatewayConfig(),
+				},
+			}
+
+			mockModel, _ := deps.HTTPRouteModel.(*MockhttpRouteModel)
+			mockModel.EXPECT().resolveRequest(
+				t.Context(),
+				req,
+			).Return(map[types.NamespacedName]resolvedRouteDetails{
+				req.NamespacedName: wantResolvedData,
+			}, (error)(nil))
+
+			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(false, nil)
+
+			mockBackendModel, _ := deps.HTTPBackendModel.(*MockhttpBackendModel)
+			mockBackendModel.EXPECT().syncRouteEndpoints(
+				t.Context(),
+				syncRouteEndpointsParams{
+					httpRoute: wantResolvedData.httpRoute,
+					config:    wantResolvedData.gatewayDetails.config,
+				},
+			).Return(nil)
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assertDriftRequeue(t, result, driftInterval)
 		})
 
 		t.Run("SetProgrammedError", func(t *testing.T) {

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
@@ -60,6 +61,11 @@ type setProgrammedParams struct {
 
 	// List of load balancer policy rules that were programmed for this route
 	programmedPolicyRules []string
+}
+
+type programmedHTTPRoutePolicyRule struct {
+	listenerName string
+	ruleName     string
 }
 
 // httpRouteModel defines the interface for managing HTTPRoute resources.
@@ -142,6 +148,77 @@ func backendRefName(
 			func() string { return string(*backendRef.BackendObjectReference.Namespace) },
 		).Else(defaultNamespace),
 	}
+}
+
+func parseProgrammedHTTPRoutePolicyRules(annotationValue string) []programmedHTTPRoutePolicyRule {
+	if annotationValue == "" {
+		return nil
+	}
+
+	entries := strings.Split(annotationValue, ",")
+	rules := make([]programmedHTTPRoutePolicyRule, 0, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		listenerName, ruleName, found := strings.Cut(entry, "/")
+		if !found {
+			rules = append(rules, programmedHTTPRoutePolicyRule{ruleName: entry})
+			continue
+		}
+		if listenerName == "" || ruleName == "" {
+			continue
+		}
+
+		rules = append(rules, programmedHTTPRoutePolicyRule{
+			listenerName: listenerName,
+			ruleName:     ruleName,
+		})
+	}
+
+	return rules
+}
+
+func programmedHTTPRoutePolicyRulesAnnotation(
+	listeners []gatewayv1.Listener,
+	ruleNames []string,
+) []string {
+	rules := make([]string, 0, len(listeners)*len(ruleNames))
+	for _, listener := range listeners {
+		for _, ruleName := range ruleNames {
+			rules = append(rules, fmt.Sprintf("%s/%s", listener.Name, ruleName))
+		}
+	}
+
+	return rules
+}
+
+func previousPolicyRulesByListener(
+	previousRules []programmedHTTPRoutePolicyRule,
+	currentListeners []gatewayv1.Listener,
+) map[string][]string {
+	previousByListener := map[string][]string{}
+	currentListenerNames := lo.SliceToMap(currentListeners, func(listener gatewayv1.Listener) (string, struct{}) {
+		return string(listener.Name), struct{}{}
+	})
+
+	for _, previousRule := range previousRules {
+		if previousRule.listenerName == "" {
+			for listenerName := range currentListenerNames {
+				previousByListener[listenerName] = append(previousByListener[listenerName], previousRule.ruleName)
+			}
+			continue
+		}
+
+		previousByListener[previousRule.listenerName] = append(
+			previousByListener[previousRule.listenerName],
+			previousRule.ruleName,
+		)
+	}
+
+	return previousByListener
 }
 
 type httpRouteModelImpl struct {
@@ -415,7 +492,6 @@ func (m *httpRouteModelImpl) resolveBackendRefs(
 	return resolvedBackendRefs, nil
 }
 
-//nolint:unparam // The result is consumed through the httpRouteModel interface.
 func (m *httpRouteModelImpl) programRoute(
 	ctx context.Context,
 	params programRouteParams,
@@ -447,18 +523,26 @@ func (m *httpRouteModelImpl) programRoute(
 		policyRulesNames = append(policyRulesNames, *rule.Name)
 	}
 
-	var prevPolicyRules []string
+	var previousRules []programmedHTTPRoutePolicyRule
 	if prevPolicyRulesStr, ok := params.httpRoute.Annotations[HTTPRouteProgrammedPolicyRulesAnnotation]; ok {
-		prevPolicyRules = strings.Split(prevPolicyRulesStr, ",")
+		previousRules = parseProgrammedHTTPRoutePolicyRules(prevPolicyRulesStr)
 	}
+	prevRulesByListener := previousPolicyRulesByListener(previousRules, params.matchedListeners)
+	currentListenerNames := lo.SliceToMap(
+		params.matchedListeners,
+		func(listener gatewayv1.Listener) (string, struct{}) {
+			return string(listener.Name), struct{}{}
+		},
+	)
 
 	// Commit the rules to each listener's policy
 	for _, listener := range params.matchedListeners {
+		listenerName := string(listener.Name)
 		err := m.ociLoadBalancerModel.commitRoutingPolicy(ctx, commitRoutingPolicyParams{
 			loadBalancerID:  params.config.Spec.LoadBalancerID,
-			listenerName:    string(listener.Name),
+			listenerName:    listenerName,
 			policyRules:     policyRules,
-			prevPolicyRules: prevPolicyRules,
+			prevPolicyRules: prevRulesByListener[listenerName],
 		})
 		if err != nil {
 			return programRouteResult{}, fmt.Errorf(
@@ -469,8 +553,29 @@ func (m *httpRouteModelImpl) programRoute(
 		}
 	}
 
+	staleListenerNames := lo.Keys(prevRulesByListener)
+	sort.Strings(staleListenerNames)
+	for _, listenerName := range staleListenerNames {
+		if _, ok := currentListenerNames[listenerName]; ok {
+			continue
+		}
+		err := m.ociLoadBalancerModel.commitRoutingPolicy(ctx, commitRoutingPolicyParams{
+			loadBalancerID:  params.config.Spec.LoadBalancerID,
+			listenerName:    listenerName,
+			policyRules:     []loadbalancer.RoutingRule{},
+			prevPolicyRules: prevRulesByListener[listenerName],
+		})
+		if err != nil {
+			return programRouteResult{}, fmt.Errorf(
+				"failed to remove stale routing policy rules for listener %s: %w",
+				listenerName,
+				err,
+			)
+		}
+	}
+
 	return programRouteResult{
-		programmedPolicyRules: policyRulesNames,
+		programmedPolicyRules: programmedHTTPRoutePolicyRulesAnnotation(params.matchedListeners, policyRulesNames),
 	}, nil
 }
 
@@ -478,14 +583,12 @@ func (m *httpRouteModelImpl) deprovisionRoute(
 	ctx context.Context,
 	params deprovisionRouteParams,
 ) error {
-	var prevPolicyRules []string
+	var previousRules []programmedHTTPRoutePolicyRule
 	if prevPolicyRulesStr, ok := params.httpRoute.Annotations[HTTPRouteProgrammedPolicyRulesAnnotation]; ok {
-		if prevPolicyRulesStr != "" { // Ensure not to split an empty string, which results in [""]
-			prevPolicyRules = strings.Split(prevPolicyRulesStr, ",")
-		}
+		previousRules = parseProgrammedHTTPRoutePolicyRules(prevPolicyRulesStr)
 	}
 
-	if len(prevPolicyRules) == 0 {
+	if len(previousRules) == 0 {
 		m.logger.InfoContext(ctx, "No previous policy rules found in annotation, skipping deprovisioning.",
 			slog.String("route", params.httpRoute.Name),
 			slog.String("annotationKey", HTTPRouteProgrammedPolicyRulesAnnotation),
@@ -493,21 +596,25 @@ func (m *httpRouteModelImpl) deprovisionRoute(
 		return nil
 	}
 
-	for _, listener := range params.matchedListeners {
+	prevRulesByListener := previousPolicyRulesByListener(previousRules, params.matchedListeners)
+	listenerNames := lo.Keys(prevRulesByListener)
+	sort.Strings(listenerNames)
+
+	for _, listenerName := range listenerNames {
 		m.logger.DebugContext(ctx, "Deprovisioning listener policies for HTTPRoute",
 			slog.String("route", params.httpRoute.Name),
-			slog.String("listener", string(listener.Name)),
+			slog.String("listener", listenerName),
 			slog.String("loadBalancerID", params.config.Spec.LoadBalancerID),
-			slog.Any("prevPolicyRules", prevPolicyRules),
+			slog.Any("prevPolicyRules", prevRulesByListener[listenerName]),
 		)
 		err := m.ociLoadBalancerModel.commitRoutingPolicy(ctx, commitRoutingPolicyParams{
 			loadBalancerID:  params.config.Spec.LoadBalancerID,
-			listenerName:    string(listener.Name),
+			listenerName:    listenerName,
 			policyRules:     []loadbalancer.RoutingRule{}, // Empty rules for deprovisioning
-			prevPolicyRules: prevPolicyRules,
+			prevPolicyRules: prevRulesByListener[listenerName],
 		})
 		if err != nil {
-			return fmt.Errorf("failed to deprovision routing policy for listener %s: %w", listener.Name, err)
+			return fmt.Errorf("failed to deprovision routing policy for listener %s: %w", listenerName, err)
 		}
 	}
 

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -39,6 +39,45 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 		}
 	}
 
+	t.Run("programmedHTTPRoutePolicyRulesAnnotation", func(t *testing.T) {
+		t.Run("formats listener scoped policy rules", func(t *testing.T) {
+			listenerA := makeRandomListener()
+			listenerB := makeRandomListener()
+			ruleNames := []string{
+				"rule-a-" + faker.New().Lorem().Word(),
+				"rule-b-" + faker.New().Lorem().Word(),
+			}
+
+			assert.Equal(t, []string{
+				fmt.Sprintf("%s/%s", listenerA.Name, ruleNames[0]),
+				fmt.Sprintf("%s/%s", listenerA.Name, ruleNames[1]),
+				fmt.Sprintf("%s/%s", listenerB.Name, ruleNames[0]),
+				fmt.Sprintf("%s/%s", listenerB.Name, ruleNames[1]),
+			}, programmedHTTPRoutePolicyRulesAnnotation([]gatewayv1.Listener{listenerA, listenerB}, ruleNames))
+		})
+	})
+
+	t.Run("parseProgrammedHTTPRoutePolicyRules", func(t *testing.T) {
+		t.Run("parses listener scoped and legacy policy rules", func(t *testing.T) {
+			fake := faker.New()
+			listenerName := "listener-" + fake.Lorem().Word()
+			scopedRule := "scoped-" + fake.Lorem().Word()
+			legacyRule := "legacy-" + fake.Lorem().Word()
+
+			assert.Equal(t, []programmedHTTPRoutePolicyRule{
+				{
+					listenerName: listenerName,
+					ruleName:     scopedRule,
+				},
+				{
+					ruleName: legacyRule,
+				},
+			}, parseProgrammedHTTPRoutePolicyRules(
+				fmt.Sprintf(" %s/%s , %s ,,", listenerName, scopedRule, legacyRule),
+			))
+		})
+	})
+
 	t.Run("resolveRequest", func(t *testing.T) {
 		t.Run("relevant parent", func(t *testing.T) {
 			fake := faker.New()
@@ -1122,6 +1161,79 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes previously programmed rules from no longer matched listeners", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			gateway := newRandomGateway()
+			config := makeRandomGatewayConfig()
+			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(makeRandomHTTPRouteRule()),
+			)
+
+			currentListener := makeRandomListener()
+			staleListenerName := "stale-" + fake.Lorem().Word()
+			staleRules := []string{
+				"stale-rule-a-" + fake.Lorem().Word(),
+				"stale-rule-b-" + fake.Lorem().Word(),
+			}
+			httpRoute.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation: strings.Join([]string{
+					fmt.Sprintf("%s/%s", staleListenerName, staleRules[0]),
+					fmt.Sprintf("%s/%s", staleListenerName, staleRules[1]),
+				}, ","),
+			}
+
+			service := makeRandomService()
+			knownServicesByName := map[string]corev1.Service{
+				types.NamespacedName{
+					Namespace: service.Namespace,
+					Name:      service.Name,
+				}.String(): service,
+			}
+
+			params := programRouteParams{
+				gateway:          *gateway,
+				config:           config,
+				httpRoute:        httpRoute,
+				knownBackends:    knownServicesByName,
+				matchedListeners: []gatewayv1.Listener{currentListener},
+			}
+
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			ociLBModel.EXPECT().reconcileBackendSet(t.Context(), reconcileBackendSetParams{
+				loadBalancerID: config.Spec.LoadBalancerID,
+				service:        service,
+			}).Return(nil)
+
+			rule := makeRandomOCIRoutingRule()
+			rule.Name = new(ociListerPolicyRuleName(httpRoute, 0))
+			ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
+				httpRoute:          httpRoute,
+				httpRouteRuleIndex: 0,
+			}).Return(rule, nil)
+
+			currentCommit := ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID: config.Spec.LoadBalancerID,
+				listenerName:   string(currentListener.Name),
+				policyRules:    []loadbalancer.RoutingRule{rule},
+			}).Return(nil).Once()
+
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  config.Spec.LoadBalancerID,
+				listenerName:    staleListenerName,
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: staleRules,
+			}).Return(nil).Once().NotBefore(currentCommit)
+
+			result, err := model.programRoute(t.Context(), params)
+			require.NoError(t, err)
+			assert.Equal(t, []string{
+				fmt.Sprintf("%s/%s", currentListener.Name, lo.FromPtr(rule.Name)),
+			}, result.programmedPolicyRules)
+		})
+
 		t.Run("fails when reconcile backend set fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)
@@ -1624,6 +1736,57 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 			// Expect commitRoutingPolicy NOT to be called
 			ociLBModel.AssertNotCalled(t, "commitRoutingPolicy", mock.Anything, mock.Anything)
+
+			err := model.deprovisionRoute(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("deprovisions listener scoped previous rules", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			config := makeRandomGatewayConfig()
+			httpRoute := makeRandomHTTPRoute()
+			httpRoute.Finalizers = []string{HTTPRouteProgrammedFinalizer}
+
+			currentListener := makeRandomListener()
+			staleListenerName := "stale-" + fake.Lorem().Word()
+			currentRule := "current-rule-" + fake.Lorem().Word()
+			staleRule := "stale-rule-" + fake.Lorem().Word()
+			httpRoute.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation: strings.Join([]string{
+					fmt.Sprintf("%s/%s", currentListener.Name, currentRule),
+					fmt.Sprintf("%s/%s", staleListenerName, staleRule),
+				}, ","),
+			}
+
+			params := deprovisionRouteParams{
+				gateway:          *newRandomGateway(),
+				config:           config,
+				httpRoute:        httpRoute,
+				matchedListeners: []gatewayv1.Listener{currentListener},
+			}
+
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			currentCommit := ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  config.Spec.LoadBalancerID,
+				listenerName:    string(currentListener.Name),
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{currentRule},
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  config.Spec.LoadBalancerID,
+				listenerName:    staleListenerName,
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{staleRule},
+			}).Return(nil).Once().NotBefore(currentCommit)
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updatedRoute, ok := obj.(*gatewayv1.HTTPRoute)
+				return ok && assert.NotContains(t, updatedRoute.Finalizers, HTTPRouteProgrammedFinalizer)
+			})).Return(nil)
 
 			err := model.deprovisionRoute(t.Context(), params)
 			require.NoError(t, err)

--- a/internal/app/l4_controller_test.go
+++ b/internal/app/l4_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,6 +120,22 @@ func TestTCPRouteController(t *testing.T) {
 		assert.Equal(t, networkLoadBalancerBusyRequeueAfter, result.RequeueAfter)
 		assert.False(t, model.programmed)
 		assert.False(t, model.rejected)
+	})
+
+	t.Run("returns drift requeue for resolved route when interval is configured", func(t *testing.T) {
+		driftInterval := 17 * time.Minute
+		model := &stubTCPRouteModel{resolved: []resolvedTCPRouteDetails{{tcpRoute: gatewayv1alpha2.TCPRoute{}}}}
+		controller := NewTCPRouteController(TCPRouteControllerDeps{
+			RootLogger:    diag.RootTestLogger(),
+			TCPRouteModel: model,
+			DriftInterval: driftInterval,
+		})
+
+		result, err := controller.Reconcile(t.Context(), req)
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, result, driftInterval)
+		assert.True(t, model.programmed)
 	})
 
 	t.Run("sets rejected status for route status errors", func(t *testing.T) {
@@ -272,6 +289,22 @@ func TestUDPRouteController(t *testing.T) {
 		assert.Equal(t, networkLoadBalancerBusyRequeueAfter, result.RequeueAfter)
 		assert.False(t, model.programmed)
 		assert.False(t, model.rejected)
+	})
+
+	t.Run("returns drift requeue for resolved route when interval is configured", func(t *testing.T) {
+		driftInterval := 19 * time.Minute
+		model := &stubUDPRouteModel{resolved: []resolvedUDPRouteDetails{{udpRoute: gatewayv1alpha2.UDPRoute{}}}}
+		controller := NewUDPRouteController(UDPRouteControllerDeps{
+			RootLogger:    diag.RootTestLogger(),
+			UDPRouteModel: model,
+			DriftInterval: driftInterval,
+		})
+
+		result, err := controller.Reconcile(t.Context(), req)
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, result, driftInterval)
+		assert.True(t, model.programmed)
 	})
 
 	t.Run("sets rejected status for route status errors", func(t *testing.T) {

--- a/internal/app/network_load_balancer_gateway_controller.go
+++ b/internal/app/network_load_balancer_gateway_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/dig"
@@ -18,6 +19,7 @@ type NetworkLoadBalancerGatewayController struct {
 	logger         *slog.Logger
 	resourcesModel resourcesModel
 	gatewayModel   networkLoadBalancerGatewayModel
+	driftInterval  time.Duration
 }
 
 type NetworkLoadBalancerGatewayControllerDeps struct {
@@ -26,6 +28,7 @@ type NetworkLoadBalancerGatewayControllerDeps struct {
 	RootLogger     *slog.Logger
 	ResourcesModel resourcesModel
 	GatewayModel   networkLoadBalancerGatewayModel
+	DriftInterval  time.Duration `name:"config.reconcile.driftInterval"`
 }
 
 func NewNetworkLoadBalancerGatewayController(
@@ -35,6 +38,7 @@ func NewNetworkLoadBalancerGatewayController(
 		logger:         deps.RootLogger.WithGroup("network-load-balancer-gateway-controller"),
 		resourcesModel: deps.ResourcesModel,
 		gatewayModel:   deps.GatewayModel,
+		driftInterval:  deps.DriftInterval,
 	}
 }
 
@@ -63,7 +67,7 @@ func (r *NetworkLoadBalancerGatewayController) processResourceError(
 		}); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to set condition for Gateway %s: %w", gateway.Name, err)
 		}
-		return reconcile.Result{}, nil
+		return driftRequeue(r.driftInterval), nil
 	}
 	return reconcile.Result{}, fmt.Errorf("failed to program Network Load Balancer Gateway %s: %w", gateway.Name, err)
 }
@@ -119,7 +123,7 @@ func (r *NetworkLoadBalancerGatewayController) Reconcile(
 		}
 	}
 
-	if r.gatewayModel.isProgrammed(ctx, &data) {
+	if r.gatewayModel.isProgrammed(ctx, &data) && r.driftInterval <= 0 {
 		r.logger.DebugContext(ctx, "Network Load Balancer Gateway already programmed",
 			slog.String("gateway", req.NamespacedName.String()),
 		)
@@ -131,10 +135,14 @@ func (r *NetworkLoadBalancerGatewayController) Reconcile(
 	}
 	nlb, err := r.gatewayModel.getNetworkLoadBalancer(ctx, &data)
 	if err != nil {
+		var statusErr *resourceStatusError
+		if errors.As(err, &statusErr) {
+			return r.processResourceError(ctx, err, &data.gateway)
+		}
 		return reconcile.Result{}, fmt.Errorf("failed to get programmed Network Load Balancer: %w", err)
 	}
 	if err = r.gatewayModel.setProgrammed(ctx, &data, nlb); err != nil {
 		return reconcile.Result{}, err
 	}
-	return reconcile.Result{}, nil
+	return driftRequeue(r.driftInterval), nil
 }

--- a/internal/app/network_load_balancer_gateway_controller.go
+++ b/internal/app/network_load_balancer_gateway_controller.go
@@ -28,7 +28,7 @@ type NetworkLoadBalancerGatewayControllerDeps struct {
 	RootLogger     *slog.Logger
 	ResourcesModel resourcesModel
 	GatewayModel   networkLoadBalancerGatewayModel
-	DriftInterval  time.Duration `name:"config.reconcile.driftInterval"`
+	DriftInterval  time.Duration `name:"config.reconcile.drift-interval"`
 }
 
 func NewNetworkLoadBalancerGatewayController(

--- a/internal/app/network_load_balancer_gateway_controller_test.go
+++ b/internal/app/network_load_balancer_gateway_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 	"github.com/stretchr/testify/assert"
@@ -205,6 +206,31 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 		assert.True(t, gatewayModel.programmedNow)
 	})
 
+	t.Run("returns drift requeue for program resource status errors", func(t *testing.T) {
+		driftInterval := 29 * time.Minute
+		resourcesModel := &stubResourcesModel{conditionSet: true}
+		controller := NewNetworkLoadBalancerGatewayController(NetworkLoadBalancerGatewayControllerDeps{
+			RootLogger:     diag.RootTestLogger(),
+			ResourcesModel: resourcesModel,
+			GatewayModel: &stubNLBGatewayModel{
+				relevant: true,
+				data:     baseData,
+				programErr: &resourceStatusError{
+					conditionType: string(gatewayv1.GatewayConditionProgrammed),
+					reason:        string(gatewayv1.GatewayReasonPending),
+					message:       "waiting for network load balancer",
+				},
+			},
+			DriftInterval: driftInterval,
+		})
+
+		result, err := controller.Reconcile(t.Context(), req)
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, result, driftInterval)
+		assert.True(t, resourcesModel.setCalled)
+	})
+
 	t.Run("wraps programmed network load balancer lookup errors", func(t *testing.T) {
 		controller := NewNetworkLoadBalancerGatewayController(NetworkLoadBalancerGatewayControllerDeps{
 			RootLogger:     diag.RootTestLogger(),
@@ -219,6 +245,31 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 		_, err := controller.Reconcile(t.Context(), req)
 
 		require.ErrorContains(t, err, "failed to get programmed Network Load Balancer")
+	})
+
+	t.Run("sets condition for programmed network load balancer lookup status errors", func(t *testing.T) {
+		driftInterval := 31 * time.Minute
+		resourcesModel := &stubResourcesModel{conditionSet: true}
+		controller := NewNetworkLoadBalancerGatewayController(NetworkLoadBalancerGatewayControllerDeps{
+			RootLogger:     diag.RootTestLogger(),
+			ResourcesModel: resourcesModel,
+			GatewayModel: &stubNLBGatewayModel{
+				relevant: true,
+				data:     baseData,
+				getErr: &resourceStatusError{
+					conditionType: string(gatewayv1.GatewayConditionProgrammed),
+					reason:        string(gatewayv1.GatewayReasonPending),
+					message:       "waiting for network load balancer",
+				},
+			},
+			DriftInterval: driftInterval,
+		})
+
+		result, err := controller.Reconcile(t.Context(), req)
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, result, driftInterval)
+		assert.True(t, resourcesModel.setCalled)
 	})
 
 	t.Run("skips deleted gateway without finalizer", func(t *testing.T) {
@@ -249,6 +300,30 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.False(t, gatewayModel.programmedNow)
+	})
+
+	t.Run("programs already programmed gateway when drift interval is enabled", func(t *testing.T) {
+		nlb := &networkloadbalancer.NetworkLoadBalancer{}
+		driftInterval := 11 * time.Minute
+		gatewayModel := &stubNLBGatewayModel{
+			relevant:    true,
+			data:        baseData,
+			alreadyDone: true,
+			nlb:         nlb,
+		}
+		controller := NewNetworkLoadBalancerGatewayController(NetworkLoadBalancerGatewayControllerDeps{
+			RootLogger:     diag.RootTestLogger(),
+			ResourcesModel: &stubResourcesModel{conditionSet: true},
+			GatewayModel:   gatewayModel,
+			DriftInterval:  driftInterval,
+		})
+
+		result, err := controller.Reconcile(t.Context(), req)
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, result, driftInterval)
+		assert.True(t, gatewayModel.programmedNow)
+		assert.Same(t, nlb, gatewayModel.programmedNLB)
 	})
 
 	t.Run("wraps accepted condition errors", func(t *testing.T) {

--- a/internal/app/network_load_balancer_gateway_model.go
+++ b/internal/app/network_load_balancer_gateway_model.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 	"github.com/samber/lo"
 	"go.uber.org/dig"
@@ -244,6 +246,14 @@ func (m *networkLoadBalancerGatewayModelImpl) getNetworkLoadBalancerByID(
 		NetworkLoadBalancerId: new(id),
 	})
 	if err != nil {
+		if serviceErr, ok := common.IsServiceError(err); ok &&
+			serviceErr.GetHTTPStatusCode() == http.StatusNotFound {
+			return nil, &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionProgrammed),
+				reason:        string(gatewayv1.GatewayReasonPending),
+				message:       fmt.Sprintf("referenced OCI Network Load Balancer %s not found", id),
+			}
+		}
 		return nil, fmt.Errorf("failed to get OCI Network Load Balancer %s: %w", id, err)
 	}
 	return &response.NetworkLoadBalancer, nil
@@ -315,10 +325,13 @@ func (m *networkLoadBalancerGatewayModelImpl) reconcileListenerBackendSet(
 			}
 			return fmt.Errorf("failed to update OCI Network Load Balancer backend set %s: %w", backendSetName, err)
 		}
-		if response.OpcWorkRequestId != nil {
-			return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
+		if response.OpcWorkRequestId == nil {
+			return fmt.Errorf(
+				"failed to update OCI Network Load Balancer backend set %s: missing work request id",
+				backendSetName,
+			)
 		}
-		return nil
+		return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
 	}
 
 	response, err := m.ociClient.CreateBackendSet(ctx, networkloadbalancer.CreateBackendSetRequest{
@@ -336,10 +349,13 @@ func (m *networkLoadBalancerGatewayModelImpl) reconcileListenerBackendSet(
 		}
 		return fmt.Errorf("failed to create OCI Network Load Balancer backend set %s: %w", backendSetName, err)
 	}
-	if response.OpcWorkRequestId != nil {
-		return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
+	if response.OpcWorkRequestId == nil {
+		return fmt.Errorf(
+			"failed to create OCI Network Load Balancer backend set %s: missing work request id",
+			backendSetName,
+		)
 	}
-	return nil
+	return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
 }
 
 func (m *networkLoadBalancerGatewayModelImpl) reconcileListener(
@@ -390,10 +406,13 @@ func (m *networkLoadBalancerGatewayModelImpl) reconcileListener(
 			}
 			return fmt.Errorf("failed to update OCI Network Load Balancer listener %s: %w", listenerName, err)
 		}
-		if response.OpcWorkRequestId != nil {
-			return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
+		if response.OpcWorkRequestId == nil {
+			return fmt.Errorf(
+				"failed to update OCI Network Load Balancer listener %s: missing work request id",
+				listenerName,
+			)
 		}
-		return nil
+		return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
 	}
 
 	response, err := m.ociClient.CreateListener(ctx, networkloadbalancer.CreateListenerRequest{
@@ -411,10 +430,13 @@ func (m *networkLoadBalancerGatewayModelImpl) reconcileListener(
 		}
 		return fmt.Errorf("failed to create OCI Network Load Balancer listener %s: %w", listenerName, err)
 	}
-	if response.OpcWorkRequestId != nil {
-		return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
+	if response.OpcWorkRequestId == nil {
+		return fmt.Errorf(
+			"failed to create OCI Network Load Balancer listener %s: missing work request id",
+			listenerName,
+		)
 	}
-	return nil
+	return m.workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId)
 }
 
 func desiredNetworkLoadBalancerListenerNames(
@@ -539,10 +561,11 @@ func removeMissingNetworkLoadBalancerResources[T any](
 				err,
 			)
 		}
-		if workRequestID != nil {
-			if err = workRequestsWatcher.WaitFor(ctx, *workRequestID); err != nil {
-				return fmt.Errorf("failed waiting for stale %s %s deletion: %w", cleanup.kind, resourceName, err)
-			}
+		if workRequestID == nil {
+			return fmt.Errorf("failed to delete stale %s %s: missing work request id", cleanup.kind, resourceName)
+		}
+		if err = workRequestsWatcher.WaitFor(ctx, *workRequestID); err != nil {
+			return fmt.Errorf("failed waiting for stale %s %s deletion: %w", cleanup.kind, resourceName, err)
 		}
 	}
 	return nil
@@ -668,12 +691,16 @@ func newNetworkLoadBalancerGatewayModel(deps networkLoadBalancerGatewayModelDeps
 	if operationLocks == nil {
 		operationLocks = newNetworkLoadBalancerOperationLocks()
 	}
+	workRequestsWatcher := deps.WorkRequestsWatcher
+	if workRequestsWatcher == nil {
+		workRequestsWatcher = noopWorkRequestsWatcher{}
+	}
 	return &networkLoadBalancerGatewayModelImpl{
 		client:              deps.K8sClient,
 		logger:              deps.RootLogger.WithGroup("network-load-balancer-gateway-model"),
 		ociClient:           deps.OciClient,
 		resourcesModel:      deps.ResourcesModel,
-		workRequestsWatcher: deps.WorkRequestsWatcher,
+		workRequestsWatcher: workRequestsWatcher,
 		operationLocks:      operationLocks,
 	}
 }

--- a/internal/app/network_load_balancer_gateway_model_test.go
+++ b/internal/app/network_load_balancer_gateway_model_test.go
@@ -46,6 +46,13 @@ type stubNetworkLoadBalancerClient struct {
 	deleteListenerErr        error
 	deleteBackendSetErr      error
 	getErr                   error
+
+	omitCreateBackendSetWorkRequest bool
+	omitUpdateBackendSetWorkRequest bool
+	omitCreateListenerWorkRequest   bool
+	omitUpdateListenerWorkRequest   bool
+	omitDeleteListenerWorkRequest   bool
+	omitDeleteBackendSetWorkRequest bool
 }
 
 func TestNetworkLoadBalancerGatewayModelResolveAndProgramStatus(t *testing.T) {
@@ -344,6 +351,11 @@ func (s *stubNetworkLoadBalancerClient) CreateListener(
 	request networkloadbalancer.CreateListenerRequest,
 ) (networkloadbalancer.CreateListenerResponse, error) {
 	s.createListenerRequests = append(s.createListenerRequests, request)
+	if s.createListenerResponse.OpcWorkRequestId == nil &&
+		s.createListenerErr == nil &&
+		!s.omitCreateListenerWorkRequest {
+		s.createListenerResponse.OpcWorkRequestId = new("create-listener-work-request")
+	}
 	return s.createListenerResponse, s.createListenerErr
 }
 
@@ -352,6 +364,11 @@ func (s *stubNetworkLoadBalancerClient) UpdateListener(
 	request networkloadbalancer.UpdateListenerRequest,
 ) (networkloadbalancer.UpdateListenerResponse, error) {
 	s.updateListenerRequests = append(s.updateListenerRequests, request)
+	if s.updateListenerResponse.OpcWorkRequestId == nil &&
+		s.updateListenerErr == nil &&
+		!s.omitUpdateListenerWorkRequest {
+		s.updateListenerResponse.OpcWorkRequestId = new("update-listener-work-request")
+	}
 	return s.updateListenerResponse, s.updateListenerErr
 }
 
@@ -360,6 +377,11 @@ func (s *stubNetworkLoadBalancerClient) DeleteListener(
 	request networkloadbalancer.DeleteListenerRequest,
 ) (networkloadbalancer.DeleteListenerResponse, error) {
 	s.deleteListenerRequests = append(s.deleteListenerRequests, request)
+	if s.deleteListenerResponse.OpcWorkRequestId == nil &&
+		s.deleteListenerErr == nil &&
+		!s.omitDeleteListenerWorkRequest {
+		s.deleteListenerResponse.OpcWorkRequestId = new("delete-listener-work-request")
+	}
 	return s.deleteListenerResponse, s.deleteListenerErr
 }
 
@@ -368,6 +390,11 @@ func (s *stubNetworkLoadBalancerClient) CreateBackendSet(
 	request networkloadbalancer.CreateBackendSetRequest,
 ) (networkloadbalancer.CreateBackendSetResponse, error) {
 	s.createBackendSetRequests = append(s.createBackendSetRequests, request)
+	if s.createBackendSetResponse.OpcWorkRequestId == nil &&
+		s.createBackendSetErr == nil &&
+		!s.omitCreateBackendSetWorkRequest {
+		s.createBackendSetResponse.OpcWorkRequestId = new("create-backend-set-work-request")
+	}
 	return s.createBackendSetResponse, s.createBackendSetErr
 }
 
@@ -376,6 +403,11 @@ func (s *stubNetworkLoadBalancerClient) UpdateBackendSet(
 	request networkloadbalancer.UpdateBackendSetRequest,
 ) (networkloadbalancer.UpdateBackendSetResponse, error) {
 	s.updateBackendSetRequests = append(s.updateBackendSetRequests, request)
+	if s.updateBackendSetResponse.OpcWorkRequestId == nil &&
+		s.updateBackendSetErr == nil &&
+		!s.omitUpdateBackendSetWorkRequest {
+		s.updateBackendSetResponse.OpcWorkRequestId = new("update-backend-set-work-request")
+	}
 	return s.updateBackendSetResponse, s.updateBackendSetErr
 }
 
@@ -384,6 +416,11 @@ func (s *stubNetworkLoadBalancerClient) DeleteBackendSet(
 	request networkloadbalancer.DeleteBackendSetRequest,
 ) (networkloadbalancer.DeleteBackendSetResponse, error) {
 	s.deleteBackendSetRequests = append(s.deleteBackendSetRequests, request)
+	if s.deleteBackendSetResponse.OpcWorkRequestId == nil &&
+		s.deleteBackendSetErr == nil &&
+		!s.omitDeleteBackendSetWorkRequest {
+		s.deleteBackendSetResponse.OpcWorkRequestId = new("delete-backend-set-work-request")
+	}
 	return s.deleteBackendSetResponse, s.deleteBackendSetErr
 }
 
@@ -418,6 +455,28 @@ func (s *stubWorkRequestsWatcher) WaitFor(_ context.Context, workRequestID strin
 	return s.err
 }
 
+func nlbHealthCheckerFromDetails(
+	details networkloadbalancer.HealthCheckerDetails,
+) *networkloadbalancer.HealthChecker {
+	return &networkloadbalancer.HealthChecker{
+		Protocol:         details.Protocol,
+		Port:             details.Port,
+		Retries:          details.Retries,
+		TimeoutInMillis:  details.TimeoutInMillis,
+		IntervalInMillis: details.IntervalInMillis,
+	}
+}
+
+func matchingNLBBackendSet(listener gatewayv1.Listener) networkloadbalancer.BackendSet {
+	healthChecker := networkLoadBalancerHealthCheckerDetails(listener.Protocol, new(int(listener.Port)))
+	return networkloadbalancer.BackendSet{
+		Name:             new(networkLoadBalancerBackendSetName(listener)),
+		Policy:           networkloadbalancer.NetworkLoadBalancingPolicyFiveTuple,
+		HealthChecker:    nlbHealthCheckerFromDetails(healthChecker),
+		IsPreserveSource: new(false),
+	}
+}
+
 func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 	newModel := func(
 		client *stubNetworkLoadBalancerClient,
@@ -429,6 +488,52 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			WorkRequestsWatcher: watcher,
 		})
 	}
+
+	t.Run("matches network load balancer listener and backend set desired state", func(t *testing.T) {
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		healthChecker := networkLoadBalancerHealthCheckerDetails(listener.Protocol, new(int(listener.Port)))
+		assert.False(t, networkLoadBalancerHealthCheckerMatches(nil, healthChecker))
+		assert.True(t, networkLoadBalancerHealthCheckerMatches(
+			nlbHealthCheckerFromDetails(healthChecker),
+			healthChecker,
+		))
+
+		assert.True(t, networkLoadBalancerBackendSetMatches(
+			matchingNLBBackendSet(listener),
+			networkloadbalancer.NetworkLoadBalancingPolicyFiveTuple,
+			healthChecker,
+		))
+		assert.False(t, networkLoadBalancerBackendSetMatches(
+			networkloadbalancer.BackendSet{
+				Policy:           networkloadbalancer.NetworkLoadBalancingPolicyFiveTuple,
+				HealthChecker:    nlbHealthCheckerFromDetails(healthChecker),
+				IsPreserveSource: new(true),
+			},
+			networkloadbalancer.NetworkLoadBalancingPolicyFiveTuple,
+			healthChecker,
+		))
+
+		assert.True(t, networkLoadBalancerListenerMatches(
+			networkloadbalancer.Listener{
+				Protocol:              networkloadbalancer.ListenerProtocolsTcp,
+				Port:                  new(1935),
+				DefaultBackendSetName: new("bs_rtmp"),
+			},
+			networkloadbalancer.ListenerProtocolsTcp,
+			1935,
+			"bs_rtmp",
+		))
+		assert.False(t, networkLoadBalancerListenerMatches(
+			networkloadbalancer.Listener{
+				Protocol:              networkloadbalancer.ListenerProtocolsUdp,
+				Port:                  new(1935),
+				DefaultBackendSetName: new("bs_rtmp"),
+			},
+			networkloadbalancer.ListenerProtocolsTcp,
+			1935,
+			"bs_rtmp",
+		))
+	})
 
 	newDetails := func() *resolvedGatewayDetails {
 		return &resolvedGatewayDetails{
@@ -450,6 +555,12 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
 					DisplayName: new("shared-nlb"),
 				},
+			},
+			createBackendSetResponse: networkloadbalancer.CreateBackendSetResponse{
+				OpcWorkRequestId: new("create-backend-set-work"),
+			},
+			createListenerResponse: networkloadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: new("create-listener-work"),
 			},
 		}
 		model := newModel(client, &stubWorkRequestsWatcher{})
@@ -476,6 +587,25 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 
 		require.Nil(t, got)
 		require.ErrorContains(t, err, "failed to get OCI Network Load Balancer")
+	})
+
+	t.Run("returns programmed false status error when network load balancer is not found", func(t *testing.T) {
+		details := newDetails()
+		model := newModel(&stubNetworkLoadBalancerClient{
+			getErr: ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(404)),
+		}, &stubWorkRequestsWatcher{})
+
+		got, err := model.ensureNetworkLoadBalancer(t.Context(), details)
+
+		require.Nil(t, got)
+		var statusErr *resourceStatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, string(gatewayv1.GatewayConditionProgrammed), statusErr.conditionType)
+		assert.Equal(t, string(gatewayv1.GatewayReasonPending), statusErr.reason)
+		assert.Equal(t,
+			"referenced OCI Network Load Balancer ocid1.networkloadbalancer.oc1..existing not found",
+			statusErr.message,
+		)
 	})
 
 	t.Run("returns invalid parameters for missing load balancer id", func(t *testing.T) {
@@ -505,6 +635,12 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
 					DisplayName: new("shared-nlb"),
 				},
+			},
+			createBackendSetResponse: networkloadbalancer.CreateBackendSetResponse{
+				OpcWorkRequestId: new("create-backend-set-work"),
+			},
+			createListenerResponse: networkloadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: new("create-listener-work"),
 			},
 		}
 		model := newModel(client, &stubWorkRequestsWatcher{})
@@ -562,6 +698,12 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 					BackendSets: map[string]networkloadbalancer.BackendSet{},
 				},
 			},
+			createBackendSetResponse: networkloadbalancer.CreateBackendSetResponse{
+				OpcWorkRequestId: new("create-backend-set-work"),
+			},
+			createListenerResponse: networkloadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: new("create-listener-work"),
+			},
 		}
 		model := newModel(client, &stubWorkRequestsWatcher{})
 		details := newDetails()
@@ -597,6 +739,12 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 					},
 				},
 			},
+			updateBackendSetResponse: networkloadbalancer.UpdateBackendSetResponse{
+				OpcWorkRequestId: new("update-backend-set-work"),
+			},
+			updateListenerResponse: networkloadbalancer.UpdateListenerResponse{
+				OpcWorkRequestId: new("update-listener-work"),
+			},
 		}
 		model := newModel(client, &stubWorkRequestsWatcher{})
 		details := newDetails()
@@ -610,6 +758,111 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		require.Len(t, client.updateBackendSetRequests, 1)
 		require.Len(t, client.updateListenerRequests, 1)
 		assert.Equal(t, "rtmp", lo.FromPtr(client.updateListenerRequests[0].ListenerName))
+	})
+
+	t.Run("skips existing listener and backend set when they already match", func(t *testing.T) {
+		healthChecker := networkLoadBalancerHealthCheckerDetails(gatewayv1.TCPProtocolType, new(1935))
+		client := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
+					DisplayName: new("shared-nlb"),
+					Listeners: map[string]networkloadbalancer.Listener{
+						"rtmp": {
+							Name:                  new("rtmp"),
+							DefaultBackendSetName: new("bs_rtmp"),
+							Port:                  new(1935),
+							Protocol:              networkloadbalancer.ListenerProtocolsTcp,
+						},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_rtmp": {
+							Name:             new("bs_rtmp"),
+							Policy:           networkloadbalancer.NetworkLoadBalancingPolicyFiveTuple,
+							HealthChecker:    nlbHealthCheckerFromDetails(healthChecker),
+							IsPreserveSource: new(false),
+						},
+					},
+				},
+			},
+			updateBackendSetResponse: networkloadbalancer.UpdateBackendSetResponse{
+				OpcWorkRequestId: new("update-backend-set-work"),
+			},
+			updateListenerResponse: networkloadbalancer.UpdateListenerResponse{
+				OpcWorkRequestId: new("update-listener-work"),
+			},
+		}
+		model := newModel(client, &stubWorkRequestsWatcher{})
+		details := newDetails()
+		details.gateway.Spec.Listeners = []gatewayv1.Listener{
+			{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+		}
+
+		err := model.programGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		assert.Empty(t, client.updateBackendSetRequests)
+		assert.Empty(t, client.updateListenerRequests)
+		assert.Empty(t, client.createBackendSetRequests)
+		assert.Empty(t, client.createListenerRequests)
+	})
+
+	t.Run("updates drifted listener and backend set fields", func(t *testing.T) {
+		client := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
+					DisplayName: new("shared-nlb"),
+					Listeners: map[string]networkloadbalancer.Listener{
+						"rtmp": {
+							Name:                  new("rtmp"),
+							DefaultBackendSetName: new("wrong"),
+							Port:                  new(80),
+							Protocol:              networkloadbalancer.ListenerProtocolsUdp,
+						},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_rtmp": {
+							Name:   new("bs_rtmp"),
+							Policy: networkloadbalancer.NetworkLoadBalancingPolicyTwoTuple,
+							HealthChecker: &networkloadbalancer.HealthChecker{
+								Protocol: networkloadbalancer.HealthCheckProtocolsUdp,
+							},
+							IsPreserveSource: new(true),
+						},
+					},
+				},
+			},
+			updateBackendSetResponse: networkloadbalancer.UpdateBackendSetResponse{
+				OpcWorkRequestId: new("update-backend-set-work"),
+			},
+			updateListenerResponse: networkloadbalancer.UpdateListenerResponse{
+				OpcWorkRequestId: new("update-listener-work"),
+			},
+		}
+		model := newModel(client, &stubWorkRequestsWatcher{})
+		details := newDetails()
+		details.gateway.Spec.Listeners = []gatewayv1.Listener{
+			{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+		}
+
+		err := model.programGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		require.Len(t, client.updateBackendSetRequests, 1)
+		assert.Equal(t, string(networkloadbalancer.NetworkLoadBalancingPolicyFiveTuple),
+			lo.FromPtr(client.updateBackendSetRequests[0].Policy))
+		assert.False(t, lo.FromPtr(client.updateBackendSetRequests[0].IsPreserveSource))
+		assert.Equal(t, networkloadbalancer.HealthCheckProtocolsTcp,
+			client.updateBackendSetRequests[0].HealthChecker.Protocol)
+		assert.Equal(t, 1935, lo.FromPtr(client.updateBackendSetRequests[0].HealthChecker.Port))
+
+		require.Len(t, client.updateListenerRequests, 1)
+		assert.Equal(t, networkloadbalancer.ListenerProtocolsTcp,
+			client.updateListenerRequests[0].UpdateListenerDetails.Protocol)
+		assert.Equal(t, 1935, lo.FromPtr(client.updateListenerRequests[0].UpdateListenerDetails.Port))
+		assert.Equal(t, "bs_rtmp",
+			lo.FromPtr(client.updateListenerRequests[0].UpdateListenerDetails.DefaultBackendSetName))
 	})
 
 	t.Run("rejects unsupported gateway listener protocol and empty load balancer id", func(t *testing.T) {
@@ -665,6 +918,12 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			deleteBackendSetResponse: networkloadbalancer.DeleteBackendSetResponse{
 				OpcWorkRequestId: new("delete-backend-set-work-request"),
 			},
+			updateBackendSetResponse: networkloadbalancer.UpdateBackendSetResponse{
+				OpcWorkRequestId: new("update-backend-set-work-request"),
+			},
+			updateListenerResponse: networkloadbalancer.UpdateListenerResponse{
+				OpcWorkRequestId: new("update-listener-work-request"),
+			},
 		}
 		model := newModel(client, watcher)
 		details := newDetails()
@@ -684,7 +943,12 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		require.Len(t, client.deleteBackendSetRequests, 1)
 		assert.Equal(t, "bs_old", lo.FromPtr(client.deleteBackendSetRequests[0].BackendSetName))
 		assert.ElementsMatch(t,
-			[]string{"delete-listener-work-request", "delete-backend-set-work-request"},
+			[]string{
+				"update-backend-set-work-request",
+				"update-listener-work-request",
+				"delete-listener-work-request",
+				"delete-backend-set-work-request",
+			},
 			watcher.waited,
 		)
 	})
@@ -920,6 +1184,9 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			},
 			"create listener": {
 				client: &stubNetworkLoadBalancerClient{
+					createBackendSetResponse: networkloadbalancer.CreateBackendSetResponse{
+						OpcWorkRequestId: new("create-backend-set-work"),
+					},
 					createListenerResponse: networkloadbalancer.CreateListenerResponse{
 						OpcWorkRequestId: new("create-listener-work"),
 					},
@@ -929,6 +1196,9 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			},
 			"update listener": {
 				client: &stubNetworkLoadBalancerClient{
+					updateBackendSetResponse: networkloadbalancer.UpdateBackendSetResponse{
+						OpcWorkRequestId: new("update-backend-set-work"),
+					},
 					updateListenerResponse: networkloadbalancer.UpdateListenerResponse{
 						OpcWorkRequestId: new("update-listener-work"),
 					},
@@ -956,6 +1226,47 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 					require.NoError(t, err)
 				}
 				assert.Contains(t, watcher.waited, tc.waited)
+			})
+		}
+	})
+
+	t.Run("returns errors when listener or backend set work request id is missing", func(t *testing.T) {
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		for name, nlb := range map[string]networkloadbalancer.NetworkLoadBalancer{
+			"create backend set": {
+				Id: new("nlb-id"),
+			},
+			"update backend set": {
+				Id:          new("nlb-id"),
+				BackendSets: map[string]networkloadbalancer.BackendSet{"bs_rtmp": {Name: new("bs_rtmp")}},
+			},
+			"create listener": {
+				Id:          new("nlb-id"),
+				BackendSets: map[string]networkloadbalancer.BackendSet{"bs_rtmp": matchingNLBBackendSet(listener)},
+			},
+			"update listener": {
+				Id:          new("nlb-id"),
+				BackendSets: map[string]networkloadbalancer.BackendSet{"bs_rtmp": matchingNLBBackendSet(listener)},
+				Listeners:   map[string]networkloadbalancer.Listener{"rtmp": {Name: new("rtmp")}},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				client := &stubNetworkLoadBalancerClient{}
+				switch name {
+				case "create backend set":
+					client.omitCreateBackendSetWorkRequest = true
+				case "update backend set":
+					client.omitUpdateBackendSetWorkRequest = true
+				case "create listener":
+					client.omitCreateListenerWorkRequest = true
+				case "update listener":
+					client.omitUpdateListenerWorkRequest = true
+				}
+				model := newModel(client, &stubWorkRequestsWatcher{})
+
+				err := mustNetworkLoadBalancerGatewayModelImpl(t, model).reconcileListener(t.Context(), nlb, listener)
+
+				require.ErrorContains(t, err, "missing work request id")
 			})
 		}
 	})
@@ -991,6 +1302,28 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			BackendSets: map[string]networkloadbalancer.BackendSet{"bs_old": {Name: new("bs_old")}},
 		}, nil)
 		require.ErrorContains(t, err, "failed waiting for stale backend set bs_old deletion")
+
+		model = newModel(
+			&stubNetworkLoadBalancerClient{omitDeleteListenerWorkRequest: true},
+			&stubWorkRequestsWatcher{},
+		)
+		modelImpl = mustNetworkLoadBalancerGatewayModelImpl(t, model)
+		err = modelImpl.removeMissingListeners(t.Context(), networkloadbalancer.NetworkLoadBalancer{
+			Id:        new("nlb-id"),
+			Listeners: map[string]networkloadbalancer.Listener{"old": {Name: new("old")}},
+		}, nil)
+		require.ErrorContains(t, err, "missing work request id")
+
+		model = newModel(
+			&stubNetworkLoadBalancerClient{omitDeleteBackendSetWorkRequest: true},
+			&stubWorkRequestsWatcher{},
+		)
+		modelImpl = mustNetworkLoadBalancerGatewayModelImpl(t, model)
+		err = modelImpl.removeMissingBackendSets(t.Context(), networkloadbalancer.NetworkLoadBalancer{
+			Id:          new("nlb-id"),
+			BackendSets: map[string]networkloadbalancer.BackendSet{"bs_old": {Name: new("bs_old")}},
+		}, nil)
+		require.ErrorContains(t, err, "missing work request id")
 
 		model = newModel(
 			&stubNetworkLoadBalancerClient{deleteListenerErr: busyErr},

--- a/internal/app/network_load_balancer_retry.go
+++ b/internal/app/network_load_balancer_retry.go
@@ -58,7 +58,11 @@ func updateNetworkLoadBalancerBackendSet(
 		return fmt.Errorf("failed to %s Network Load Balancer backend set %s: %w", operation, backendSetName, err)
 	}
 	if response.OpcWorkRequestId == nil {
-		return nil
+		return fmt.Errorf(
+			"failed to %s Network Load Balancer backend set %s: missing work request id",
+			operation,
+			backendSetName,
+		)
 	}
 	if err = workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId); err != nil {
 		return fmt.Errorf("failed waiting for backend set %s %s: %w", backendSetName, operation, err)

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -102,9 +102,10 @@ type removeMissingListenersParams struct {
 }
 
 type removeUnusedCertificatesParams struct {
-	loadBalancerID       string
-	listenerCertificates map[string][]loadbalancer.Certificate
-	knownCertificates    map[string]loadbalancer.Certificate
+	loadBalancerID                   string
+	previouslyProgrammedCertificates []string
+	desiredCertificates              []string
+	knownCertificates                map[string]loadbalancer.Certificate
 }
 
 type ociLoadBalancerModel interface {
@@ -253,6 +254,20 @@ func ociBackendToDetails(backend loadbalancer.Backend, _ int) loadbalancer.Backe
 	}
 }
 
+func healthCheckerFromDetails(details loadbalancer.HealthCheckerDetails) *loadbalancer.HealthChecker {
+	return &loadbalancer.HealthChecker{
+		Protocol:          details.Protocol,
+		Port:              details.Port,
+		ReturnCode:        details.ReturnCode,
+		ResponseBodyRegex: details.ResponseBodyRegex,
+		UrlPath:           details.UrlPath,
+		Retries:           details.Retries,
+		TimeoutInMillis:   details.TimeoutInMillis,
+		IntervalInMillis:  details.IntervalInMillis,
+		IsForcePlainText:  details.IsForcePlainText,
+	}
+}
+
 func (m *ociLoadBalancerModelImpl) reconcileDefaultBackendSet(
 	ctx context.Context,
 	params reconcileDefaultBackendParams,
@@ -272,6 +287,8 @@ func (m *ociLoadBalancerModelImpl) reconcileDefaultBackendSet(
 			); err != nil {
 				return loadbalancer.BackendSet{}, err
 			}
+			existingBackendSet.Policy = new(desiredPolicy)
+			existingBackendSet.HealthChecker = healthCheckerFromDetails(desiredHealthChecker)
 		}
 		m.logger.DebugContext(ctx, "Default backend set already exists",
 			slog.String("loadBalancerId", params.loadBalancerID),
@@ -1075,6 +1092,34 @@ func (m *ociLoadBalancerModelImpl) removeMissingListeners(
 	return errors.Join(errs...)
 }
 
+func routingRuleLess(ruleI, ruleJ loadbalancer.RoutingRule) bool {
+	ruleNameI := lo.FromPtr(ruleI.Name)
+	ruleNameJ := lo.FromPtr(ruleJ.Name)
+	if ruleNameI == defaultCatchAllRuleName {
+		return false
+	}
+	if ruleNameJ == defaultCatchAllRuleName {
+		return true
+	}
+	return ruleNameI < ruleNameJ
+}
+
+func sortRoutingRules(rules []loadbalancer.RoutingRule) {
+	sort.Slice(rules, func(i, j int) bool {
+		return routingRuleLess(rules[i], rules[j])
+	})
+}
+
+func sortedRoutingRules(rules []loadbalancer.RoutingRule) []loadbalancer.RoutingRule {
+	sorted := slices.Clone(rules)
+	sortRoutingRules(sorted)
+	return sorted
+}
+
+func routingRulesEqual(rulesA, rulesB []loadbalancer.RoutingRule) bool {
+	return reflect.DeepEqual(sortedRoutingRules(rulesA), sortedRoutingRules(rulesB))
+}
+
 func (m *ociLoadBalancerModelImpl) commitRoutingPolicy(
 	ctx context.Context,
 	params commitRoutingPolicyParams,
@@ -1115,21 +1160,9 @@ func (m *ociLoadBalancerModelImpl) commitRoutingPolicy(
 	}
 
 	mergedRules := lo.Values(currentRulesByName)
+	sortRoutingRules(mergedRules)
 
-	// Sort the rules: defaultCatchAllRuleName should be at the end
-	sort.Slice(mergedRules, func(i, j int) bool {
-		ruleI := lo.FromPtr(mergedRules[i].Name)
-		ruleJ := lo.FromPtr(mergedRules[j].Name)
-		if ruleI == defaultCatchAllRuleName {
-			return false
-		}
-		if ruleJ == defaultCatchAllRuleName {
-			return true
-		}
-		return ruleI < ruleJ
-	})
-
-	if reflect.DeepEqual(policyResponse.RoutingPolicy.Rules, mergedRules) {
+	if routingRulesEqual(policyResponse.RoutingPolicy.Rules, mergedRules) {
 		m.logger.DebugContext(ctx, "Routing policy already up to date, skipping update",
 			slog.String("loadBalancerId", params.loadBalancerID),
 			slog.String("policyName", policyName),
@@ -1174,22 +1207,22 @@ func (m *ociLoadBalancerModelImpl) commitRoutingPolicy(
 	return nil
 }
 
-//nolint:unparam // The error return is part of the ociLoadBalancerModel interface contract.
 func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 	ctx context.Context,
 	params removeUnusedCertificatesParams,
 ) error {
-	// Create a set of all certificates that are in use by listeners
-	usedCertificates := make(map[string]struct{})
-	for _, certs := range params.listenerCertificates {
-		for _, cert := range certs {
-			usedCertificates[*cert.CertificateName] = struct{}{}
-		}
+	desiredCertificates := make(map[string]struct{}, len(params.desiredCertificates))
+	for _, certName := range params.desiredCertificates {
+		desiredCertificates[certName] = struct{}{}
 	}
 
-	// Iterate through all known certificates and remove those that are not in use
-	for certName, cert := range params.knownCertificates {
-		if _, isUsed := usedCertificates[certName]; isUsed || !isControllerManagedCertificateName(certName) {
+	for _, certName := range params.previouslyProgrammedCertificates {
+		if _, isDesired := desiredCertificates[certName]; isDesired {
+			continue
+		}
+
+		cert, exists := params.knownCertificates[certName]
+		if !exists {
 			continue
 		}
 
@@ -1233,11 +1266,26 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 		)
 	}
 
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("failed to remove unused certificates: %w", err)
+	}
+
 	return nil
 }
 
-func isControllerManagedCertificateName(certName string) bool {
-	return strings.Contains(certName, "-rev-")
+func certificateNamesFromListenerCertificates(
+	listenerCertificates map[string][]loadbalancer.Certificate,
+) []string {
+	certNames := make([]string, 0, len(listenerCertificates))
+	for _, certificates := range listenerCertificates {
+		for _, cert := range certificates {
+			if cert.CertificateName == nil {
+				continue
+			}
+			certNames = append(certNames, *cert.CertificateName)
+		}
+	}
+	return normalizeProgrammedCertificateNames(certNames)
 }
 
 func listenerPolicyName(listenerName string) string {

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -160,17 +161,123 @@ type ociLoadBalancerModelImpl struct {
 	routingRulesMapper  ociLoadBalancerRoutingRulesMapper
 }
 
+func loadBalancerHealthCheckerMatches(
+	current *loadbalancer.HealthChecker,
+	desired loadbalancer.HealthCheckerDetails,
+) bool {
+	if current == nil {
+		return false
+	}
+	return lo.FromPtr(current.Protocol) == lo.FromPtr(desired.Protocol) &&
+		lo.FromPtr(current.Port) == lo.FromPtr(desired.Port)
+}
+
+func loadBalancerBackendSetMatches(
+	current loadbalancer.BackendSet,
+	policy string,
+	healthChecker loadbalancer.HealthCheckerDetails,
+) bool {
+	return lo.FromPtr(current.Policy) == policy &&
+		loadBalancerHealthCheckerMatches(current.HealthChecker, healthChecker)
+}
+
+func loadBalancerBackendSetHealthChecker(port int) loadbalancer.HealthCheckerDetails {
+	return loadbalancer.HealthCheckerDetails{
+		Protocol: new("TCP"),
+		Port:     new(port),
+	}
+}
+
+func (m *ociLoadBalancerModelImpl) updateBackendSetConfig(
+	ctx context.Context,
+	loadBalancerID string,
+	backendSetName string,
+	backendSet loadbalancer.BackendSet,
+	policy string,
+	healthChecker loadbalancer.HealthCheckerDetails,
+) error {
+	updateRes, err := m.ociClient.UpdateBackendSet(ctx, loadbalancer.UpdateBackendSetRequest{
+		LoadBalancerId: new(loadBalancerID),
+		BackendSetName: new(backendSetName),
+		UpdateBackendSetDetails: loadbalancer.UpdateBackendSetDetails{
+			Backends:                                lo.Map(backendSet.Backends, ociBackendToDetails),
+			Policy:                                  new(policy),
+			HealthChecker:                           &healthChecker,
+			SessionPersistenceConfiguration:         backendSet.SessionPersistenceConfiguration,
+			LbCookieSessionPersistenceConfiguration: backendSet.LbCookieSessionPersistenceConfiguration,
+			SslConfiguration:                        sslConfigurationDetailsFromBackendSet(backendSet.SslConfiguration),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update backend set %s: %w", backendSetName, err)
+	}
+	if updateRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to update backend set %s: missing work request id", backendSetName)
+	}
+	if err = m.workRequestsWatcher.WaitFor(ctx, *updateRes.OpcWorkRequestId); err != nil {
+		return fmt.Errorf("failed to wait for backend set %s update: %w", backendSetName, err)
+	}
+	return nil
+}
+
+func sslConfigurationDetailsFromBackendSet(
+	config *loadbalancer.SslConfiguration,
+) *loadbalancer.SslConfigurationDetails {
+	if config == nil {
+		return nil
+	}
+	return &loadbalancer.SslConfigurationDetails{
+		VerifyDepth:                    config.VerifyDepth,
+		VerifyPeerCertificate:          config.VerifyPeerCertificate,
+		HasSessionResumption:           config.HasSessionResumption,
+		TrustedCertificateAuthorityIds: config.TrustedCertificateAuthorityIds,
+		CertificateIds:                 config.CertificateIds,
+		CertificateName:                config.CertificateName,
+		Protocols:                      config.Protocols,
+		CipherSuiteName:                config.CipherSuiteName,
+		ServerOrderPreference: loadbalancer.SslConfigurationDetailsServerOrderPreferenceEnum(
+			config.ServerOrderPreference,
+		),
+	}
+}
+
+func ociBackendToDetails(backend loadbalancer.Backend, _ int) loadbalancer.BackendDetails {
+	return loadbalancer.BackendDetails{
+		Backup:         backend.Backup,
+		Drain:          backend.Drain,
+		IpAddress:      backend.IpAddress,
+		Offline:        backend.Offline,
+		Port:           backend.Port,
+		Weight:         backend.Weight,
+		MaxConnections: backend.MaxConnections,
+	}
+}
+
 func (m *ociLoadBalancerModelImpl) reconcileDefaultBackendSet(
 	ctx context.Context,
 	params reconcileDefaultBackendParams,
 ) (loadbalancer.BackendSet, error) {
 	defaultBackendSetName := params.gateway.Name + "-default"
-	if _, ok := params.knownBackendSets[defaultBackendSetName]; ok {
+	desiredPolicy := "ROUND_ROBIN"
+	desiredHealthChecker := loadBalancerBackendSetHealthChecker(defaultBackendSetPort)
+	if existingBackendSet, ok := params.knownBackendSets[defaultBackendSetName]; ok {
+		if !loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, desiredHealthChecker) {
+			if err := m.updateBackendSetConfig(
+				ctx,
+				params.loadBalancerID,
+				defaultBackendSetName,
+				existingBackendSet,
+				desiredPolicy,
+				desiredHealthChecker,
+			); err != nil {
+				return loadbalancer.BackendSet{}, err
+			}
+		}
 		m.logger.DebugContext(ctx, "Default backend set already exists",
 			slog.String("loadBalancerId", params.loadBalancerID),
 			slog.String("backendName", defaultBackendSetName),
 		)
-		return params.knownBackendSets[defaultBackendSetName], nil
+		return existingBackendSet, nil
 	}
 
 	m.logger.InfoContext(ctx, "Default backend set not found, creating",
@@ -180,17 +287,18 @@ func (m *ociLoadBalancerModelImpl) reconcileDefaultBackendSet(
 	createRes, err := m.ociClient.CreateBackendSet(ctx, loadbalancer.CreateBackendSetRequest{
 		LoadBalancerId: &params.loadBalancerID,
 		CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
-			Name:   &defaultBackendSetName,
-			Policy: new("ROUND_ROBIN"),
-			HealthChecker: &loadbalancer.HealthCheckerDetails{
-				Protocol: new("TCP"),
-				Port:     new(int(defaultBackendSetPort)),
-			},
+			Name:          &defaultBackendSetName,
+			Policy:        new(desiredPolicy),
+			HealthChecker: &desiredHealthChecker,
 		},
 	})
 	if err != nil {
 		return loadbalancer.BackendSet{},
 			fmt.Errorf("failed to create default backend set %s: %w", defaultBackendSetName, err)
+	}
+	if createRes.OpcWorkRequestId == nil {
+		return loadbalancer.BackendSet{},
+			fmt.Errorf("failed to create default backend set %s: missing work request id", defaultBackendSetName)
 	}
 
 	if err = m.workRequestsWatcher.WaitFor(
@@ -397,61 +505,189 @@ func (m *ociLoadBalancerModelImpl) logCertificateAlreadyExists(
 	)
 }
 
+func defaultCatchAllRoutingRule(defaultBackendSetName string) loadbalancer.RoutingRule {
+	return loadbalancer.RoutingRule{
+		Name:      new(defaultCatchAllRuleName),
+		Condition: new("any(http.request.url.path sw '/')"),
+		Actions: []loadbalancer.Action{
+			loadbalancer.ForwardToBackendSet{
+				BackendSetName: new(defaultBackendSetName),
+			},
+		},
+	}
+}
+
+func routingRuleForwardsToBackendSet(rule loadbalancer.RoutingRule, backendSetName string) bool {
+	if len(rule.Actions) != 1 {
+		return false
+	}
+	forward, ok := rule.Actions[0].(loadbalancer.ForwardToBackendSet)
+	return ok && lo.FromPtr(forward.BackendSetName) == backendSetName
+}
+
+func defaultCatchAllRuleMatches(rule loadbalancer.RoutingRule, defaultBackendSetName string) bool {
+	return lo.FromPtr(rule.Name) == defaultCatchAllRuleName &&
+		lo.FromPtr(rule.Condition) == "any(http.request.url.path sw '/')" &&
+		routingRuleForwardsToBackendSet(rule, defaultBackendSetName)
+}
+
+func routingPolicyDefaultRuleDrifted(policy loadbalancer.RoutingPolicy, defaultBackendSetName string) bool {
+	for _, rule := range policy.Rules {
+		if lo.FromPtr(rule.Name) == defaultCatchAllRuleName {
+			return !defaultCatchAllRuleMatches(rule, defaultBackendSetName)
+		}
+	}
+	return true
+}
+
+func desiredRoutingPolicyRulesWithDefault(
+	policy loadbalancer.RoutingPolicy,
+	defaultBackendSetName string,
+) []loadbalancer.RoutingRule {
+	rules := make([]loadbalancer.RoutingRule, 0, len(policy.Rules)+1)
+	defaultRuleFound := false
+	for _, rule := range policy.Rules {
+		if lo.FromPtr(rule.Name) == defaultCatchAllRuleName {
+			defaultRuleFound = true
+			rules = append(rules, defaultCatchAllRoutingRule(defaultBackendSetName))
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	if !defaultRuleFound {
+		rules = append(rules, defaultCatchAllRoutingRule(defaultBackendSetName))
+	}
+	return rules
+}
+
 func (m *ociLoadBalancerModelImpl) reconcileListenerRoutingPolicy(
 	ctx context.Context,
 	params reconcileHTTPListenerParams,
 ) error {
 	listenerName := string(params.listenerSpec.Name)
 	routingPolicyName := listenerPolicyName(listenerName)
+	policy, ok := params.knownRoutingPolicies[routingPolicyName]
 
-	if _, ok := params.knownRoutingPolicies[routingPolicyName]; !ok {
-		m.logger.InfoContext(ctx, "Creating routing policy for listener",
-			slog.String("loadBalancerId", params.loadBalancerID),
-			slog.String("routingPolicyName", routingPolicyName),
-			slog.String("listenerName", listenerName),
-		)
+	if !ok {
+		return m.createListenerRoutingPolicy(ctx, params, routingPolicyName, listenerName)
+	}
+	if routingPolicyDefaultRuleDrifted(policy, params.defaultBackendSetName) {
+		return m.updateListenerRoutingPolicyDefaultRule(ctx, params, routingPolicyName, policy)
+	}
 
-		createRoutingPolicyRes, err := m.ociClient.CreateRoutingPolicy(ctx, loadbalancer.CreateRoutingPolicyRequest{
-			LoadBalancerId: &params.loadBalancerID,
-			CreateRoutingPolicyDetails: loadbalancer.CreateRoutingPolicyDetails{
-				Name:                     new(routingPolicyName),
-				ConditionLanguageVersion: loadbalancer.CreateRoutingPolicyDetailsConditionLanguageVersionV1,
-				Rules: []loadbalancer.RoutingRule{
-					// We're creating routing policy to have it available when reconciling routes
-					// It's not possible to create an empty routing policy, so we're adding a default rule.
-					// Alternative could be to create and attach routing policy when reconciling routes, but
-					// it may be a bit more complex on the route reconciler side.
-					{
-						Name:      new(defaultCatchAllRuleName),
-						Condition: new("any(http.request.url.path sw '/')"),
-						Actions: []loadbalancer.Action{
-							loadbalancer.ForwardToBackendSet{
-								BackendSetName: new(params.defaultBackendSetName),
-							},
-						},
-					},
-				},
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create routing policy %s: %w", routingPolicyName, err)
-		}
+	m.logger.DebugContext(ctx, "Routing policy already exists, skipping creation",
+		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("routingPolicyName", routingPolicyName),
+		slog.String("listenerName", listenerName),
+	)
 
-		if err = m.workRequestsWatcher.WaitFor(
-			ctx,
-			*createRoutingPolicyRes.OpcWorkRequestId,
-		); err != nil {
-			return fmt.Errorf("failed to wait for routing policy %s: %w", routingPolicyName, err)
-		}
-	} else {
-		m.logger.DebugContext(ctx, "Routing policy already exists, skipping creation",
-			slog.String("loadBalancerId", params.loadBalancerID),
-			slog.String("routingPolicyName", routingPolicyName),
-			slog.String("listenerName", listenerName),
-		)
+	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) createListenerRoutingPolicy(
+	ctx context.Context,
+	params reconcileHTTPListenerParams,
+	routingPolicyName string,
+	listenerName string,
+) error {
+	m.logger.InfoContext(ctx, "Creating routing policy for listener",
+		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("routingPolicyName", routingPolicyName),
+		slog.String("listenerName", listenerName),
+	)
+
+	createRoutingPolicyRes, err := m.ociClient.CreateRoutingPolicy(ctx, loadbalancer.CreateRoutingPolicyRequest{
+		LoadBalancerId: &params.loadBalancerID,
+		CreateRoutingPolicyDetails: loadbalancer.CreateRoutingPolicyDetails{
+			Name:                     new(routingPolicyName),
+			ConditionLanguageVersion: loadbalancer.CreateRoutingPolicyDetailsConditionLanguageVersionV1,
+			// We're creating routing policy to have it available when reconciling routes.
+			// It's not possible to create an empty routing policy, so we're adding a default rule.
+			Rules: []loadbalancer.RoutingRule{defaultCatchAllRoutingRule(params.defaultBackendSetName)},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create routing policy %s: %w", routingPolicyName, err)
+	}
+	if createRoutingPolicyRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to create routing policy %s: missing work request id", routingPolicyName)
+	}
+
+	if err = m.workRequestsWatcher.WaitFor(ctx, *createRoutingPolicyRes.OpcWorkRequestId); err != nil {
+		return fmt.Errorf("failed to wait for routing policy %s: %w", routingPolicyName, err)
 	}
 
 	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) updateListenerRoutingPolicyDefaultRule(
+	ctx context.Context,
+	params reconcileHTTPListenerParams,
+	routingPolicyName string,
+	policy loadbalancer.RoutingPolicy,
+) error {
+	updateRoutingPolicyRes, err := m.ociClient.UpdateRoutingPolicy(ctx, loadbalancer.UpdateRoutingPolicyRequest{
+		LoadBalancerId:    &params.loadBalancerID,
+		RoutingPolicyName: &routingPolicyName,
+		UpdateRoutingPolicyDetails: loadbalancer.UpdateRoutingPolicyDetails{
+			ConditionLanguageVersion: loadbalancer.UpdateRoutingPolicyDetailsConditionLanguageVersionEnum(
+				policy.ConditionLanguageVersion,
+			),
+			Rules: desiredRoutingPolicyRulesWithDefault(policy, params.defaultBackendSetName),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update routing policy %s: %w", routingPolicyName, err)
+	}
+	if updateRoutingPolicyRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to update routing policy %s: missing work request id", routingPolicyName)
+	}
+	if err = m.workRequestsWatcher.WaitFor(ctx, *updateRoutingPolicyRes.OpcWorkRequestId); err != nil {
+		return fmt.Errorf("failed to wait for routing policy %s update: %w", routingPolicyName, err)
+	}
+
+	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) reconcileExistingBackendSet(
+	ctx context.Context,
+	params reconcileBackendSetParams,
+	backendSetName string,
+	existingBackendSet loadbalancer.BackendSet,
+	desiredPolicy string,
+	desiredHealthChecker loadbalancer.HealthCheckerDetails,
+) error {
+	if !loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, desiredHealthChecker) {
+		if err := m.updateBackendSetConfig(
+			ctx,
+			params.loadBalancerID,
+			backendSetName,
+			existingBackendSet,
+			desiredPolicy,
+			desiredHealthChecker,
+		); err != nil {
+			return err
+		}
+	}
+
+	m.logger.DebugContext(ctx, "Backend set found",
+		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("backendSetName", backendSetName),
+	)
+
+	return nil
+}
+
+func backendSetLookupFound(err error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+	serviceErr, ok := common.IsServiceError(err)
+	if ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound {
+		return false, nil
+	}
+
+	return false, err
 }
 
 func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
@@ -488,66 +724,87 @@ func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
 		}
 	}
 
-	var workRequestID string
-	if _, ok := params.knownListeners[listenerName]; ok {
-		updateDetails, hasChanges := makeOciListenerUpdateDetails(makeOciListenerUpdateDetailsParams{
-			existingListenerData:  params.knownListeners[listenerName],
-			listenerName:          listenerName,
-			listenerSpec:          params.listenerSpec,
-			defaultBackendSetName: params.defaultBackendSetName,
-			sslConfig:             sslConfig,
-		})
-		if !hasChanges {
-			m.logger.DebugContext(ctx, "Listener already up to date, skipping update",
-				slog.String("loadBalancerId", params.loadBalancerID),
-				slog.String("listenerName", listenerName),
-			)
-			return nil
-		}
+	if existingListener, ok := params.knownListeners[listenerName]; ok {
+		return m.reconcileExistingHTTPListener(ctx, params, listenerName, existingListener, sslConfig)
+	}
 
-		m.logger.DebugContext(ctx, "Updating existing listener",
+	return m.createHTTPListener(ctx, params, listenerName, sslConfig)
+}
+
+func (m *ociLoadBalancerModelImpl) reconcileExistingHTTPListener(
+	ctx context.Context,
+	params reconcileHTTPListenerParams,
+	listenerName string,
+	existingListener loadbalancer.Listener,
+	sslConfig *loadbalancer.SslConfigurationDetails,
+) error {
+	updateDetails, hasChanges := makeOciListenerUpdateDetails(makeOciListenerUpdateDetailsParams{
+		existingListenerData:  existingListener,
+		listenerName:          listenerName,
+		listenerSpec:          params.listenerSpec,
+		defaultBackendSetName: params.defaultBackendSetName,
+		sslConfig:             sslConfig,
+	})
+	if !hasChanges {
+		m.logger.DebugContext(ctx, "Listener already up to date, skipping update",
 			slog.String("loadBalancerId", params.loadBalancerID),
 			slog.String("listenerName", listenerName),
 		)
-
-		updateRes, err := m.ociClient.UpdateListener(ctx, loadbalancer.UpdateListenerRequest{
-			ListenerName:          &listenerName,
-			LoadBalancerId:        &params.loadBalancerID,
-			UpdateListenerDetails: updateDetails,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update listener %s: %w", listenerName, err)
-		}
-
-		workRequestID = *updateRes.OpcWorkRequestId
-	} else {
-		m.logger.InfoContext(ctx, "Listener not found, creating",
-			slog.String("loadBalancerId", params.loadBalancerID),
-			slog.String("name", listenerName),
-		)
-
-		createRes, err := m.ociClient.CreateListener(ctx, loadbalancer.CreateListenerRequest{
-			LoadBalancerId: &params.loadBalancerID,
-			CreateListenerDetails: loadbalancer.CreateListenerDetails{
-				Name:                  new(listenerName),
-				DefaultBackendSetName: new(params.defaultBackendSetName),
-				Port:                  new(int(params.listenerSpec.Port)),
-				Protocol:              new("HTTP"),
-				RoutingPolicyName:     new(listenerPolicyName(listenerName)),
-				SslConfiguration:      sslConfig,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create listener %s: %w", listenerName, err)
-		}
-
-		workRequestID = *createRes.OpcWorkRequestId
+		return nil
 	}
 
-	if err := m.workRequestsWatcher.WaitFor(
-		ctx,
-		workRequestID,
-	); err != nil {
+	m.logger.DebugContext(ctx, "Updating existing listener",
+		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("listenerName", listenerName),
+	)
+
+	updateRes, err := m.ociClient.UpdateListener(ctx, loadbalancer.UpdateListenerRequest{
+		ListenerName:          &listenerName,
+		LoadBalancerId:        &params.loadBalancerID,
+		UpdateListenerDetails: updateDetails,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update listener %s: %w", listenerName, err)
+	}
+	if updateRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to update listener %s: missing work request id", listenerName)
+	}
+	if err = m.workRequestsWatcher.WaitFor(ctx, *updateRes.OpcWorkRequestId); err != nil {
+		return fmt.Errorf("failed to wait for listener %s: %w", listenerName, err)
+	}
+
+	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) createHTTPListener(
+	ctx context.Context,
+	params reconcileHTTPListenerParams,
+	listenerName string,
+	sslConfig *loadbalancer.SslConfigurationDetails,
+) error {
+	m.logger.InfoContext(ctx, "Listener not found, creating",
+		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("name", listenerName),
+	)
+
+	createRes, err := m.ociClient.CreateListener(ctx, loadbalancer.CreateListenerRequest{
+		LoadBalancerId: &params.loadBalancerID,
+		CreateListenerDetails: loadbalancer.CreateListenerDetails{
+			Name:                  new(listenerName),
+			DefaultBackendSetName: new(params.defaultBackendSetName),
+			Port:                  new(int(params.listenerSpec.Port)),
+			Protocol:              new("HTTP"),
+			RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+			SslConfiguration:      sslConfig,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create listener %s: %w", listenerName, err)
+	}
+	if createRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to create listener %s: missing work request id", listenerName)
+	}
+	if err = m.workRequestsWatcher.WaitFor(ctx, *createRes.OpcWorkRequestId); err != nil {
 		return fmt.Errorf("failed to wait for listener %s: %w", listenerName, err)
 	}
 
@@ -559,29 +816,32 @@ func (m *ociLoadBalancerModelImpl) reconcileBackendSet(
 	params reconcileBackendSetParams,
 ) error {
 	backendSetName := ociBackendSetNameFromService(params.service)
-
-	_, err := m.ociClient.GetBackendSet(ctx, loadbalancer.GetBackendSetRequest{
-		BackendSetName: &backendSetName,
-		LoadBalancerId: &params.loadBalancerID,
-	})
-	if err != nil {
-		serviceErr, ok := common.IsServiceError(err)
-		if !ok || serviceErr.GetHTTPStatusCode() != http.StatusNotFound {
-			return fmt.Errorf("failed to get backend set %s: %w", backendSetName, err)
-		}
-	} else {
-		m.logger.DebugContext(ctx, "Backend set found, skipping creation",
-			slog.String("loadBalancerId", params.loadBalancerID),
-			slog.String("backendSetName", backendSetName),
-		)
-		return nil
-	}
-
 	healthCheckerPort := params.service.Spec.Ports[0].TargetPort.IntValue()
 	if healthCheckerPort == 0 {
 		// Not the best option. Potentially have to be refactored to use
 		// port from the backend ref. Some research is needed.
 		healthCheckerPort = int(params.service.Spec.Ports[0].Port)
+	}
+	desiredPolicy := "ROUND_ROBIN"
+	desiredHealthChecker := loadBalancerBackendSetHealthChecker(healthCheckerPort)
+
+	getResponse, err := m.ociClient.GetBackendSet(ctx, loadbalancer.GetBackendSetRequest{
+		BackendSetName: &backendSetName,
+		LoadBalancerId: &params.loadBalancerID,
+	})
+	found, lookupErr := backendSetLookupFound(err)
+	if lookupErr != nil {
+		return fmt.Errorf("failed to get backend set %s: %w", backendSetName, lookupErr)
+	}
+	if found {
+		return m.reconcileExistingBackendSet(
+			ctx,
+			params,
+			backendSetName,
+			getResponse.BackendSet,
+			desiredPolicy,
+			desiredHealthChecker,
+		)
 	}
 
 	m.logger.InfoContext(ctx, "Backend set not found, creating",
@@ -593,17 +853,17 @@ func (m *ociLoadBalancerModelImpl) reconcileBackendSet(
 	createRes, err := m.ociClient.CreateBackendSet(ctx, loadbalancer.CreateBackendSetRequest{
 		LoadBalancerId: &params.loadBalancerID,
 		CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
-			Name:   &backendSetName,
-			Policy: new("ROUND_ROBIN"),
-			HealthChecker: &loadbalancer.HealthCheckerDetails{
-				Protocol: new("TCP"),
-				Port:     new(healthCheckerPort),
-			},
+			Name:          &backendSetName,
+			Policy:        new(desiredPolicy),
+			HealthChecker: &desiredHealthChecker,
 		},
 	})
 
 	if err != nil {
 		return fmt.Errorf("failed to create backend set %s: %w", backendSetName, err)
+	}
+	if createRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to create backend set %s: missing work request id", backendSetName)
 	}
 
 	if err = m.workRequestsWatcher.WaitFor(
@@ -651,6 +911,9 @@ func (m *ociLoadBalancerModelImpl) deprovisionBackendSet(
 			return nil // Skip deletion as it's used in routing policy
 		}
 		return fmt.Errorf("failed to delete backend set %s: %w", backendSetName, err)
+	}
+	if deleteRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to delete backend set %s: missing work request id", backendSetName)
 	}
 
 	if err = m.workRequestsWatcher.WaitFor(
@@ -727,6 +990,9 @@ func (m *ociLoadBalancerModelImpl) deleteMissingListener(
 		)
 		return fmt.Errorf("failed to delete listener %s: %w", lo.FromPtr(listener.Name), err)
 	}
+	if resp.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to delete listener %s: missing work request id", lo.FromPtr(listener.Name))
+	}
 
 	if err = m.workRequestsWatcher.WaitFor(ctx, *resp.OpcWorkRequestId); err != nil {
 		return fmt.Errorf("failed to wait for listener %s deletion: %w", lo.FromPtr(listener.Name), err)
@@ -752,6 +1018,12 @@ func (m *ociLoadBalancerModelImpl) deleteMissingRoutingPolicy(
 		})
 		if err != nil {
 			return fmt.Errorf("failed to delete routing policy %s: %w", *listener.RoutingPolicyName, err)
+		}
+		if deletePolicyRes.OpcWorkRequestId == nil {
+			return fmt.Errorf(
+				"failed to delete routing policy %s: missing work request id",
+				*listener.RoutingPolicyName,
+			)
 		}
 
 		if err = m.workRequestsWatcher.WaitFor(ctx, *deletePolicyRes.OpcWorkRequestId); err != nil {
@@ -857,6 +1129,14 @@ func (m *ociLoadBalancerModelImpl) commitRoutingPolicy(
 		return ruleI < ruleJ
 	})
 
+	if reflect.DeepEqual(policyResponse.RoutingPolicy.Rules, mergedRules) {
+		m.logger.DebugContext(ctx, "Routing policy already up to date, skipping update",
+			slog.String("loadBalancerId", params.loadBalancerID),
+			slog.String("policyName", policyName),
+		)
+		return nil
+	}
+
 	updateRes, err := m.ociClient.UpdateRoutingPolicy(ctx, loadbalancer.UpdateRoutingPolicyRequest{
 		LoadBalancerId:    &params.loadBalancerID,
 		RoutingPolicyName: &policyName,
@@ -875,6 +1155,9 @@ func (m *ociLoadBalancerModelImpl) commitRoutingPolicy(
 			slog.Any("policyRules", mergedRules),
 		)
 		return fmt.Errorf("failed to update routing policy %s: %w", policyName, err)
+	}
+	if updateRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to update routing policy %s: missing work request id", policyName)
 	}
 
 	if err = m.workRequestsWatcher.WaitFor(
@@ -906,42 +1189,55 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 
 	// Iterate through all known certificates and remove those that are not in use
 	for certName, cert := range params.knownCertificates {
-		if _, isUsed := usedCertificates[certName]; !isUsed {
-			m.logger.InfoContext(ctx, "Removing unused certificate",
-				slog.String("loadBalancerId", params.loadBalancerID),
-				slog.String("certificateName", certName),
-			)
-
-			resp, err := m.ociClient.DeleteCertificate(ctx, loadbalancer.DeleteCertificateRequest{
-				LoadBalancerId:  &params.loadBalancerID,
-				CertificateName: cert.CertificateName,
-			})
-			if err != nil {
-				m.logger.WarnContext(ctx, "Failed to delete certificate",
-					diag.ErrAttr(err),
-					slog.String("certificateName", certName),
-					slog.String("loadBalancerId", params.loadBalancerID),
-				)
-				continue
-			}
-
-			if err = m.workRequestsWatcher.WaitFor(ctx, *resp.OpcWorkRequestId); err != nil {
-				m.logger.WarnContext(ctx, "Failed to wait for certificate deletion",
-					diag.ErrAttr(err),
-					slog.String("certificateName", certName),
-					slog.String("loadBalancerId", params.loadBalancerID),
-				)
-				continue
-			}
-
-			m.logger.DebugContext(ctx, "Successfully removed unused certificate",
-				slog.String("loadBalancerId", params.loadBalancerID),
-				slog.String("certificateName", certName),
-			)
+		if _, isUsed := usedCertificates[certName]; isUsed || !isControllerManagedCertificateName(certName) {
+			continue
 		}
+
+		m.logger.InfoContext(ctx, "Removing unused certificate",
+			slog.String("loadBalancerId", params.loadBalancerID),
+			slog.String("certificateName", certName),
+		)
+
+		resp, err := m.ociClient.DeleteCertificate(ctx, loadbalancer.DeleteCertificateRequest{
+			LoadBalancerId:  &params.loadBalancerID,
+			CertificateName: cert.CertificateName,
+		})
+		if err != nil {
+			m.logger.WarnContext(ctx, "Failed to delete certificate",
+				diag.ErrAttr(err),
+				slog.String("certificateName", certName),
+				slog.String("loadBalancerId", params.loadBalancerID),
+			)
+			continue
+		}
+		if resp.OpcWorkRequestId == nil {
+			m.logger.WarnContext(ctx, "Failed to delete certificate: missing work request id",
+				slog.String("certificateName", certName),
+				slog.String("loadBalancerId", params.loadBalancerID),
+			)
+			continue
+		}
+
+		if err = m.workRequestsWatcher.WaitFor(ctx, *resp.OpcWorkRequestId); err != nil {
+			m.logger.WarnContext(ctx, "Failed to wait for certificate deletion",
+				diag.ErrAttr(err),
+				slog.String("loadBalancerId", params.loadBalancerID),
+				slog.String("certificateName", certName),
+			)
+			continue
+		}
+
+		m.logger.DebugContext(ctx, "Successfully removed unused certificate",
+			slog.String("loadBalancerId", params.loadBalancerID),
+			slog.String("certificateName", certName),
+		)
 	}
 
 	return nil
+}
+
+func isControllerManagedCertificateName(certName string) bool {
+	return strings.Contains(certName, "-rev-")
 }
 
 func listenerPolicyName(listenerName string) string {

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -36,16 +37,34 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
 		}
 	}
+	makeMatchingRoutingPolicy := func(routingPolicyName, defaultBackendSetName string) loadbalancer.RoutingPolicy {
+		return loadbalancer.RoutingPolicy{
+			Name:                     new(routingPolicyName),
+			ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+			Rules: []loadbalancer.RoutingRule{
+				defaultCatchAllRoutingRule(defaultBackendSetName),
+			},
+		}
+	}
 
 	t.Run("reconcileDefaultBackendSet", func(t *testing.T) {
 		t.Run("when backend set exists", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
-			existingBackendSet := makeRandomOCIBackendSet()
 			gw := newRandomGateway()
 
 			wantBsName := gw.Name + "-default"
+			existingBackendSet := makeRandomOCIBackendSet(
+				randomOCIBackendSetWithNameOpt(wantBsName),
+				func(bs *loadbalancer.BackendSet) {
+					bs.Policy = new("ROUND_ROBIN")
+					bs.HealthChecker = &loadbalancer.HealthChecker{
+						Protocol: new("TCP"),
+						Port:     new(defaultBackendSetPort),
+					}
+				},
+			)
 
 			knownBackendSets := map[string]loadbalancer.BackendSet{
 				wantBsName:       existingBackendSet,
@@ -59,6 +78,46 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				gateway:          gw,
 			}
 			actualBackendSet, err := model.reconcileDefaultBackendSet(t.Context(), params)
+			require.NoError(t, err)
+			assert.Equal(t, existingBackendSet, actualBackendSet)
+		})
+
+		t.Run("updates existing backend set config drift", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gw := newRandomGateway()
+			wantBsName := gw.Name + "-default"
+			existingBackendSet := makeRandomOCIBackendSet(randomOCIBackendSetWithNameOpt(wantBsName))
+
+			params := reconcileDefaultBackendParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownBackendSets: map[string]loadbalancer.BackendSet{
+					wantBsName: existingBackendSet,
+				},
+				gateway: gw,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			workRequestID := fake.UUID().V4()
+
+			ociLoadBalancerClient.EXPECT().UpdateBackendSet(
+				t.Context(),
+				mock.MatchedBy(func(req loadbalancer.UpdateBackendSetRequest) bool {
+					return assert.Equal(t, params.loadBalancerID, *req.LoadBalancerId) &&
+						assert.Equal(t, wantBsName, *req.BackendSetName) &&
+						assert.Equal(t, "ROUND_ROBIN", *req.Policy) &&
+						assert.Equal(t, "TCP", *req.HealthChecker.Protocol) &&
+						assert.Equal(t, defaultBackendSetPort, *req.HealthChecker.Port)
+				}),
+			).Return(loadbalancer.UpdateBackendSetResponse{
+				OpcWorkRequestId: &workRequestID,
+			}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			actualBackendSet, err := model.reconcileDefaultBackendSet(t.Context(), params)
+
 			require.NoError(t, err)
 			assert.Equal(t, existingBackendSet, actualBackendSet)
 		})
@@ -180,6 +239,35 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			_, err := model.reconcileDefaultBackendSet(t.Context(), params)
 			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("when create backend set has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gw := newRandomGateway()
+			wantBsName := gw.Name + "-default"
+
+			params := reconcileDefaultBackendParams{
+				loadBalancerID: fake.UUID().V4(),
+				gateway:        gw,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			ociLoadBalancerClient.EXPECT().CreateBackendSet(t.Context(), loadbalancer.CreateBackendSetRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
+					Name: &wantBsName,
+					HealthChecker: &loadbalancer.HealthCheckerDetails{
+						Port:     new(int(80)),
+						Protocol: new("TCP"),
+					},
+					Policy: new("ROUND_ROBIN"),
+				},
+			}).Return(loadbalancer.CreateBackendSetResponse{}, nil)
+
+			_, err := model.reconcileDefaultBackendSet(t.Context(), params)
+			require.ErrorContains(t, err, "missing work request id")
 		})
 
 		t.Run("when final get backend set fails", func(t *testing.T) {
@@ -589,18 +677,19 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			)
 
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
 
 			params := reconcileHTTPListenerParams{
 				loadBalancerID: fake.UUID().V4(),
 				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
 					fake.UUID().V4():  makeRandomOCIRoutingPolicy(),
-					routingPolicyName: makeRandomOCIRoutingPolicy(),
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
 				},
 				knownListeners: map[string]loadbalancer.Listener{
 					string(gwListener.Name): lbListener,
 					fake.UUID().V4():        makeRandomOCIListener(),
 				},
-				defaultBackendSetName: fake.UUID().V4(),
+				defaultBackendSetName: defaultBackendSetName,
 				listenerSpec:          &gwListener,
 			}
 
@@ -641,16 +730,17 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			)
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
 			wantErr := errors.New(faker.New().Lorem().Sentence(10))
+			defaultBackendSetName := faker.New().UUID().V4()
 
 			params := reconcileHTTPListenerParams{
 				loadBalancerID: faker.New().UUID().V4(),
 				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
-					routingPolicyName: makeRandomOCIRoutingPolicy(),
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
 				},
 				knownListeners: map[string]loadbalancer.Listener{
 					string(gwListener.Name): lbListener,
 				},
-				defaultBackendSetName: faker.New().UUID().V4(),
+				defaultBackendSetName: defaultBackendSetName,
 				listenerSpec:          &gwListener,
 			}
 
@@ -669,6 +759,43 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			err := model.reconcileHTTPListener(t.Context(), params)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("fails when existing listener update has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+			lbListener := makeRandomOCIListener(
+				func(l *loadbalancer.Listener) {
+					l.Name = new(string(gwListener.Name))
+				},
+			)
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
+
+			params := reconcileHTTPListenerParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
+				},
+				knownListeners: map[string]loadbalancer.Listener{
+					string(gwListener.Name): lbListener,
+				},
+				defaultBackendSetName: defaultBackendSetName,
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			ociLoadBalancerClient.EXPECT().
+				UpdateListener(t.Context(), mock.Anything).
+				Return(loadbalancer.UpdateListenerResponse{}, nil)
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
 		})
 
 		t.Run("when listener exists no changes", func(t *testing.T) {
@@ -694,7 +821,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				loadBalancerID: fake.UUID().V4(),
 				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
 					fake.UUID().V4():  makeRandomOCIRoutingPolicy(),
-					routingPolicyName: makeRandomOCIRoutingPolicy(),
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
 				},
 				knownListeners: map[string]loadbalancer.Listener{
 					string(gwListener.Name): lbListener,
@@ -732,19 +859,20 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
 
 			params := reconcileHTTPListenerParams{
 				loadBalancerID: fake.UUID().V4(),
 				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
 					fake.UUID().V4():  makeRandomOCIRoutingPolicy(),
-					routingPolicyName: makeRandomOCIRoutingPolicy(),
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
 				},
 				knownListeners: map[string]loadbalancer.Listener{
 					string(gwListener.Name): lbListener,
 					fake.UUID().V4():        makeRandomOCIListener(),
 				},
 				listenerCertificates:  listenerCertificates,
-				defaultBackendSetName: fake.UUID().V4(),
+				defaultBackendSetName: defaultBackendSetName,
 				listenerSpec:          &gwListener,
 			}
 
@@ -782,13 +910,14 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				randomListenerWithHTTPSParamsOpt(),
 			)
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := faker.New().UUID().V4()
 
 			params := reconcileHTTPListenerParams{
 				loadBalancerID: faker.New().UUID().V4(),
 				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
-					routingPolicyName: makeRandomOCIRoutingPolicy(),
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
 				},
-				defaultBackendSetName: faker.New().UUID().V4(),
+				defaultBackendSetName: defaultBackendSetName,
 				listenerSpec:          &gwListener,
 			}
 
@@ -964,13 +1093,14 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				randomListenerWithHTTPSParamsOpt(),
 			)
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := faker.New().UUID().V4()
 
 			params := reconcileHTTPListenerParams{
 				loadBalancerID: faker.New().UUID().V4(),
 				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
-					routingPolicyName: makeRandomOCIRoutingPolicy(),
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
 				},
-				defaultBackendSetName: faker.New().UUID().V4(),
+				defaultBackendSetName: defaultBackendSetName,
 				listenerSpec:          &gwListener,
 			}
 
@@ -996,6 +1126,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			)
 
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
 
 			params := reconcileHTTPListenerParams{
 				loadBalancerID: fake.UUID().V4(),
@@ -1004,11 +1135,17 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					fake.UUID().V4(): makeRandomOCIListener(),
 				},
 				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
-					fake.UUID().V4():  makeRandomOCIRoutingPolicy(),
-					routingPolicyName: makeRandomOCIRoutingPolicy(),
-					fake.UUID().V4():  makeRandomOCIRoutingPolicy(),
+					fake.UUID().V4(): makeRandomOCIRoutingPolicy(),
+					routingPolicyName: {
+						Name:                     new(routingPolicyName),
+						ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+						Rules: []loadbalancer.RoutingRule{
+							defaultCatchAllRoutingRule(defaultBackendSetName),
+						},
+					},
+					fake.UUID().V4(): makeRandomOCIRoutingPolicy(),
 				},
-				defaultBackendSetName: fake.UUID().V4(),
+				defaultBackendSetName: defaultBackendSetName,
 				listenerSpec:          &gwListener,
 			}
 
@@ -1037,6 +1174,245 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			err := model.reconcileHTTPListener(t.Context(), params)
 			require.NoError(t, err)
 			ociLoadBalancerClient.AssertNotCalled(t, "CreateRoutingPolicy")
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
+		})
+
+		t.Run("fails when created listener has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
+			params := reconcileHTTPListenerParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
+				},
+				defaultBackendSetName: defaultBackendSetName,
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			ociLoadBalancerClient.EXPECT().
+				CreateListener(t.Context(), mock.Anything).
+				Return(loadbalancer.CreateListenerResponse{}, nil)
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
+		})
+
+		t.Run("fails when created routing policy has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+
+			params := reconcileHTTPListenerParams{
+				loadBalancerID:        fake.UUID().V4(),
+				knownRoutingPolicies:  map[string]loadbalancer.RoutingPolicy{},
+				defaultBackendSetName: fake.UUID().V4(),
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			ociLoadBalancerClient.EXPECT().
+				CreateRoutingPolicy(t.Context(), mock.Anything).
+				Return(loadbalancer.CreateRoutingPolicyResponse{}, nil)
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
+			ociLoadBalancerClient.AssertNotCalled(t, "CreateListener")
+		})
+
+		t.Run("updates routing policy default rule drift", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
+			existingRule := defaultCatchAllRoutingRule("wrong-" + fake.UUID().V4())
+			extraRule := loadbalancer.RoutingRule{
+				Name:      new("r" + fake.Lorem().Word()),
+				Condition: new("any(http.request.url.path sw '/api')"),
+				Actions: []loadbalancer.Action{
+					loadbalancer.ForwardToBackendSet{BackendSetName: new("api-" + fake.UUID().V4())},
+				},
+			}
+			existingPolicy := loadbalancer.RoutingPolicy{
+				Name:                     new(routingPolicyName),
+				ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+				Rules:                    []loadbalancer.RoutingRule{extraRule, existingRule},
+			}
+
+			params := reconcileHTTPListenerParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					routingPolicyName: existingPolicy,
+				},
+				defaultBackendSetName: defaultBackendSetName,
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			policyWorkRequestID := fake.UUID().V4()
+			listenerWorkRequestID := fake.UUID().V4()
+
+			ociLoadBalancerClient.EXPECT().UpdateRoutingPolicy(
+				t.Context(),
+				mock.MatchedBy(func(req loadbalancer.UpdateRoutingPolicyRequest) bool {
+					return assert.Equal(t, params.loadBalancerID, *req.LoadBalancerId) &&
+						assert.Equal(t, routingPolicyName, *req.RoutingPolicyName) &&
+						assert.ElementsMatch(
+							t,
+							[]loadbalancer.RoutingRule{
+								extraRule,
+								defaultCatchAllRoutingRule(defaultBackendSetName),
+							},
+							req.UpdateRoutingPolicyDetails.Rules,
+						)
+				}),
+			).Return(loadbalancer.UpdateRoutingPolicyResponse{
+				OpcWorkRequestId: &policyWorkRequestID,
+			}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), policyWorkRequestID).Return(nil).Once()
+
+			ociLoadBalancerClient.EXPECT().CreateListener(t.Context(), loadbalancer.CreateListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				CreateListenerDetails: loadbalancer.CreateListenerDetails{
+					Name:                  new(string(gwListener.Name)),
+					Port:                  new(int(gwListener.Port)),
+					Protocol:              new("HTTP"),
+					DefaultBackendSetName: new(params.defaultBackendSetName),
+					RoutingPolicyName:     new(routingPolicyName),
+				},
+			}).Return(loadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: &listenerWorkRequestID,
+			}, nil)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), listenerWorkRequestID).Return(nil).Once()
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("restores missing routing policy default rule", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
+			extraRule := loadbalancer.RoutingRule{
+				Name:      new("r" + fake.Lorem().Word()),
+				Condition: new("any(http.request.url.path sw '/api')"),
+				Actions: []loadbalancer.Action{
+					loadbalancer.ForwardToBackendSet{BackendSetName: new("api-" + fake.UUID().V4())},
+				},
+			}
+			existingPolicy := loadbalancer.RoutingPolicy{
+				Name:                     new(routingPolicyName),
+				ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+				Rules:                    []loadbalancer.RoutingRule{extraRule},
+			}
+
+			params := reconcileHTTPListenerParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					routingPolicyName: existingPolicy,
+				},
+				defaultBackendSetName: defaultBackendSetName,
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			policyWorkRequestID := fake.UUID().V4()
+			listenerWorkRequestID := fake.UUID().V4()
+
+			ociLoadBalancerClient.EXPECT().UpdateRoutingPolicy(
+				t.Context(),
+				mock.MatchedBy(func(req loadbalancer.UpdateRoutingPolicyRequest) bool {
+					return assert.ElementsMatch(
+						t,
+						[]loadbalancer.RoutingRule{
+							extraRule,
+							defaultCatchAllRoutingRule(defaultBackendSetName),
+						},
+						req.UpdateRoutingPolicyDetails.Rules,
+					)
+				}),
+			).Return(loadbalancer.UpdateRoutingPolicyResponse{
+				OpcWorkRequestId: &policyWorkRequestID,
+			}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), policyWorkRequestID).Return(nil).Once()
+
+			ociLoadBalancerClient.EXPECT().CreateListener(t.Context(), loadbalancer.CreateListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				CreateListenerDetails: loadbalancer.CreateListenerDetails{
+					Name:                  new(string(gwListener.Name)),
+					Port:                  new(int(gwListener.Port)),
+					Protocol:              new("HTTP"),
+					DefaultBackendSetName: new(params.defaultBackendSetName),
+					RoutingPolicyName:     new(routingPolicyName),
+				},
+			}).Return(loadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: &listenerWorkRequestID,
+			}, nil)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), listenerWorkRequestID).Return(nil).Once()
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("fails when routing policy default rule update has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			existingPolicy := loadbalancer.RoutingPolicy{
+				Name:                     new(routingPolicyName),
+				ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+				Rules:                    []loadbalancer.RoutingRule{defaultCatchAllRoutingRule(fake.UUID().V4())},
+			}
+			params := reconcileHTTPListenerParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					routingPolicyName: existingPolicy,
+				},
+				defaultBackendSetName: fake.UUID().V4(),
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			ociLoadBalancerClient.EXPECT().
+				UpdateRoutingPolicy(t.Context(), mock.Anything).
+				Return(loadbalancer.UpdateRoutingPolicyResponse{}, nil)
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
+			ociLoadBalancerClient.AssertNotCalled(t, "CreateListener")
 		})
 
 		t.Run("when create routing policy fails", func(t *testing.T) {
@@ -1296,6 +1672,11 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			wantBsName := ociBackendSetNameFromService(service)
 			exitingBs := makeRandomOCIBackendSet(func(bs *loadbalancer.BackendSet) {
 				bs.Name = new(wantBsName)
+				bs.Policy = new("ROUND_ROBIN")
+				bs.HealthChecker = &loadbalancer.HealthChecker{
+					Protocol: new("TCP"),
+					Port:     new(service.Spec.Ports[0].TargetPort.IntValue()),
+				}
 			})
 
 			params := reconcileBackendSetParams{
@@ -1313,6 +1694,50 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}, nil)
 
 			err := model.reconcileBackendSet(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("updates backend set config drift", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+
+			service := makeRandomService()
+			wantBsName := ociBackendSetNameFromService(service)
+			existingBs := makeRandomOCIBackendSet(randomOCIBackendSetWithNameOpt(wantBsName))
+
+			params := reconcileBackendSetParams{
+				loadBalancerID: fake.UUID().V4(),
+				service:        service,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			workRequestID := fake.UUID().V4()
+
+			ociLoadBalancerClient.EXPECT().GetBackendSet(t.Context(), loadbalancer.GetBackendSetRequest{
+				BackendSetName: &wantBsName,
+				LoadBalancerId: &params.loadBalancerID,
+			}).Return(loadbalancer.GetBackendSetResponse{
+				BackendSet: existingBs,
+			}, nil).Once()
+
+			ociLoadBalancerClient.EXPECT().UpdateBackendSet(
+				t.Context(),
+				mock.MatchedBy(func(req loadbalancer.UpdateBackendSetRequest) bool {
+					return assert.Equal(t, params.loadBalancerID, *req.LoadBalancerId) &&
+						assert.Equal(t, wantBsName, *req.BackendSetName) &&
+						assert.Equal(t, "ROUND_ROBIN", *req.Policy) &&
+						assert.Equal(t, "TCP", *req.HealthChecker.Protocol) &&
+						assert.Equal(t, service.Spec.Ports[0].TargetPort.IntValue(), *req.HealthChecker.Port)
+				}),
+			).Return(loadbalancer.UpdateBackendSetResponse{
+				OpcWorkRequestId: &workRequestID,
+			}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			err := model.reconcileBackendSet(t.Context(), params)
+
 			require.NoError(t, err)
 		})
 
@@ -1396,6 +1821,42 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			err := model.reconcileBackendSet(t.Context(), params)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("fails when create backend set has no work request id", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			service := makeRandomService()
+			wantBsName := ociBackendSetNameFromService(service)
+			params := reconcileBackendSetParams{
+				loadBalancerID: faker.New().UUID().V4(),
+				service:        service,
+			}
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			ociLoadBalancerClient.EXPECT().GetBackendSet(t.Context(), loadbalancer.GetBackendSetRequest{
+				BackendSetName: &wantBsName,
+				LoadBalancerId: &params.loadBalancerID,
+			}).Return(
+				loadbalancer.GetBackendSetResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(404)),
+			).Once()
+
+			ociLoadBalancerClient.EXPECT().CreateBackendSet(t.Context(), loadbalancer.CreateBackendSetRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
+					Name: &wantBsName,
+					HealthChecker: &loadbalancer.HealthCheckerDetails{
+						Protocol: new("TCP"),
+						Port:     new(service.Spec.Ports[0].TargetPort.IntValue()),
+					},
+					Policy: new("ROUND_ROBIN"),
+				},
+			}).Return(loadbalancer.CreateBackendSetResponse{}, nil).Once()
+
+			err := model.reconcileBackendSet(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
 		})
 
 		t.Run("fails when create backend set wait fails", func(t *testing.T) {
@@ -1657,6 +2118,31 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			assert.ErrorIs(t, err, wantErr)
 		})
 
+		t.Run("fails when listener delete has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			lbListenerToRemove := makeRandomOCIListener()
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					*lbListenerToRemove.Name: lbListenerToRemove,
+				},
+				gatewayListeners: []gatewayv1.Listener{},
+			}
+
+			ociLoadBalancerClient.EXPECT().DeleteListener(t.Context(), loadbalancer.DeleteListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				ListenerName:   lbListenerToRemove.Name,
+			}).Return(loadbalancer.DeleteListenerResponse{}, nil).Once()
+
+			err := model.removeMissingListeners(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
+		})
+
 		t.Run("continues deleting even if one fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -1778,6 +2264,39 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			err := model.removeMissingListeners(t.Context(), params)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("fails when routing policy delete has no work request id", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			lbListenerToRemove := makeRandomOCIListener(func(l *loadbalancer.Listener) {
+				l.RoutingPolicyName = new(listenerPolicyName(lo.FromPtr(l.Name)))
+			})
+
+			params := removeMissingListenersParams{
+				loadBalancerID: faker.New().UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					*lbListenerToRemove.Name: lbListenerToRemove,
+				},
+				gatewayListeners: []gatewayv1.Listener{},
+			}
+
+			deleteListenerRequestID := faker.New().UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteListener(t.Context(), loadbalancer.DeleteListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				ListenerName:   lbListenerToRemove.Name,
+			}).Return(loadbalancer.DeleteListenerResponse{OpcWorkRequestId: &deleteListenerRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), deleteListenerRequestID).Return(nil).Once()
+			ociLoadBalancerClient.EXPECT().DeleteRoutingPolicy(t.Context(), loadbalancer.DeleteRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: lbListenerToRemove.RoutingPolicyName,
+			}).Return(loadbalancer.DeleteRoutingPolicyResponse{}, nil).Once()
+
+			err := model.removeMissingListeners(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
 		})
 	})
 
@@ -2137,6 +2656,42 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("skips update when routing policy already matches desired rules", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			listenerName := fake.UUID().V4()
+			policyName := listenerPolicyName(listenerName)
+			defaultRule := defaultCatchAllRoutingRule("default-" + fake.Lorem().Word())
+			firstRule := makeRandomOCIRoutingRule()
+			firstRule.Name = new("first-" + fake.Lorem().Word())
+			secondRule := makeRandomOCIRoutingRule()
+			secondRule.Name = new("second-" + fake.Lorem().Word())
+			existingRules := []loadbalancer.RoutingRule{firstRule, secondRule, defaultRule}
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				RoutingPolicyName: new(policyName),
+				LoadBalancerId:    &loadBalancerID,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: loadbalancer.RoutingPolicy{
+					Name:                     new(policyName),
+					Rules:                    existingRules,
+					ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+				},
+			}, nil)
+
+			err := model.commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID: loadBalancerID,
+				listenerName:   listenerName,
+				policyRules:    []loadbalancer.RoutingRule{secondRule, firstRule},
+			})
+			require.NoError(t, err)
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
+		})
+
 		t.Run("fail when get routing policy fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -2208,6 +2763,39 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			err := model.commitRoutingPolicy(t.Context(), params)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("fail when update routing policy has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			listenerName := fake.UUID().V4()
+			policyName := listenerPolicyName(listenerName)
+			existingPolicy := makeRandomOCIRoutingPolicy(
+				func(policy *loadbalancer.RoutingPolicy) {
+					policy.Name = new(policyName)
+				},
+			)
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				RoutingPolicyName: new(policyName),
+				LoadBalancerId:    &loadBalancerID,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: existingPolicy,
+			}, nil)
+			ociLoadBalancerClient.EXPECT().UpdateRoutingPolicy(t.Context(), mock.Anything).
+				Return(loadbalancer.UpdateRoutingPolicyResponse{}, nil)
+
+			err := model.commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID: loadBalancerID,
+				listenerName:   listenerName,
+				policyRules:    []loadbalancer.RoutingRule{makeRandomOCIRoutingRule()},
+			})
+
+			require.ErrorContains(t, err, "missing work request id")
 		})
 
 		t.Run("fail when wait for update fails", func(t *testing.T) {
@@ -2354,6 +2942,33 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			assert.ErrorIs(t, err, wantErr)
 		})
 
+		t.Run("returns error if delete backend set has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			httpRoute := makeRandomHTTPRoute()
+			backendRef := makeRandomBackendRef()
+			backendSetName := ociBackendSetNameFromBackendRef(httpRoute, backendRef)
+
+			params := deprovisionBackendSetParams{
+				loadBalancerID: loadBalancerID,
+				httpRoute:      httpRoute,
+				backendRef:     backendRef,
+			}
+
+			ociLoadBalancerClient.EXPECT().DeleteBackendSet(t.Context(), loadbalancer.DeleteBackendSetRequest{
+				LoadBalancerId: &loadBalancerID,
+				BackendSetName: &backendSetName,
+			}).Return(loadbalancer.DeleteBackendSetResponse{}, nil).Once()
+
+			err := model.deprovisionBackendSet(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
+		})
+
 		t.Run("succeeds if backend set does not exist (404 on delete)", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -2416,6 +3031,13 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 	})
 
 	t.Run("removeUnusedCertificates", func(t *testing.T) {
+		makeManagedCertificate := func(namespace, name, resourceVersion string) loadbalancer.Certificate {
+			certName := fmt.Sprintf("%s-%s-rev-%s", namespace, name, resourceVersion)
+			cert := makeRandomOCICertificate()
+			cert.CertificateName = new(certName)
+			return cert
+		}
+
 		t.Run("no certificates to remove", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -2458,8 +3080,8 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			// Create certificates, some used and some unused
 			usedCert1 := makeRandomOCICertificate()
 			usedCert2 := makeRandomOCICertificate()
-			unusedCert1 := makeRandomOCICertificate()
-			unusedCert2 := makeRandomOCICertificate()
+			unusedCert1 := makeManagedCertificate("default", "unused-one", fake.UUID().V4())
+			unusedCert2 := makeManagedCertificate("default", "unused-two", fake.UUID().V4())
 
 			knownCertificates := map[string]loadbalancer.Certificate{
 				*usedCert1.CertificateName:   usedCert1,
@@ -2503,6 +3125,60 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("preserves unused certificates not created by the controller", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			usedCert := makeRandomOCICertificate()
+			externalUnusedCert := makeRandomOCICertificate()
+
+			err := model.removeUnusedCertificates(t.Context(), removeUnusedCertificatesParams{
+				loadBalancerID: fake.UUID().V4(),
+				listenerCertificates: map[string][]loadbalancer.Certificate{
+					"listener1": {usedCert},
+				},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					lo.FromPtr(usedCert.CertificateName):           usedCert,
+					lo.FromPtr(externalUnusedCert.CertificateName): externalUnusedCert,
+				},
+			})
+
+			require.NoError(t, err)
+			ociLoadBalancerClient.AssertNotCalled(t, "DeleteCertificate")
+		})
+
+		t.Run("continues when certificate delete has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			usedCert := makeRandomOCICertificate()
+			unusedCert := makeManagedCertificate("default", "unused", fake.UUID().V4())
+
+			params := removeUnusedCertificatesParams{
+				loadBalancerID: fake.UUID().V4(),
+				listenerCertificates: map[string][]loadbalancer.Certificate{
+					"listener1": {usedCert},
+				},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					*usedCert.CertificateName:   usedCert,
+					*unusedCert.CertificateName: unusedCert,
+				},
+			}
+
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: unusedCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{}, nil).Once()
+
+			err := model.removeUnusedCertificates(t.Context(), params)
+
+			require.NoError(t, err)
+		})
+
 		t.Run("continues deletion even if one fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -2512,8 +3188,8 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			// Create certificates, some used and some unused
 			usedCert := makeRandomOCICertificate()
-			unusedCert1 := makeRandomOCICertificate() // This one will fail
-			unusedCert2 := makeRandomOCICertificate() // This one will succeed
+			unusedCert1 := makeManagedCertificate("default", "unused-one", fake.UUID().V4()) // This one will fail
+			unusedCert2 := makeManagedCertificate("default", "unused-two", fake.UUID().V4()) // This one will succeed
 
 			knownCertificates := map[string]loadbalancer.Certificate{
 				*usedCert.CertificateName:    usedCert,
@@ -2533,19 +3209,27 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			// First certificate deletion fails
 			wantErr := errors.New(fake.Lorem().Sentence(10))
-			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
-				LoadBalancerId:  &params.loadBalancerID,
-				CertificateName: unusedCert1.CertificateName,
-			}).Return(loadbalancer.DeleteCertificateResponse{}, wantErr).Once()
-
-			// Second certificate deletion succeeds
 			workRequestID := fake.UUID().V4()
-			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
-				LoadBalancerId:  &params.loadBalancerID,
-				CertificateName: unusedCert2.CertificateName,
-			}).Return(loadbalancer.DeleteCertificateResponse{
-				OpcWorkRequestId: &workRequestID,
-			}, nil).Once()
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(
+				t.Context(),
+				mock.MatchedBy(func(req loadbalancer.DeleteCertificateRequest) bool {
+					return assert.Equal(t, params.loadBalancerID, *req.LoadBalancerId) &&
+						(lo.FromPtr(req.CertificateName) == lo.FromPtr(unusedCert1.CertificateName) ||
+							lo.FromPtr(req.CertificateName) == lo.FromPtr(unusedCert2.CertificateName))
+				}),
+			).RunAndReturn(
+				func(
+					_ context.Context,
+					req loadbalancer.DeleteCertificateRequest,
+				) (loadbalancer.DeleteCertificateResponse, error) {
+					if lo.FromPtr(req.CertificateName) == lo.FromPtr(unusedCert1.CertificateName) {
+						return loadbalancer.DeleteCertificateResponse{}, wantErr
+					}
+					return loadbalancer.DeleteCertificateResponse{
+						OpcWorkRequestId: &workRequestID,
+					}, nil
+				},
+			).Twice()
 			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
 
 			err := model.removeUnusedCertificates(t.Context(), params)
@@ -2561,7 +3245,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			// Create certificates, some used and some unused
 			usedCert := makeRandomOCICertificate()
-			unusedCert := makeRandomOCICertificate()
+			unusedCert := makeManagedCertificate("default", "unused", fake.UUID().V4())
 
 			knownCertificates := map[string]loadbalancer.Certificate{
 				*usedCert.CertificateName:   usedCert,
@@ -3022,7 +3706,13 @@ func TestOciLoadBalancerModelOCICertificateIDs(t *testing.T) {
 				},
 			},
 			knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
-				"https_policy": {},
+				"https_policy": {
+					Name:                     new("https_policy"),
+					ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+					Rules: []loadbalancer.RoutingRule{
+						defaultCatchAllRoutingRule("default"),
+					},
+				},
 			},
 			listenerCertificateID: "ocid1.certificate.oc1..test",
 			defaultBackendSetName: "default",
@@ -3078,7 +3768,13 @@ func TestOciLoadBalancerModelOCICertificateIDs(t *testing.T) {
 				},
 			},
 			knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
-				"https_policy": {},
+				"https_policy": {
+					Name:                     new("https_policy"),
+					ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+					Rules: []loadbalancer.RoutingRule{
+						defaultCatchAllRoutingRule("default"),
+					},
+				},
 			},
 			listenerCertificateID: "ocid1.certificate.oc1..test",
 			defaultBackendSetName: "default",
@@ -3615,6 +4311,36 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 				randomListenerWithHTTPProtocolOpt(),
 			)
 			defaultBackendSetName := fake.UUID().V4()
+
+			return testCase{
+				name: "protocol change",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("TCP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+				},
+				want: loadbalancer.UpdateListenerDetails{
+					Protocol:              new("HTTP"),
+					Port:                  new(int(listenerSpec.Port)),
+					DefaultBackendSetName: new(defaultBackendSetName),
+					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+				},
+				wantOk: true,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
 			newDefaultBackendSetName := fake.UUID().V4()
 
 			return testCase{
@@ -3634,6 +4360,36 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 					Protocol:              new("HTTP"),
 					Port:                  new(int(listenerSpec.Port)),
 					DefaultBackendSetName: new(newDefaultBackendSetName),
+					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+				},
+				wantOk: true,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+
+			return testCase{
+				name: "routing policy name change",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new("wrong-" + listenerPolicyName(listenerName)),
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+				},
+				want: loadbalancer.UpdateListenerDetails{
+					Protocol:              new("HTTP"),
+					Port:                  new(int(listenerSpec.Port)),
+					DefaultBackendSetName: new(defaultBackendSetName),
 					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
 				},
 				wantOk: true,

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -119,7 +119,10 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			actualBackendSet, err := model.reconcileDefaultBackendSet(t.Context(), params)
 
 			require.NoError(t, err)
-			assert.Equal(t, existingBackendSet, actualBackendSet)
+			assert.Equal(t, "ROUND_ROBIN", lo.FromPtr(actualBackendSet.Policy))
+			require.NotNil(t, actualBackendSet.HealthChecker)
+			assert.Equal(t, "TCP", lo.FromPtr(actualBackendSet.HealthChecker.Protocol))
+			assert.Equal(t, defaultBackendSetPort, lo.FromPtr(actualBackendSet.HealthChecker.Port))
 		})
 
 		t.Run("when backend set does not exist", func(t *testing.T) {
@@ -2670,7 +2673,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			firstRule.Name = new("first-" + fake.Lorem().Word())
 			secondRule := makeRandomOCIRoutingRule()
 			secondRule.Name = new("second-" + fake.Lorem().Word())
-			existingRules := []loadbalancer.RoutingRule{firstRule, secondRule, defaultRule}
+			existingRules := []loadbalancer.RoutingRule{defaultRule, secondRule, firstRule}
 
 			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
 				RoutingPolicyName: new(policyName),
@@ -3061,9 +3064,14 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			params := removeUnusedCertificatesParams{
-				loadBalancerID:       fake.UUID().V4(),
-				listenerCertificates: listenerCertificates,
-				knownCertificates:    knownCertificates,
+				loadBalancerID: fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(cert1.CertificateName),
+					lo.FromPtr(cert2.CertificateName),
+					lo.FromPtr(cert3.CertificateName),
+				},
+				desiredCertificates: certificateNamesFromListenerCertificates(listenerCertificates),
+				knownCertificates:   knownCertificates,
 			}
 
 			err := model.removeUnusedCertificates(t.Context(), params)
@@ -3097,9 +3105,15 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			params := removeUnusedCertificatesParams{
-				loadBalancerID:       fake.UUID().V4(),
-				listenerCertificates: listenerCertificates,
-				knownCertificates:    knownCertificates,
+				loadBalancerID: fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(usedCert1.CertificateName),
+					lo.FromPtr(usedCert2.CertificateName),
+					lo.FromPtr(unusedCert1.CertificateName),
+					lo.FromPtr(unusedCert2.CertificateName),
+				},
+				desiredCertificates: certificateNamesFromListenerCertificates(listenerCertificates),
+				knownCertificates:   knownCertificates,
 			}
 
 			// Expect deletion of unused certificates
@@ -3125,7 +3139,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run("preserves unused certificates not created by the controller", func(t *testing.T) {
+		t.Run("preserves unused certificates not previously programmed by the controller", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
@@ -3133,15 +3147,18 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			usedCert := makeRandomOCICertificate()
 			externalUnusedCert := makeRandomOCICertificate()
+			externalUnusedCertWithRev := makeRandomOCICertificate()
+			externalUnusedCertWithRev.CertificateName = new("external-rev-certificate")
 
 			err := model.removeUnusedCertificates(t.Context(), removeUnusedCertificatesParams{
 				loadBalancerID: fake.UUID().V4(),
-				listenerCertificates: map[string][]loadbalancer.Certificate{
+				desiredCertificates: certificateNamesFromListenerCertificates(map[string][]loadbalancer.Certificate{
 					"listener1": {usedCert},
-				},
+				}),
 				knownCertificates: map[string]loadbalancer.Certificate{
-					lo.FromPtr(usedCert.CertificateName):           usedCert,
-					lo.FromPtr(externalUnusedCert.CertificateName): externalUnusedCert,
+					lo.FromPtr(usedCert.CertificateName):                  usedCert,
+					lo.FromPtr(externalUnusedCert.CertificateName):        externalUnusedCert,
+					lo.FromPtr(externalUnusedCertWithRev.CertificateName): externalUnusedCertWithRev,
 				},
 			})
 
@@ -3160,9 +3177,13 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			params := removeUnusedCertificatesParams{
 				loadBalancerID: fake.UUID().V4(),
-				listenerCertificates: map[string][]loadbalancer.Certificate{
-					"listener1": {usedCert},
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(usedCert.CertificateName),
+					lo.FromPtr(unusedCert.CertificateName),
 				},
+				desiredCertificates: certificateNamesFromListenerCertificates(map[string][]loadbalancer.Certificate{
+					"listener1": {usedCert},
+				}),
 				knownCertificates: map[string]loadbalancer.Certificate{
 					*usedCert.CertificateName:   usedCert,
 					*unusedCert.CertificateName: unusedCert,
@@ -3202,9 +3223,14 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			params := removeUnusedCertificatesParams{
-				loadBalancerID:       fake.UUID().V4(),
-				listenerCertificates: listenerCertificates,
-				knownCertificates:    knownCertificates,
+				loadBalancerID: fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(usedCert.CertificateName),
+					lo.FromPtr(unusedCert1.CertificateName),
+					lo.FromPtr(unusedCert2.CertificateName),
+				},
+				desiredCertificates: certificateNamesFromListenerCertificates(listenerCertificates),
+				knownCertificates:   knownCertificates,
 			}
 
 			// First certificate deletion fails
@@ -3257,9 +3283,13 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			params := removeUnusedCertificatesParams{
-				loadBalancerID:       fake.UUID().V4(),
-				listenerCertificates: listenerCertificates,
-				knownCertificates:    knownCertificates,
+				loadBalancerID: fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(usedCert.CertificateName),
+					lo.FromPtr(unusedCert.CertificateName),
+				},
+				desiredCertificates: certificateNamesFromListenerCertificates(listenerCertificates),
+				knownCertificates:   knownCertificates,
 			}
 
 			workRequestID := fake.UUID().V4()

--- a/internal/app/ports.go
+++ b/internal/app/ports.go
@@ -81,6 +81,12 @@ type workRequestsWatcher interface {
 	WaitFor(ctx context.Context, workRequestID string) error
 }
 
+type noopWorkRequestsWatcher struct{}
+
+func (noopWorkRequestsWatcher) WaitFor(context.Context, string) error {
+	return nil
+}
+
 // ociNetworkLoadBalancerClient defines the interface for OCI Network Load Balancer operations.
 type ociNetworkLoadBalancerClient interface {
 	GetNetworkLoadBalancer(ctx context.Context, request networkloadbalancer.GetNetworkLoadBalancerRequest) (

--- a/internal/app/tcproute_controller.go
+++ b/internal/app/tcproute_controller.go
@@ -25,7 +25,7 @@ type TCPRouteControllerDeps struct {
 
 	RootLogger    *slog.Logger
 	TCPRouteModel tcpRouteModel
-	DriftInterval time.Duration `name:"config.reconcile.driftInterval"`
+	DriftInterval time.Duration `name:"config.reconcile.drift-interval"`
 }
 
 func NewTCPRouteController(deps TCPRouteControllerDeps) *TCPRouteController {

--- a/internal/app/tcproute_controller.go
+++ b/internal/app/tcproute_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.uber.org/dig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,6 +17,7 @@ import (
 type TCPRouteController struct {
 	logger        *slog.Logger
 	tcpRouteModel tcpRouteModel
+	driftInterval time.Duration
 }
 
 type TCPRouteControllerDeps struct {
@@ -23,12 +25,14 @@ type TCPRouteControllerDeps struct {
 
 	RootLogger    *slog.Logger
 	TCPRouteModel tcpRouteModel
+	DriftInterval time.Duration `name:"config.reconcile.driftInterval"`
 }
 
 func NewTCPRouteController(deps TCPRouteControllerDeps) *TCPRouteController {
 	return &TCPRouteController{
 		logger:        deps.RootLogger.WithGroup("tcproute-controller"),
 		tcpRouteModel: deps.TCPRouteModel,
+		driftInterval: deps.DriftInterval,
 	}
 }
 
@@ -44,6 +48,7 @@ func (r *TCPRouteController) Reconcile(ctx context.Context, req reconcile.Reques
 		deprovision:   r.tcpRouteModel.deprovisionRoute,
 		program:       r.tcpRouteModel.programRoute,
 		setProgrammed: r.tcpRouteModel.setProgrammed,
+		driftInterval: r.driftInterval,
 		setRejected: func(details resolvedTCPRouteDetails, err error) (bool, error) {
 			var statusErr tcpRouteStatusError
 			if errors.As(err, &statusErr) {
@@ -65,6 +70,7 @@ type reconcileL4RouteParams[D any] struct {
 	deprovision   func(context.Context, D) error
 	program       func(context.Context, D) error
 	setProgrammed func(context.Context, D) error
+	driftInterval time.Duration
 	setRejected   func(D, error) (bool, error)
 }
 
@@ -99,7 +105,7 @@ func reconcileL4Route[D any](ctx context.Context, params reconcileL4RouteParams[
 		}
 	}
 
-	return reconcile.Result{}, nil
+	return driftRequeue(params.driftInterval), nil
 }
 
 func reconcileResolvedL4Route[D any](

--- a/internal/app/tcproute_model.go
+++ b/internal/app/tcproute_model.go
@@ -1377,12 +1377,16 @@ func newTCPRouteModel(deps tcpRouteModelDeps) *tcpRouteModelImpl {
 	if operationLocks == nil {
 		operationLocks = newNetworkLoadBalancerOperationLocks()
 	}
+	watcher := deps.WorkRequestsWatcher
+	if watcher == nil {
+		watcher = noopWorkRequestsWatcher{}
+	}
 	return &tcpRouteModelImpl{
 		client:                    deps.K8sClient,
 		logger:                    deps.RootLogger.WithGroup("tcproute-model"),
 		networkLoadBalancerModel:  deps.NetworkLoadBalancerModel,
 		ociNetworkLoadBalancerAPI: deps.OciNetworkLoadBalancerAPI,
-		workRequestsWatcher:       deps.WorkRequestsWatcher,
+		workRequestsWatcher:       watcher,
 		operationLocks:            operationLocks,
 	}
 }

--- a/internal/app/tcproute_model_test.go
+++ b/internal/app/tcproute_model_test.go
@@ -1299,6 +1299,10 @@ func TestTCPRouteModel(t *testing.T) {
 				client: &stubNetworkLoadBalancerClient{updateBackendSetErr: errors.New("update failed")},
 				err:    "failed to update Network Load Balancer backend set",
 			},
+			"missing work request": {
+				client: &stubNetworkLoadBalancerClient{omitUpdateBackendSetWorkRequest: true},
+				err:    "missing work request id",
+			},
 			"wait": {
 				client: &stubNetworkLoadBalancerClient{
 					updateBackendSetResponse: networkloadbalancer.UpdateBackendSetResponse{
@@ -1588,6 +1592,21 @@ func TestTCPRouteModel(t *testing.T) {
 		modelImpl = mustTCPRouteModelImpl(t, model)
 		err = modelImpl.clearBackendSetByName(t.Context(), resolvedGatewayDetails{}, "iot/rtmp", "bs_rtmp", nil)
 		require.ErrorContains(t, err, "failed waiting for backend set bs_rtmp clear")
+
+		model = newTCPRouteModel(tcpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{"bs_rtmp": {Name: new("bs_rtmp")}},
+				},
+			},
+			OciNetworkLoadBalancerAPI: &stubNetworkLoadBalancerClient{omitUpdateBackendSetWorkRequest: true},
+			WorkRequestsWatcher:       &stubWorkRequestsWatcher{},
+		})
+		modelImpl = mustTCPRouteModelImpl(t, model)
+		err = modelImpl.clearBackendSetByName(t.Context(), resolvedGatewayDetails{}, "iot/rtmp", "bs_rtmp", nil)
+		require.ErrorContains(t, err, "missing work request id")
 
 		model = newTCPRouteModel(tcpRouteModelDeps{
 			RootLogger: diag.RootTestLogger(),

--- a/internal/app/udproute_controller.go
+++ b/internal/app/udproute_controller.go
@@ -23,7 +23,7 @@ type UDPRouteControllerDeps struct {
 
 	RootLogger    *slog.Logger
 	UDPRouteModel udpRouteModel
-	DriftInterval time.Duration `name:"config.reconcile.driftInterval"`
+	DriftInterval time.Duration `name:"config.reconcile.drift-interval"`
 }
 
 func NewUDPRouteController(deps UDPRouteControllerDeps) *UDPRouteController {

--- a/internal/app/udproute_controller.go
+++ b/internal/app/udproute_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"go.uber.org/dig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,6 +15,7 @@ import (
 type UDPRouteController struct {
 	logger        *slog.Logger
 	udpRouteModel udpRouteModel
+	driftInterval time.Duration
 }
 
 type UDPRouteControllerDeps struct {
@@ -21,12 +23,14 @@ type UDPRouteControllerDeps struct {
 
 	RootLogger    *slog.Logger
 	UDPRouteModel udpRouteModel
+	DriftInterval time.Duration `name:"config.reconcile.driftInterval"`
 }
 
 func NewUDPRouteController(deps UDPRouteControllerDeps) *UDPRouteController {
 	return &UDPRouteController{
 		logger:        deps.RootLogger.WithGroup("udproute-controller"),
 		udpRouteModel: deps.UDPRouteModel,
+		driftInterval: deps.DriftInterval,
 	}
 }
 
@@ -42,6 +46,7 @@ func (r *UDPRouteController) Reconcile(ctx context.Context, req reconcile.Reques
 		deprovision:   r.udpRouteModel.deprovisionRoute,
 		program:       r.udpRouteModel.programRoute,
 		setProgrammed: r.udpRouteModel.setProgrammed,
+		driftInterval: r.driftInterval,
 		setRejected: func(details resolvedUDPRouteDetails, err error) (bool, error) {
 			var statusErr udpRouteStatusError
 			if errors.As(err, &statusErr) {

--- a/internal/app/udproute_model.go
+++ b/internal/app/udproute_model.go
@@ -829,12 +829,16 @@ func newUDPRouteModel(deps udpRouteModelDeps) *udpRouteModelImpl {
 	if operationLocks == nil {
 		operationLocks = newNetworkLoadBalancerOperationLocks()
 	}
+	watcher := deps.WorkRequestsWatcher
+	if watcher == nil {
+		watcher = noopWorkRequestsWatcher{}
+	}
 	return &udpRouteModelImpl{
 		client:                    deps.K8sClient,
 		logger:                    deps.RootLogger.WithGroup("udproute-model"),
 		networkLoadBalancerModel:  deps.NetworkLoadBalancerModel,
 		ociNetworkLoadBalancerAPI: deps.OciNetworkLoadBalancerAPI,
-		workRequestsWatcher:       deps.WorkRequestsWatcher,
+		workRequestsWatcher:       watcher,
 		operationLocks:            operationLocks,
 	}
 }

--- a/internal/app/udproute_model_test.go
+++ b/internal/app/udproute_model_test.go
@@ -1254,6 +1254,10 @@ func TestUDPRouteModel(t *testing.T) {
 				client: &stubNetworkLoadBalancerClient{updateBackendSetErr: errors.New("update failed")},
 				err:    "failed to update Network Load Balancer backend set",
 			},
+			"missing work request": {
+				client: &stubNetworkLoadBalancerClient{omitUpdateBackendSetWorkRequest: true},
+				err:    "missing work request id",
+			},
 			"wait": {
 				client: &stubNetworkLoadBalancerClient{
 					updateBackendSetResponse: networkloadbalancer.UpdateBackendSetResponse{
@@ -1669,6 +1673,21 @@ func TestUDPRouteModel(t *testing.T) {
 		modelImpl = mustUDPRouteModelImpl(t, model)
 		err = modelImpl.clearBackendSetByName(t.Context(), resolvedGatewayDetails{}, "iot/coap", "bs_coap", nil)
 		require.ErrorContains(t, err, "failed waiting for backend set bs_coap clear")
+
+		model = newUDPRouteModel(udpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{"bs_coap": {Name: new("bs_coap")}},
+				},
+			},
+			OciNetworkLoadBalancerAPI: &stubNetworkLoadBalancerClient{omitUpdateBackendSetWorkRequest: true},
+			WorkRequestsWatcher:       &stubWorkRequestsWatcher{},
+		})
+		modelImpl = mustUDPRouteModelImpl(t, model)
+		err = modelImpl.clearBackendSetByName(t.Context(), resolvedGatewayDetails{}, "iot/coap", "bs_coap", nil)
+		require.ErrorContains(t, err, "missing work request id")
 
 		model = newUDPRouteModel(udpRouteModelDeps{
 			RootLogger: diag.RootTestLogger(),

--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -688,8 +688,7 @@ func (m *WatchesModel) MapGatewayConfigToGateway(ctx context.Context, obj client
 	requests := make([]reconcile.Request, 0)
 	for _, gateway := range gatewayList.Items {
 		if gateway.DeletionTimestamp != nil ||
-			gateway.Annotations == nil ||
-			gateway.Annotations[ControllerClassName] != "true" ||
+			!gatewayUsesSupportedController(&gateway) ||
 			gateway.Spec.Infrastructure == nil ||
 			gateway.Spec.Infrastructure.ParametersRef == nil ||
 			gateway.Spec.Infrastructure.ParametersRef.Name != config.Name {
@@ -709,6 +708,14 @@ func (m *WatchesModel) MapGatewayConfigToGateway(ctx context.Context, obj client
 	}
 
 	return requests
+}
+
+func gatewayUsesSupportedController(gateway *gatewayv1.Gateway) bool {
+	if gateway.Annotations == nil {
+		return false
+	}
+	return gateway.Annotations[ControllerClassName] == "true" ||
+		gateway.Annotations[NetworkLoadBalancerControllerClassName] == "true"
 }
 
 // MapSecretToGateway maps Secret events to Gateway reconcile requests.

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -1194,6 +1194,36 @@ func TestWatchesModel(t *testing.T) {
 					},
 				},
 				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "iot",
+						Name:      "edge-l4",
+						Annotations: map[string]string{
+							NetworkLoadBalancerControllerClassName: "true",
+						},
+					},
+					Spec: gatewayv1.GatewaySpec{
+						Infrastructure: &gatewayv1.GatewayInfrastructure{
+							ParametersRef: &gatewayv1.LocalParametersReference{
+								Name: "edge-config",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "iot",
+						Name:        "unsupported",
+						Annotations: map[string]string{"example.com/controller": "true"},
+					},
+					Spec: gatewayv1.GatewaySpec{
+						Infrastructure: &gatewayv1.GatewayInfrastructure{
+							ParametersRef: &gatewayv1.LocalParametersReference{
+								Name: "edge-config",
+							},
+						},
+					},
+				},
+				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "other"},
 					Spec: gatewayv1.GatewaySpec{
 						Infrastructure: &gatewayv1.GatewayInfrastructure{
@@ -1231,6 +1261,7 @@ func TestWatchesModel(t *testing.T) {
 
 			require.Equal(t, []reconcile.Request{
 				{NamespacedName: apitypes.NamespacedName{Namespace: "iot", Name: "edge"}},
+				{NamespacedName: apitypes.NamespacedName{Namespace: "iot", Name: "edge-l4"}},
 			}, model.MapGatewayConfigToGateway(t.Context(), config))
 			require.Nil(t, model.MapGatewayConfigToGateway(t.Context(), &corev1.Service{}))
 		})

--- a/internal/config/default.json
+++ b/internal/config/default.json
@@ -18,6 +18,9 @@
   "ociapi": {
     "noop": false
   },
+  "reconcile": {
+    "driftInterval": "0s"
+  },
   "features": {
     "reconcileGatewayClass": true,
     "reconcileGateway": true,

--- a/internal/config/default.json
+++ b/internal/config/default.json
@@ -19,7 +19,7 @@
     "noop": false
   },
   "reconcile": {
-    "driftInterval": "0s"
+    "drift-interval": "0s"
   },
   "features": {
     "reconcileGatewayClass": true,

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -33,5 +34,14 @@ func TestLoad(t *testing.T) {
 		cfg := New()
 		err := Load(cfg, NewLoadOpts().WithEnv("not-existing"))
 		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+	t.Run("should load drift interval from env", func(t *testing.T) {
+		t.Setenv("APP_RECONCILE_DRIFT_INTERVAL", "2m")
+
+		cfg := New()
+		err := Load(cfg, NewLoadOpts())
+
+		require.NoError(t, err)
+		require.Equal(t, 2*time.Minute, cfg.GetDuration("reconcile.drift-interval"))
 	})
 }

--- a/internal/config/provide.go
+++ b/internal/config/provide.go
@@ -62,6 +62,9 @@ func Provide(container *dig.Container, cfg *viper.Viper) error {
 		// ociapi config
 		provideConfigValue(cfg, "ociapi.noop").asBool(),
 
+		// reconcile config
+		provideConfigValue(cfg, "reconcile.driftInterval").asDuration(),
+
 		// features config
 		provideConfigValue(cfg, "features.reconcileGatewayClass").asBool(),
 		provideConfigValue(cfg, "features.reconcileGateway").asBool(),

--- a/internal/config/provide.go
+++ b/internal/config/provide.go
@@ -63,7 +63,7 @@ func Provide(container *dig.Container, cfg *viper.Viper) error {
 		provideConfigValue(cfg, "ociapi.noop").asBool(),
 
 		// reconcile config
-		provideConfigValue(cfg, "reconcile.driftInterval").asDuration(),
+		provideConfigValue(cfg, "reconcile.drift-interval").asDuration(),
 
 		// features config
 		provideConfigValue(cfg, "features.reconcileGatewayClass").asBool(),


### PR DESCRIPTION
## OCI drift detection

Adds optional periodic OCI drift reconciliation so Kubernetes Gateway API resources remain the source of truth even when OCI Load Balancer (ALB) or Network Load Balancer resources are changed out of band.

When enabled, controllers periodically re-run their existing reconciliation paths even if the Kubernetes resource generation has not changed. This lets the controller detect and repair drift in OCI resources that would otherwise not trigger a Kubernetes watch event.

### Drift Coverage

#### This covers supported ALB resources:

- Gateway listeners, listener protocol/port/default backend/routing policy settings
- Default backend set policy and health checker configuration
- Routing policy existence, default catch-all rule, route rules, and stale HTTPRoute rules
- HTTPRoute backend sets and backend membership, including backend IP and port
- Listener certificate configuration, including Secret-backed certs and OCI certificate IDs
- Stale controller-managed listeners/certificates
- Gateway `status.addresses` refresh from live OCI load balancer state

#### This also covers supported NLB resources:
- Gateway listener protocol/port/default backend set settings
- Listener backend set policy and health checker configuration
- TCPRoute and UDPRoute backend membership, including backend IP and port
- UDPRoute TCP health check configuration
- Stale controller-managed listeners and backend sets
- Gateway `status.addresses` refresh from live OCI network load balancer state

### Configuration

Drift reconciliation is disabled by default, but set as a controller option
```yaml
deployment:
  reconcile:
    driftInterval: 10m
```

The controller also supports the environment variable: `APP_RECONCILE_DRIFT_INTERVAL=10m`