### PR TITLE
Add support for BackendTLSPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ See [deploy/manifests/examples/grpcroute.yaml](./deploy/manifests/examples/grpcr
 
 `BackendTLSPolicy` configures TLS from OCI Load Balancer backend sets to backend Pods for ALB-backed `HTTPRoute`, `GRPCRoute`, and `TLSRoute` with `tls.mode: Terminate`. It is not supported for OCI Network Load Balancer routes.
 
-OCI backend SSL validates the backend certificate chain but does not enforce hostname/SAN identity. Policies must explicitly set `oci.oraclecloud.com/backend-hostname-validation: Disabled`, and unsupported standard fields such as `subjectAltNames` are rejected.
+OCI backend SSL validates the backend certificate chain but does not enforce hostname/SAN identity. Policies must explicitly set `oci.oraclecloud.com/backend-hostname-validation: Disabled`, and unsupported standard fields such as `subjectAltNames` are rejected. CA trust can come from `validation.caCertificateRefs`, from pre-managed OCI CA bundle OCIDs in `oci.oraclecloud.com/trusted-ca-bundle-ocids`, or both.
 
 See [deploy/manifests/examples/backendtlspolicy.yaml](./deploy/manifests/examples/backendtlspolicy.yaml) for a complete example with a Gateway, HTTPRoute, Service, CA ConfigMap, and BackendTLSPolicy.
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,14 @@ The controller supports gRPC host, service, method, and exact header matching. `
 
 See [deploy/manifests/examples/grpcroute.yaml](./deploy/manifests/examples/grpcroute.yaml) for a minimal route example.
 
+## Backend TLS
+
+`BackendTLSPolicy` configures TLS from OCI Load Balancer backend sets to backend Pods for ALB-backed `HTTPRoute`, `GRPCRoute`, and `TLSRoute` with `tls.mode: Terminate`. It is not supported for OCI Network Load Balancer routes.
+
+OCI backend SSL validates the backend certificate chain but does not enforce hostname/SAN identity. Policies must explicitly set `oci.oraclecloud.com/backend-hostname-validation: Disabled`, and unsupported standard fields such as `subjectAltNames` are rejected.
+
+See [deploy/manifests/examples/backendtlspolicy.yaml](./deploy/manifests/examples/backendtlspolicy.yaml) for an example.
+
 ## TCPRoute And UDPRoute With OCI Network Load Balancer
 
 Layer 4 support uses an existing OCI Network Load Balancer. The controller reconciles listeners, backend sets, and backends on the referenced NLB, but does not create or delete the NLB resource itself.
@@ -256,7 +264,7 @@ are not configured by this controller.
 
 `TLSRoute` supports two OCI-backed modes:
 
-- OCI Load Balancer with `tls.mode: Terminate`: terminates TLS at the ALB and forwards plain TCP to the backend Service port.
+- OCI Load Balancer with `tls.mode: Terminate`: terminates TLS at the ALB and forwards to the backend Service port. Use `BackendTLSPolicy` when the backend connection should also use TLS.
 - OCI Network Load Balancer with `tls.mode: Passthrough`: forwards encrypted TCP bytes to a backend that terminates TLS itself.
 
 Unsupported combinations are rejected: ALB passthrough and NLB termination. OCI does not support SNI fanout for ALB TCP+SSL listeners or NLB TCP passthrough listeners, so only one effective `TLSRoute` can own a TLS listener. TLSRoute health checks use TCP on the resolved backend Service port.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ See [deploy/manifests/examples/grpcroute.yaml](./deploy/manifests/examples/grpcr
 
 OCI backend SSL validates the backend certificate chain but does not enforce hostname/SAN identity. Policies must explicitly set `oci.oraclecloud.com/backend-hostname-validation: Disabled`, and unsupported standard fields such as `subjectAltNames` are rejected.
 
-See [deploy/manifests/examples/backendtlspolicy.yaml](./deploy/manifests/examples/backendtlspolicy.yaml) for an example.
+See [deploy/manifests/examples/backendtlspolicy.yaml](./deploy/manifests/examples/backendtlspolicy.yaml) for a complete example with a Gateway, HTTPRoute, Service, CA ConfigMap, and BackendTLSPolicy.
 
 ## TCPRoute And UDPRoute With OCI Network Load Balancer
 

--- a/deploy/helm/controller/templates/clusterrole.yaml
+++ b/deploy/helm/controller/templates/clusterrole.yaml
@@ -8,14 +8,14 @@ metadata:
 rules:
 # Permissions to watch and update Gateway API resources
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["gatewayclasses", "gateways", "httproutes", "grpcroutes", "tcproutes", "udproutes", "tlsroutes", "referencegrants"]
+  resources: ["gatewayclasses", "gateways", "httproutes", "grpcroutes", "tcproutes", "udproutes", "tlsroutes", "backendtlspolicies", "referencegrants"]
   verbs: ["get", "list", "watch", "update", "patch"] # Read access + update/patch for finalizers/annotations
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "tcproutes/status", "udproutes/status", "tlsroutes/status"]
+  resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "tcproutes/status", "udproutes/status", "tlsroutes/status", "backendtlspolicies/status"]
   verbs: ["update", "patch"] # Update status
 # Permissions to read necessary core resources for OCI LB configuration
 - apiGroups: [""]
-  resources: ["services", "endpoints", "secrets", "nodes", "namespaces"]
+  resources: ["services", "endpoints", "secrets", "configmaps", "nodes", "namespaces"]
   verbs: ["get", "list", "watch"] # Read-only access
 # Permissions for leader election
 - apiGroups: ["coordination.k8s.io"]

--- a/deploy/helm/controller/templates/deployment.yaml
+++ b/deploy/helm/controller/templates/deployment.yaml
@@ -51,8 +51,6 @@ spec:
           value: /etc/oci/config
         - name: APP_RECONCILE_DRIFT_INTERVAL
           value: {{ index .Values.reconcile "drift-interval" | quote }}
-        - name: APP_FEATURES_RECONCILE_BACKEND_TLS_POLICY
-          value: {{ .Values.features.reconcileBackendTLSPolicy | quote }}
         volumeMounts:
         - name: oci-config-volume
           mountPath: "/etc/oci"

--- a/deploy/helm/controller/templates/deployment.yaml
+++ b/deploy/helm/controller/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           value: /etc/oci/config
         - name: APP_RECONCILE_DRIFT_INTERVAL
           value: {{ index .Values.reconcile "drift-interval" | quote }}
+        - name: APP_FEATURES_RECONCILE_BACKEND_TLS_POLICY
+          value: {{ .Values.features.reconcileBackendTLSPolicy | quote }}
         volumeMounts:
         - name: oci-config-volume
           mountPath: "/etc/oci"

--- a/deploy/helm/controller/values.yaml
+++ b/deploy/helm/controller/values.yaml
@@ -12,9 +12,6 @@ reconcile:
   # Periodic OCI drift reconciliation interval. Use 0s to disable.
   drift-interval: 0s
 
-features:
-  reconcileBackendTLSPolicy: true
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/deploy/helm/controller/values.yaml
+++ b/deploy/helm/controller/values.yaml
@@ -12,6 +12,9 @@ reconcile:
   # Periodic OCI drift reconciliation interval. Use 0s to disable.
   drift-interval: 0s
 
+features:
+  reconcileBackendTLSPolicy: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/deploy/manifests/examples/backendtlspolicy.yaml
+++ b/deploy/manifests/examples/backendtlspolicy.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-ca
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    REPLACE_WITH_BACKEND_CA_CERTIFICATE_PEM
+    -----END CERTIFICATE-----
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-tls-server
+  labels:
+    app: backend-tls-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend-tls-server
+  template:
+    metadata:
+      labels:
+        app: backend-tls-server
+    spec:
+      containers:
+      - name: app
+        # Replace this with an application image that serves TLS on port 8443
+        # using a certificate signed by backend-ca.
+        image: example.com/backend-tls-server:latest
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-tls-server
+  labels:
+    app: backend-tls-server
+spec:
+  selector:
+    app: backend-tls-server
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+    protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: backend-tls-server
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backend-tls-server
+    sectionName: https
+  validation:
+    hostname: backend.example.com
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: backend-ca
+  options:
+    oci.oraclecloud.com/backend-hostname-validation: Disabled
+    oci.oraclecloud.com/tls-protocols: TLSv1.2,TLSv1.3
+    oci.oraclecloud.com/verify-depth: "3"

--- a/deploy/manifests/examples/backendtlspolicy.yaml
+++ b/deploy/manifests/examples/backendtlspolicy.yaml
@@ -8,6 +8,57 @@ data:
     REPLACE_WITH_BACKEND_CA_CERTIFICATE_PEM
     -----END CERTIFICATE-----
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frontend-tls
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    REPLACE_WITH_FRONTEND_CERTIFICATE_PEM
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    REPLACE_WITH_FRONTEND_PRIVATE_KEY_PEM
+    -----END PRIVATE KEY-----
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: backend-tls
+spec:
+  gatewayClassName: oke-alb
+  listeners:
+  - name: https
+    protocol: HTTPS
+    port: 443
+    hostname: backend.example.com
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: frontend-tls
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-tls-server
+spec:
+  parentRefs:
+  - name: backend-tls
+    sectionName: https
+  hostnames:
+  - backend.example.com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: backend-tls-server
+      port: 8443
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/internal/app/backend_tls_policy_controller.go
+++ b/internal/app/backend_tls_policy_controller.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.uber.org/dig"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -11,6 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+const backendTLSPolicyCleanupRequeueAfter = 30 * time.Second
 
 type BackendTLSPolicyController struct {
 	logger *slog.Logger
@@ -52,6 +56,14 @@ func (c *BackendTLSPolicyController) Reconcile(
 	}
 	if policy.DeletionTimestamp != nil {
 		if err := c.model.cleanupDeletingPolicy(ctx, policy); err != nil {
+			if errors.Is(err, errBackendTLSCABundleStillAssociated) {
+				c.logger.InfoContext(ctx,
+					"BackendTLSPolicy cleanup is waiting for OCI CA bundle associations to be removed",
+					slog.String("policy", req.NamespacedName.String()),
+					slog.Duration("requeueAfter", backendTLSPolicyCleanupRequeueAfter),
+				)
+				return reconcile.Result{RequeueAfter: backendTLSPolicyCleanupRequeueAfter}, nil
+			}
 			return reconcile.Result{}, fmt.Errorf("failed to cleanup BackendTLSPolicy %s: %w", req.NamespacedName, err)
 		}
 	}

--- a/internal/app/backend_tls_policy_controller.go
+++ b/internal/app/backend_tls_policy_controller.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.uber.org/dig"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type BackendTLSPolicyController struct {
+	logger *slog.Logger
+	client k8sClient
+	model  backendTLSPolicyModel
+}
+
+type BackendTLSPolicyControllerDeps struct {
+	dig.In
+
+	RootLogger *slog.Logger
+	K8sClient  k8sClient
+	Model      backendTLSPolicyModel
+}
+
+func NewBackendTLSPolicyController(deps BackendTLSPolicyControllerDeps) *BackendTLSPolicyController {
+	return &BackendTLSPolicyController{
+		logger: deps.RootLogger.WithGroup("backend-tls-policy-controller"),
+		client: deps.K8sClient,
+		model:  deps.Model,
+	}
+}
+
+func (c *BackendTLSPolicyController) Reconcile(
+	ctx context.Context,
+	req reconcile.Request,
+) (reconcile.Result, error) {
+	c.logger.InfoContext(ctx, fmt.Sprintf("Processing reconciliation for BackendTLSPolicy %s", req.NamespacedName))
+
+	var policy gatewayv1.BackendTLSPolicy
+	if err := c.client.Get(ctx, apitypes.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      req.Name,
+	}, &policy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get BackendTLSPolicy %s: %w", req.NamespacedName, err)
+	}
+	if policy.DeletionTimestamp != nil {
+		if err := c.model.cleanupDeletingPolicy(ctx, policy); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to cleanup BackendTLSPolicy %s: %w", req.NamespacedName, err)
+		}
+	}
+	return reconcile.Result{}, nil
+}

--- a/internal/app/backend_tls_policy_controller_test.go
+++ b/internal/app/backend_tls_policy_controller_test.go
@@ -137,6 +137,32 @@ func TestBackendTLSPolicyController(t *testing.T) {
 		assert.Equal(t, "deleting", model.cleanupPolicy.Name)
 	})
 
+	t.Run("requeues cleanup while OCI CA bundle associations remain", func(t *testing.T) {
+		now := metav1.Now()
+		policy := gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "default",
+				Name:              "associated",
+				Finalizers:        []string{BackendTLSPolicyProgrammedFinalizer},
+				DeletionTimestamp: &now,
+			},
+		}
+		model := &stubBackendTLSPolicyModel{cleanupErr: errBackendTLSCABundleStillAssociated}
+		controller := NewBackendTLSPolicyController(BackendTLSPolicyControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(&policy).Build(),
+			Model:      model,
+		})
+
+		result, err := controller.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{Namespace: "default", Name: "associated"},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, model.cleanupPolicy)
+		assert.Equal(t, backendTLSPolicyCleanupRequeueAfter, result.RequeueAfter)
+	})
+
 	t.Run("wraps cleanup errors", func(t *testing.T) {
 		now := metav1.Now()
 		wantErr := errors.New("cleanup failed")

--- a/internal/app/backend_tls_policy_controller_test.go
+++ b/internal/app/backend_tls_policy_controller_test.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gemyago/oke-gateway-api/internal/diag"
+)
+
+type stubBackendTLSPolicyModel struct {
+	cleanupPolicy *gatewayv1.BackendTLSPolicy
+	cleanupErr    error
+	resolveErr    error
+	resolveFunc   func(resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error)
+}
+
+func (s *stubBackendTLSPolicyModel) resolveForBackendRef(
+	_ context.Context,
+	params resolveBackendTLSPolicyParams,
+) (*loadbalancer.SslConfigurationDetails, error) {
+	if s.resolveFunc != nil {
+		return s.resolveFunc(params)
+	}
+	return nil, s.resolveErr
+}
+
+func (s *stubBackendTLSPolicyModel) cleanupDeletingPolicy(
+	_ context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+) error {
+	s.cleanupPolicy = &policy
+	return s.cleanupErr
+}
+
+func TestBackendTLSPolicyController(t *testing.T) {
+	t.Run("constructs controller", func(t *testing.T) {
+		model := &stubBackendTLSPolicyModel{}
+
+		controller := NewBackendTLSPolicyController(BackendTLSPolicyControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).Build(),
+			Model:      model,
+		})
+
+		require.NotNil(t, controller)
+		assert.Same(t, model, controller.model)
+	})
+
+	t.Run("ignores missing policies", func(t *testing.T) {
+		controller := NewBackendTLSPolicyController(BackendTLSPolicyControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).Build(),
+			Model:      &stubBackendTLSPolicyModel{},
+		})
+
+		result, err := controller.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{Namespace: "default", Name: "missing"},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns get errors", func(t *testing.T) {
+		wantErr := apierrors.NewForbidden(
+			schema.GroupResource{Group: gatewayv1.GroupName, Resource: "backendtlspolicies"},
+			"blocked",
+			errors.New("denied"),
+		)
+		controller := NewBackendTLSPolicyController(BackendTLSPolicyControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  &failingBackendTLSPolicyClient{err: wantErr},
+			Model:      &stubBackendTLSPolicyModel{},
+		})
+
+		_, err := controller.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{Namespace: "default", Name: "blocked"},
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		assert.ErrorContains(t, err, "failed to get BackendTLSPolicy")
+	})
+
+	t.Run("does not cleanup active policies", func(t *testing.T) {
+		policy := gatewayv1.BackendTLSPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "active"}}
+		model := &stubBackendTLSPolicyModel{}
+		controller := NewBackendTLSPolicyController(BackendTLSPolicyControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(&policy).Build(),
+			Model:      model,
+		})
+
+		_, err := controller.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{Namespace: "default", Name: "active"},
+		})
+
+		require.NoError(t, err)
+		assert.Nil(t, model.cleanupPolicy)
+	})
+
+	t.Run("cleans up deleting policies", func(t *testing.T) {
+		now := metav1.Now()
+		policy := gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "default",
+				Name:              "deleting",
+				Finalizers:        []string{BackendTLSPolicyProgrammedFinalizer},
+				DeletionTimestamp: &now,
+			},
+		}
+		model := &stubBackendTLSPolicyModel{}
+		controller := NewBackendTLSPolicyController(BackendTLSPolicyControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(&policy).Build(),
+			Model:      model,
+		})
+
+		_, err := controller.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{Namespace: "default", Name: "deleting"},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, model.cleanupPolicy)
+		assert.Equal(t, "deleting", model.cleanupPolicy.Name)
+	})
+
+	t.Run("wraps cleanup errors", func(t *testing.T) {
+		now := metav1.Now()
+		wantErr := errors.New("cleanup failed")
+		policy := gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "default",
+				Name:              "cleanup-error",
+				Finalizers:        []string{BackendTLSPolicyProgrammedFinalizer},
+				DeletionTimestamp: &now,
+			},
+		}
+		controller := NewBackendTLSPolicyController(BackendTLSPolicyControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(&policy).Build(),
+			Model:      &stubBackendTLSPolicyModel{cleanupErr: wantErr},
+		})
+
+		_, err := controller.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: apitypes.NamespacedName{Namespace: "default", Name: "cleanup-error"},
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		assert.ErrorContains(t, err, "failed to cleanup BackendTLSPolicy")
+	})
+}
+
+type failingBackendTLSPolicyClient struct {
+	k8sClient
+
+	err error
+}
+
+func (c *failingBackendTLSPolicyClient) Get(
+	_ context.Context,
+	_ client.ObjectKey,
+	_ client.Object,
+	_ ...client.GetOption,
+) error {
+	return c.err
+}

--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -170,6 +170,9 @@ func (m *backendTLSPolicyModelImpl) matchingPolicies(
 ) ([]backendTLSPolicyCandidate, error) {
 	var policyList gatewayv1.BackendTLSPolicyList
 	if err := m.k8sClient.List(ctx, &policyList, client.InNamespace(service.Namespace)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to list BackendTLSPolicies: %w", err)
 	}
 	matches := make([]backendTLSPolicyCandidate, 0)
@@ -396,11 +399,12 @@ func validateBackendTLSPolicyShape(policy gatewayv1.BackendTLSPolicy) error {
 			}
 		}
 	}
-	if len(policy.Spec.Validation.CACertificateRefs) == 0 {
+	if len(policy.Spec.Validation.CACertificateRefs) == 0 &&
+		len(splitCSVOption(policy.Spec.Options[BackendTLSOptionTrustedCABundleOCIDs])) == 0 {
 		return backendTLSPolicyStatusError{
 			policy:  policy,
 			reason:  gatewayv1.BackendTLSPolicyReasonNoValidCACertificate,
-			message: "at least one caCertificateRef is required for OCI backend TLS",
+			message: "at least one caCertificateRef or trusted OCI CA bundle OCID is required for OCI backend TLS",
 		}
 	}
 	return nil

--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -653,9 +654,10 @@ func backendTLSCABundleName(
 	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
 	ref gatewayv1.LocalObjectReference,
 ) string {
-	hashInput := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s/%s/%s",
+	hashInput := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s/%s/%s/%s",
 		policy.Namespace,
 		policy.Name,
+		backendTLSPolicyObjectIdentity(policy),
 		targetRef.Group,
 		targetRef.Kind,
 		targetRef.Name,
@@ -665,6 +667,16 @@ func backendTLSCABundleName(
 		ref.Name,
 	)
 	return backendTLSCABundleNamePrefix + sha256Hex(hashInput)[:24]
+}
+
+func backendTLSPolicyObjectIdentity(policy gatewayv1.BackendTLSPolicy) string {
+	if policy.UID != "" {
+		return string(policy.UID)
+	}
+	if !policy.CreationTimestamp.IsZero() {
+		return policy.CreationTimestamp.UTC().Format(time.RFC3339Nano)
+	}
+	return strconv.FormatInt(policy.Generation, 10)
 }
 
 func backendTLSCABundleTags(policy gatewayv1.BackendTLSPolicy, caHash string) map[string]string {

--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -166,12 +168,12 @@ func (m *backendTLSPolicyModelImpl) matchingPolicies(
 	backendRef gatewayv1.BackendRef,
 ) ([]backendTLSPolicyCandidate, error) {
 	var policyList gatewayv1.BackendTLSPolicyList
-	if err := m.k8sClient.List(ctx, &policyList); err != nil {
+	if err := m.k8sClient.List(ctx, &policyList, client.InNamespace(service.Namespace)); err != nil {
 		return nil, fmt.Errorf("failed to list BackendTLSPolicies: %w", err)
 	}
 	matches := make([]backendTLSPolicyCandidate, 0)
 	for _, policy := range policyList.Items {
-		if policy.Namespace != service.Namespace || policy.DeletionTimestamp != nil {
+		if policy.DeletionTimestamp != nil {
 			continue
 		}
 		for _, targetRef := range policy.Spec.TargetRefs {
@@ -880,6 +882,7 @@ func (m *backendTLSPolicyModelImpl) setPolicyConditions(
 		Name:      gatewayv1.ObjectName(gateway.Name),
 	}
 	controllerName := gatewayv1.GatewayController(ControllerClassName)
+	originalAncestors := policyToUpdate.DeepCopy().Status.Ancestors
 	ancestorIndex := -1
 	for i := range policyToUpdate.Status.Ancestors {
 		ancestor := policyToUpdate.Status.Ancestors[i]
@@ -899,6 +902,9 @@ func (m *backendTLSPolicyModelImpl) setPolicyConditions(
 		for _, condition := range conditions {
 			meta.SetStatusCondition(&policyToUpdate.Status.Ancestors[ancestorIndex].Conditions, condition)
 		}
+	}
+	if reflect.DeepEqual(originalAncestors, policyToUpdate.Status.Ancestors) {
+		return nil
 	}
 	if err := m.k8sClient.Status().Update(ctx, &policyToUpdate); err != nil {
 		return fmt.Errorf("failed to update BackendTLSPolicy %s/%s status: %w",

--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -9,11 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/samber/lo"
 	"go.uber.org/dig"
@@ -503,9 +505,8 @@ func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
 	caHash := sha256Hex(caPEM)
 	tags := backendTLSCABundleTags(policy, caHash)
 	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
-		CompartmentId:  &compartmentID,
-		Name:           &name,
-		LifecycleState: certificatesmanagement.ListCaBundlesLifecycleStateActive,
+		CompartmentId: &compartmentID,
+		Name:          &name,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to list OCI CA bundles for BackendTLSPolicy %s/%s: %w",
@@ -514,14 +515,19 @@ func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
 			err,
 		)
 	}
-	if len(listResp.Items) > 0 {
-		bundle := listResp.Items[0]
+	for _, bundle := range listResp.Items {
+		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted {
+			continue
+		}
 		if !isOwnedBackendTLSCABundle(bundle.FreeformTags, policy) {
 			return "", fmt.Errorf("OCI CA bundle %s already exists and is not owned by BackendTLSPolicy %s/%s",
 				name,
 				policy.Namespace,
 				policy.Name,
 			)
+		}
+		if usableErr := ensureBackendTLSCABundleUsable(bundle); usableErr != nil {
+			return "", usableErr
 		}
 		if bundle.FreeformTags[backendTLSCAHashTag] != caHash {
 			m.logger.InfoContext(ctx, "Updating OCI CA bundle for BackendTLSPolicy",
@@ -555,9 +561,86 @@ func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
 		},
 	})
 	if err != nil {
+		if isBackendTLSCABundleAlreadyExists(err) {
+			return m.resolveExistingOCIManagedCABundle(ctx, policy, compartmentID, name, caHash)
+		}
 		return "", fmt.Errorf("failed to create OCI CA bundle %s: %w", name, err)
 	}
+	if createResp.CaBundle.LifecycleState != certificatesmanagement.CaBundleLifecycleStateActive {
+		return "", fmt.Errorf("OCI CA bundle %s is %s and is not ready for backend TLS",
+			name,
+			createResp.CaBundle.LifecycleState,
+		)
+	}
 	return lo.FromPtr(createResp.CaBundle.Id), nil
+}
+
+func (m *backendTLSPolicyModelImpl) resolveExistingOCIManagedCABundle(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	compartmentID string,
+	name string,
+	caHash string,
+) (string, error) {
+	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
+		CompartmentId: &compartmentID,
+		Name:          &name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to re-list OCI CA bundle %s after create conflict: %w", name, err)
+	}
+	for _, bundle := range listResp.Items {
+		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted {
+			continue
+		}
+		if !isOwnedBackendTLSCABundle(bundle.FreeformTags, policy) {
+			return "", fmt.Errorf("OCI CA bundle %s already exists and is not owned by BackendTLSPolicy %s/%s",
+				name,
+				policy.Namespace,
+				policy.Name,
+			)
+		}
+		if usableErr := ensureBackendTLSCABundleUsable(bundle); usableErr != nil {
+			return "", usableErr
+		}
+		if bundle.FreeformTags[backendTLSCAHashTag] != caHash {
+			return "", fmt.Errorf(
+				"OCI CA bundle %s already exists with stale CA data and is not ready for update",
+				name,
+			)
+		}
+		m.logger.InfoContext(ctx, "Reusing OCI CA bundle after create conflict",
+			slog.String("policy", fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)),
+			slog.String("caBundleName", name),
+		)
+		return lo.FromPtr(bundle.Id), nil
+	}
+	return "", fmt.Errorf("OCI CA bundle %s already exists but was not visible in list response", name)
+}
+
+func ensureBackendTLSCABundleUsable(bundle certificatesmanagement.CaBundleSummary) error {
+	switch bundle.LifecycleState {
+	case "", certificatesmanagement.CaBundleLifecycleStateActive:
+		return nil
+	case certificatesmanagement.CaBundleLifecycleStateDeleting:
+		return fmt.Errorf("OCI CA bundle %s is %s and cannot be reused for backend TLS",
+			lo.FromPtr(bundle.Name),
+			bundle.LifecycleState,
+		)
+	case certificatesmanagement.CaBundleLifecycleStateCreating,
+		certificatesmanagement.CaBundleLifecycleStateUpdating,
+		certificatesmanagement.CaBundleLifecycleStateDeleted,
+		certificatesmanagement.CaBundleLifecycleStateFailed:
+		return fmt.Errorf("OCI CA bundle %s is %s and is not ready for backend TLS",
+			lo.FromPtr(bundle.Name),
+			bundle.LifecycleState,
+		)
+	default:
+		return fmt.Errorf("OCI CA bundle %s is %s and is not ready for backend TLS",
+			lo.FromPtr(bundle.Name),
+			bundle.LifecycleState,
+		)
+	}
 }
 
 func backendTLSCABundleName(
@@ -926,14 +1009,17 @@ func (m *backendTLSPolicyModelImpl) deleteOwnedCABundles(
 		return nil
 	}
 	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
-		CompartmentId:  &compartmentID,
-		LifecycleState: certificatesmanagement.ListCaBundlesLifecycleStateActive,
+		CompartmentId: &compartmentID,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to list OCI CA bundles for BackendTLSPolicy cleanup: %w", err)
 	}
 	for _, bundle := range listResp.Items {
 		if !isOwnedBackendTLSCABundle(bundle.FreeformTags, policy) {
+			continue
+		}
+		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted ||
+			bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleting {
 			continue
 		}
 		m.logger.InfoContext(ctx, "Deleting OCI CA bundle for BackendTLSPolicy",
@@ -943,10 +1029,26 @@ func (m *backendTLSPolicyModelImpl) deleteOwnedCABundles(
 		if _, err = m.certsClient.DeleteCaBundle(ctx, certificatesmanagement.DeleteCaBundleRequest{
 			CaBundleId: bundle.Id,
 		}); err != nil {
+			if isBackendTLSCABundleAlreadyDeleted(err) {
+				continue
+			}
 			return fmt.Errorf("failed to delete OCI CA bundle %s: %w", lo.FromPtr(bundle.Name), err)
 		}
 	}
 	return nil
+}
+
+func isBackendTLSCABundleAlreadyDeleted(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound
+}
+
+func isBackendTLSCABundleAlreadyExists(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok &&
+		serviceErr.GetHTTPStatusCode() == http.StatusBadRequest &&
+		serviceErr.GetCode() == "InvalidParameter" &&
+		strings.Contains(serviceErr.GetMessage(), "already exists")
 }
 
 type backendTLSPolicyModelDeps struct {

--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -40,7 +40,10 @@ const (
 	defaultBackendTLSVerifyDepth         = 3
 )
 
-var errBackendTLSPolicyNotFound = errors.New("backend TLS policy not found")
+var (
+	errBackendTLSPolicyNotFound          = errors.New("backend TLS policy not found")
+	errBackendTLSCABundleStillAssociated = errors.New("backend TLS CA bundle still associated")
+)
 
 type resolveBackendTLSPolicyParams struct {
 	gateway    gatewayv1.Gateway
@@ -1032,6 +1035,9 @@ func (m *backendTLSPolicyModelImpl) deleteOwnedCABundles(
 			if isBackendTLSCABundleAlreadyDeleted(err) {
 				continue
 			}
+			if isBackendTLSCABundleStillAssociated(err) {
+				return errBackendTLSCABundleStillAssociated
+			}
 			return fmt.Errorf("failed to delete OCI CA bundle %s: %w", lo.FromPtr(bundle.Name), err)
 		}
 	}
@@ -1041,6 +1047,14 @@ func (m *backendTLSPolicyModelImpl) deleteOwnedCABundles(
 func isBackendTLSCABundleAlreadyDeleted(err error) bool {
 	serviceErr, ok := common.IsServiceError(err)
 	return ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound
+}
+
+func isBackendTLSCABundleStillAssociated(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok &&
+		serviceErr.GetHTTPStatusCode() == http.StatusConflict &&
+		serviceErr.GetCode() == "IncorrectState" &&
+		strings.Contains(serviceErr.GetMessage(), "Association")
 }
 
 func isBackendTLSCABundleAlreadyExists(err error) bool {

--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -1,0 +1,968 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
+	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/samber/lo"
+	"go.uber.org/dig"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gemyago/oke-gateway-api/internal/types"
+)
+
+const (
+	backendTLSHostnameValidationDisabled = "Disabled"
+	backendTLSCABundleNamePrefix         = "oke-btls-"
+	backendTLSCAHashTag                  = "oke-gateway-api-ca-sha256"
+	backendTLSManagedByTag               = "oke-gateway-api-managed-by"
+	backendTLSPolicyTag                  = "oke-gateway-api-policy"
+	backendTLSManagedByValue             = "backend-tls-policy"
+	defaultBackendTLSVerifyDepth         = 3
+)
+
+var errBackendTLSPolicyNotFound = errors.New("backend TLS policy not found")
+
+type resolveBackendTLSPolicyParams struct {
+	gateway    gatewayv1.Gateway
+	config     types.GatewayConfig
+	service    corev1.Service
+	backendRef gatewayv1.BackendRef
+}
+
+type backendTLSPolicyModel interface {
+	resolveForBackendRef(
+		ctx context.Context,
+		params resolveBackendTLSPolicyParams,
+	) (*loadbalancer.SslConfigurationDetails, error)
+	cleanupDeletingPolicy(ctx context.Context, policy gatewayv1.BackendTLSPolicy) error
+}
+
+type backendTLSPolicyModelImpl struct {
+	logger             *slog.Logger
+	k8sClient          k8sClient
+	loadBalancerClient ociLoadBalancerClient
+	certsClient        ociCertificatesManagementClient
+}
+
+type backendTLSPolicyStatusError struct {
+	policy  gatewayv1.BackendTLSPolicy
+	reason  gatewayv1.PolicyConditionReason
+	message string
+}
+
+func (e backendTLSPolicyStatusError) Error() string {
+	return e.message
+}
+
+type backendTLSPolicyCandidate struct {
+	policy         gatewayv1.BackendTLSPolicy
+	targetRef      gatewayv1.LocalPolicyTargetReferenceWithSectionName
+	servicePort    *corev1.ServicePort
+	invalidReason  gatewayv1.PolicyConditionReason
+	invalidMessage string
+}
+
+type backendTLSResolvedCARef struct {
+	ref   gatewayv1.LocalObjectReference
+	caPEM string
+}
+
+func (m *backendTLSPolicyModelImpl) resolveForBackendRef(
+	ctx context.Context,
+	params resolveBackendTLSPolicyParams,
+) (*loadbalancer.SslConfigurationDetails, error) {
+	candidates, err := m.matchingPolicies(ctx, params.service, params.backendRef)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, errBackendTLSPolicyNotFound
+	}
+
+	sortBackendTLSPolicyCandidates(candidates)
+	selected := candidates[0]
+	if selected.invalidReason != "" {
+		statusErr := backendTLSPolicyStatusError{
+			policy:  selected.policy,
+			reason:  selected.invalidReason,
+			message: selected.invalidMessage,
+		}
+		_ = m.setPolicyErrorConditions(ctx, statusErr.policy, params.gateway, statusErr.reason, statusErr.message)
+		return nil, statusErr
+	}
+	for _, conflicted := range candidates[1:] {
+		_ = m.setPolicyCondition(ctx, conflicted.policy, params.gateway, metav1.ConditionFalse,
+			gatewayv1.PolicyReasonConflicted,
+			fmt.Sprintf("BackendTLSPolicy %s/%s has lower precedence than %s/%s for Service %s/%s",
+				conflicted.policy.Namespace,
+				conflicted.policy.Name,
+				selected.policy.Namespace,
+				selected.policy.Name,
+				params.service.Namespace,
+				params.service.Name,
+			),
+		)
+	}
+
+	sslConfig, err := m.resolveAcceptedPolicy(ctx, selected, params)
+	if err != nil {
+		var statusErr backendTLSPolicyStatusError
+		if ok := errors.As(err, &statusErr); ok {
+			_ = m.setPolicyErrorConditions(ctx, statusErr.policy, params.gateway, statusErr.reason, statusErr.message)
+		}
+		return nil, err
+	}
+
+	if err = m.setPolicyConditions(
+		ctx,
+		selected.policy,
+		params.gateway,
+		backendTLSPolicyCondition(
+			selected.policy.Generation,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+			"OCI backend TLS is configured with CA-chain validation only; hostname/SAN validation is disabled by explicit option.",
+		),
+		backendTLSPolicyCondition(
+			selected.policy.Generation,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionTrue,
+			gatewayv1.BackendTLSPolicyReasonResolvedRefs,
+			"BackendTLSPolicy references are resolved.",
+		),
+	); err != nil {
+		return nil, err
+	}
+	return sslConfig, nil
+}
+
+func (m *backendTLSPolicyModelImpl) matchingPolicies(
+	ctx context.Context,
+	service corev1.Service,
+	backendRef gatewayv1.BackendRef,
+) ([]backendTLSPolicyCandidate, error) {
+	var policyList gatewayv1.BackendTLSPolicyList
+	if err := m.k8sClient.List(ctx, &policyList); err != nil {
+		return nil, fmt.Errorf("failed to list BackendTLSPolicies: %w", err)
+	}
+	matches := make([]backendTLSPolicyCandidate, 0)
+	for _, policy := range policyList.Items {
+		if policy.Namespace != service.Namespace || policy.DeletionTimestamp != nil {
+			continue
+		}
+		for _, targetRef := range policy.Spec.TargetRefs {
+			servicePort, matched := backendTLSPolicyTargetMatchesService(targetRef, service, backendRef)
+			if matched {
+				matches = append(matches, backendTLSPolicyCandidate{
+					policy:      policy,
+					targetRef:   targetRef,
+					servicePort: servicePort,
+				})
+				continue
+			}
+			if backendTLSPolicyTargetRefUnsupportedKind(targetRef, service) {
+				matches = append(matches, backendTLSPolicyCandidate{
+					policy:        policy,
+					targetRef:     targetRef,
+					invalidReason: gatewayv1.BackendTLSPolicyReasonInvalidKind,
+					invalidMessage: fmt.Sprintf(
+						"targetRef %s/%s must reference a core Service",
+						targetRef.Group,
+						targetRef.Kind,
+					),
+				})
+				continue
+			}
+			if backendTLSPolicyTargetRefMissingServicePort(targetRef, service) {
+				matches = append(matches, backendTLSPolicyCandidate{
+					policy:        policy,
+					targetRef:     targetRef,
+					invalidReason: gatewayv1.PolicyReasonTargetNotFound,
+					invalidMessage: fmt.Sprintf(
+						"targetRef sectionName %q does not match any port on Service %s/%s",
+						lo.FromPtr(targetRef.SectionName),
+						service.Namespace,
+						service.Name,
+					),
+				})
+			}
+		}
+	}
+	return matches, nil
+}
+
+func backendTLSPolicyTargetMatchesService(
+	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
+	service corev1.Service,
+	backendRef gatewayv1.BackendRef,
+) (*corev1.ServicePort, bool) {
+	if targetRef.Group != "" || targetRef.Kind != "Service" || string(targetRef.Name) != service.Name {
+		return nil, false
+	}
+	if targetRef.SectionName == nil {
+		return nil, true
+	}
+	for i := range service.Spec.Ports {
+		port := &service.Spec.Ports[i]
+		if port.Name == string(*targetRef.SectionName) &&
+			(backendRef.Port == nil || lo.FromPtr(backendRef.Port) == port.Port) {
+			return port, true
+		}
+	}
+	return nil, false
+}
+
+func backendTLSPolicyTargetRefUnsupportedKind(
+	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
+	service corev1.Service,
+) bool {
+	return string(targetRef.Name) == service.Name &&
+		(targetRef.Group != "" || targetRef.Kind != "Service")
+}
+
+func backendTLSPolicyTargetRefMissingServicePort(
+	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
+	service corev1.Service,
+) bool {
+	if targetRef.Group != "" ||
+		targetRef.Kind != "Service" ||
+		string(targetRef.Name) != service.Name ||
+		targetRef.SectionName == nil {
+		return false
+	}
+	for i := range service.Spec.Ports {
+		if service.Spec.Ports[i].Name == string(*targetRef.SectionName) {
+			return false
+		}
+	}
+	return true
+}
+
+func sortBackendTLSPolicyCandidates(candidates []backendTLSPolicyCandidate) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		left := candidates[i].policy
+		right := candidates[j].policy
+		if !left.CreationTimestamp.Equal(&right.CreationTimestamp) {
+			return left.CreationTimestamp.Before(&right.CreationTimestamp)
+		}
+		return fmt.Sprintf("%s/%s", left.Namespace, left.Name) < fmt.Sprintf("%s/%s", right.Namespace, right.Name)
+	})
+}
+
+func (m *backendTLSPolicyModelImpl) resolveAcceptedPolicy(
+	ctx context.Context,
+	candidate backendTLSPolicyCandidate,
+	params resolveBackendTLSPolicyParams,
+) (*loadbalancer.SslConfigurationDetails, error) {
+	policy := candidate.policy
+	if err := validateBackendTLSPolicyShape(policy); err != nil {
+		return nil, err
+	}
+
+	resolvedCARefs := make([]backendTLSResolvedCARef, 0, len(policy.Spec.Validation.CACertificateRefs))
+	for _, caRef := range policy.Spec.Validation.CACertificateRefs {
+		caPEM, resolveErr := m.resolveCACertificateRefPEM(ctx, policy, caRef)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		resolvedCARefs = append(resolvedCARefs, backendTLSResolvedCARef{
+			ref:   caRef,
+			caPEM: caPEM,
+		})
+	}
+	optionCAIDs := splitCSVOption(policy.Spec.Options[BackendTLSOptionTrustedCABundleOCIDs])
+	for _, caID := range optionCAIDs {
+		if _, err := m.certsClient.GetCaBundle(ctx, certificatesmanagement.GetCaBundleRequest{
+			CaBundleId: &caID,
+		}); err != nil {
+			return nil, backendTLSPolicyStatusError{
+				policy: policy,
+				reason: gatewayv1.PolicyReasonInvalid,
+				message: fmt.Sprintf("option %s references an OCI CA bundle that cannot be resolved: %s",
+					BackendTLSOptionTrustedCABundleOCIDs,
+					caID,
+				),
+			}
+		}
+	}
+	sslConfig, err := backendTLSSSLConfigFromOptions(policy, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	lbResp, err := m.loadBalancerClient.GetLoadBalancer(ctx, loadbalancer.GetLoadBalancerRequest{
+		LoadBalancerId: &params.config.Spec.LoadBalancerID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Load Balancer %s for BackendTLSPolicy: %w",
+			params.config.Spec.LoadBalancerID,
+			err,
+		)
+	}
+	compartmentID := lo.FromPtr(lbResp.LoadBalancer.CompartmentId)
+	if compartmentID == "" {
+		return nil, fmt.Errorf("failed to resolve Load Balancer compartment for BackendTLSPolicy %s/%s",
+			policy.Namespace,
+			policy.Name,
+		)
+	}
+	if err = m.ensurePolicyFinalizerAndCompartment(ctx, policy, compartmentID); err != nil {
+		return nil, err
+	}
+
+	trustedCAIDs := make([]string, 0, len(resolvedCARefs)+len(optionCAIDs))
+	for _, caRef := range resolvedCARefs {
+		caID, resolveErr := m.ensureOCIManagedCABundle(
+			ctx,
+			policy,
+			candidate.targetRef,
+			caRef.ref,
+			compartmentID,
+			caRef.caPEM,
+		)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		trustedCAIDs = append(trustedCAIDs, caID)
+	}
+	trustedCAIDs = append(trustedCAIDs, optionCAIDs...)
+	trustedCAIDs = lo.Uniq(trustedCAIDs)
+	sort.Strings(trustedCAIDs)
+	sslConfig.TrustedCertificateAuthorityIds = trustedCAIDs
+	return sslConfig, nil
+}
+
+func validateBackendTLSPolicyShape(policy gatewayv1.BackendTLSPolicy) error {
+	if policy.Spec.Validation.WellKnownCACertificates != nil &&
+		string(lo.FromPtr(policy.Spec.Validation.WellKnownCACertificates)) != "" {
+		return backendTLSPolicyStatusError{
+			policy:  policy,
+			reason:  gatewayv1.PolicyReasonInvalid,
+			message: "wellKnownCACertificates is not supported by OCI backend TLS",
+		}
+	}
+	if len(policy.Spec.Validation.SubjectAltNames) > 0 {
+		return backendTLSPolicyStatusError{
+			policy:  policy,
+			reason:  gatewayv1.PolicyReasonInvalid,
+			message: "subjectAltNames is not supported because OCI backend TLS does not enforce hostname/SAN identity",
+		}
+	}
+	hostnameValidation := string(policy.Spec.Options[BackendTLSOptionHostnameValidation])
+	if hostnameValidation != backendTLSHostnameValidationDisabled {
+		return backendTLSPolicyStatusError{
+			policy: policy,
+			reason: gatewayv1.PolicyReasonInvalid,
+			message: fmt.Sprintf(
+				"option %s must be set to %q because OCI backend TLS does not enforce hostname/SAN identity",
+				BackendTLSOptionHostnameValidation,
+				backendTLSHostnameValidationDisabled,
+			),
+		}
+	}
+	for key := range policy.Spec.Options {
+		if !supportedBackendTLSOption(string(key)) {
+			return backendTLSPolicyStatusError{
+				policy:  policy,
+				reason:  gatewayv1.PolicyReasonInvalid,
+				message: fmt.Sprintf("unsupported BackendTLSPolicy option %s", key),
+			}
+		}
+	}
+	if len(policy.Spec.Validation.CACertificateRefs) == 0 {
+		return backendTLSPolicyStatusError{
+			policy:  policy,
+			reason:  gatewayv1.BackendTLSPolicyReasonNoValidCACertificate,
+			message: "at least one caCertificateRef is required for OCI backend TLS",
+		}
+	}
+	return nil
+}
+
+func supportedBackendTLSOption(key string) bool {
+	switch key {
+	case BackendTLSOptionHostnameValidation,
+		BackendTLSOptionTrustedCABundleOCIDs,
+		BackendTLSOptionProtocols,
+		BackendTLSOptionCipherSuiteName,
+		BackendTLSOptionVerifyDepth,
+		BackendTLSOptionSessionResumption:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *backendTLSPolicyModelImpl) resolveCACertificateRefPEM(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	ref gatewayv1.LocalObjectReference,
+) (string, error) {
+	if ref.Group != "" || ref.Kind != "ConfigMap" {
+		return "", backendTLSPolicyStatusError{
+			policy:  policy,
+			reason:  gatewayv1.BackendTLSPolicyReasonInvalidKind,
+			message: fmt.Sprintf("caCertificateRef %s/%s must reference a core ConfigMap", ref.Group, ref.Kind),
+		}
+	}
+	var configMap corev1.ConfigMap
+	if err := m.k8sClient.Get(ctx, apitypes.NamespacedName{
+		Namespace: policy.Namespace,
+		Name:      string(ref.Name),
+	}, &configMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", backendTLSPolicyStatusError{
+				policy:  policy,
+				reason:  gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+				message: fmt.Sprintf("caCertificateRef ConfigMap %s/%s was not found", policy.Namespace, ref.Name),
+			}
+		}
+		return "", fmt.Errorf("failed to get caCertificateRef ConfigMap %s/%s: %w", policy.Namespace, ref.Name, err)
+	}
+	caPEM, ok := configMap.Data["ca.crt"]
+	if !ok {
+		return "", backendTLSPolicyStatusError{
+			policy:  policy,
+			reason:  gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+			message: fmt.Sprintf("caCertificateRef ConfigMap %s/%s is missing ca.crt", policy.Namespace, ref.Name),
+		}
+	}
+	if err := validateCABundlePEM(caPEM); err != nil {
+		return "", backendTLSPolicyStatusError{
+			policy: policy,
+			reason: gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+			message: fmt.Sprintf(
+				"caCertificateRef ConfigMap %s/%s has invalid ca.crt: %v",
+				policy.Namespace,
+				ref.Name,
+				err,
+			),
+		}
+	}
+	return caPEM, nil
+}
+
+func validateCABundlePEM(caPEM string) error {
+	remaining := []byte(caPEM)
+	parsed := 0
+	for {
+		block, rest := pem.Decode(remaining)
+		if block == nil {
+			break
+		}
+		remaining = rest
+		if block.Type != "CERTIFICATE" {
+			return fmt.Errorf("unexpected PEM block type %q", block.Type)
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("failed to parse certificate: %w", err)
+		}
+		if !cert.IsCA {
+			return fmt.Errorf("certificate %s is not a CA certificate", cert.Subject.CommonName)
+		}
+		parsed++
+	}
+	if parsed == 0 {
+		return errors.New("no CA certificates found")
+	}
+	if strings.TrimSpace(string(remaining)) != "" {
+		return errors.New("unexpected trailing data")
+	}
+	return nil
+}
+
+func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
+	ref gatewayv1.LocalObjectReference,
+	compartmentID string,
+	caPEM string,
+) (string, error) {
+	name := backendTLSCABundleName(policy, targetRef, ref)
+	caHash := sha256Hex(caPEM)
+	tags := backendTLSCABundleTags(policy, caHash)
+	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
+		CompartmentId:  &compartmentID,
+		Name:           &name,
+		LifecycleState: certificatesmanagement.ListCaBundlesLifecycleStateActive,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list OCI CA bundles for BackendTLSPolicy %s/%s: %w",
+			policy.Namespace,
+			policy.Name,
+			err,
+		)
+	}
+	if len(listResp.Items) > 0 {
+		bundle := listResp.Items[0]
+		if !isOwnedBackendTLSCABundle(bundle.FreeformTags, policy) {
+			return "", fmt.Errorf("OCI CA bundle %s already exists and is not owned by BackendTLSPolicy %s/%s",
+				name,
+				policy.Namespace,
+				policy.Name,
+			)
+		}
+		if bundle.FreeformTags[backendTLSCAHashTag] != caHash {
+			m.logger.InfoContext(ctx, "Updating OCI CA bundle for BackendTLSPolicy",
+				slog.String("policy", fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)),
+				slog.String("caBundleName", name),
+			)
+			_, err = m.certsClient.UpdateCaBundle(ctx, certificatesmanagement.UpdateCaBundleRequest{
+				CaBundleId: bundle.Id,
+				UpdateCaBundleDetails: certificatesmanagement.UpdateCaBundleDetails{
+					CaBundlePem:  &caPEM,
+					FreeformTags: tags,
+				},
+			})
+			if err != nil {
+				return "", fmt.Errorf("failed to update OCI CA bundle %s: %w", name, err)
+			}
+		}
+		return lo.FromPtr(bundle.Id), nil
+	}
+
+	m.logger.InfoContext(ctx, "Creating OCI CA bundle for BackendTLSPolicy",
+		slog.String("policy", fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)),
+		slog.String("caBundleName", name),
+	)
+	createResp, err := m.certsClient.CreateCaBundle(ctx, certificatesmanagement.CreateCaBundleRequest{
+		CreateCaBundleDetails: certificatesmanagement.CreateCaBundleDetails{
+			Name:          &name,
+			CompartmentId: &compartmentID,
+			CaBundlePem:   &caPEM,
+			FreeformTags:  tags,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create OCI CA bundle %s: %w", name, err)
+	}
+	return lo.FromPtr(createResp.CaBundle.Id), nil
+}
+
+func backendTLSCABundleName(
+	policy gatewayv1.BackendTLSPolicy,
+	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
+	ref gatewayv1.LocalObjectReference,
+) string {
+	hashInput := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s/%s/%s",
+		policy.Namespace,
+		policy.Name,
+		targetRef.Group,
+		targetRef.Kind,
+		targetRef.Name,
+		lo.FromPtr(targetRef.SectionName),
+		ref.Group,
+		ref.Kind,
+		ref.Name,
+	)
+	return backendTLSCABundleNamePrefix + sha256Hex(hashInput)[:24]
+}
+
+func backendTLSCABundleTags(policy gatewayv1.BackendTLSPolicy, caHash string) map[string]string {
+	return map[string]string{
+		backendTLSManagedByTag: backendTLSManagedByValue,
+		backendTLSPolicyTag:    fmt.Sprintf("%s/%s", policy.Namespace, policy.Name),
+		backendTLSCAHashTag:    caHash,
+	}
+}
+
+func isOwnedBackendTLSCABundle(tags map[string]string, policy gatewayv1.BackendTLSPolicy) bool {
+	return tags[backendTLSManagedByTag] == backendTLSManagedByValue &&
+		tags[backendTLSPolicyTag] == fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func backendTLSSSLConfigFromOptions(
+	policy gatewayv1.BackendTLSPolicy,
+	trustedCAIDs []string,
+) (*loadbalancer.SslConfigurationDetails, error) {
+	verifyDepth := defaultBackendTLSVerifyDepth
+	if value := strings.TrimSpace(string(policy.Spec.Options[BackendTLSOptionVerifyDepth])); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed < 1 {
+			return nil, backendTLSPolicyStatusError{
+				policy:  policy,
+				reason:  gatewayv1.PolicyReasonInvalid,
+				message: fmt.Sprintf("option %s must be a positive integer", BackendTLSOptionVerifyDepth),
+			}
+		}
+		verifyDepth = parsed
+	}
+	verifyPeer := true
+	sslConfig := &loadbalancer.SslConfigurationDetails{
+		VerifyPeerCertificate:          &verifyPeer,
+		VerifyDepth:                    &verifyDepth,
+		TrustedCertificateAuthorityIds: trustedCAIDs,
+	}
+	if protocols := splitCSVOption(policy.Spec.Options[BackendTLSOptionProtocols]); len(protocols) > 0 {
+		sslConfig.Protocols = protocols
+	}
+	cipherSuite := strings.TrimSpace(string(policy.Spec.Options[BackendTLSOptionCipherSuiteName]))
+	if cipherSuite != "" {
+		sslConfig.CipherSuiteName = &cipherSuite
+	}
+	if value := strings.TrimSpace(string(policy.Spec.Options[BackendTLSOptionSessionResumption])); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return nil, backendTLSPolicyStatusError{
+				policy:  policy,
+				reason:  gatewayv1.PolicyReasonInvalid,
+				message: fmt.Sprintf("option %s must be a boolean", BackendTLSOptionSessionResumption),
+			}
+		}
+		sslConfig.HasSessionResumption = &parsed
+	}
+	return sslConfig, nil
+}
+
+func splitCSVOption(value gatewayv1.AnnotationValue) []string {
+	parts := strings.Split(string(value), ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func (m *backendTLSPolicyModelImpl) ensurePolicyFinalizerAndCompartment(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	compartmentID string,
+) error {
+	policyToUpdate := policy.DeepCopy()
+	needsUpdate := controllerutil.AddFinalizer(policyToUpdate, BackendTLSPolicyProgrammedFinalizer)
+	if addBackendTLSPolicyCompartment(policyToUpdate, compartmentID) {
+		needsUpdate = true
+	}
+	if !needsUpdate {
+		return nil
+	}
+	if err := m.k8sClient.Update(ctx, policyToUpdate); err != nil {
+		return fmt.Errorf("failed to add BackendTLSPolicy finalizer: %w", err)
+	}
+	return nil
+}
+
+func addBackendTLSPolicyCompartment(policy *gatewayv1.BackendTLSPolicy, compartmentID string) bool {
+	if compartmentID == "" {
+		return false
+	}
+	compartmentIDs := backendTLSPolicyCompartmentIDs(*policy)
+	if lo.Contains(compartmentIDs, compartmentID) {
+		return false
+	}
+	compartmentIDs = append(compartmentIDs, compartmentID)
+	sort.Strings(compartmentIDs)
+	if policy.Annotations == nil {
+		policy.Annotations = map[string]string{}
+	}
+	policy.Annotations[BackendTLSPolicyCompartmentsAnnotation] = strings.Join(compartmentIDs, ",")
+	return true
+}
+
+func backendTLSPolicyCompartmentIDs(policy gatewayv1.BackendTLSPolicy) []string {
+	compartmentAnnotation := policy.Annotations[BackendTLSPolicyCompartmentsAnnotation]
+	if compartmentAnnotation == "" {
+		return nil
+	}
+	compartments := strings.Split(compartmentAnnotation, ",")
+	uniqueCompartments := make(map[string]struct{}, len(compartments))
+	for _, compartment := range compartments {
+		compartment = strings.TrimSpace(compartment)
+		if compartment == "" {
+			continue
+		}
+		uniqueCompartments[compartment] = struct{}{}
+	}
+	result := lo.Keys(uniqueCompartments)
+	sort.Strings(result)
+	return result
+}
+
+func (m *backendTLSPolicyModelImpl) setPolicyCondition(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	gateway gatewayv1.Gateway,
+	status metav1.ConditionStatus,
+	reason gatewayv1.PolicyConditionReason,
+	message string,
+) error {
+	return m.setPolicyConditions(ctx, policy, gateway, backendTLSPolicyCondition(
+		policy.Generation,
+		gatewayv1.PolicyConditionAccepted,
+		status,
+		reason,
+		message,
+	))
+}
+
+func (m *backendTLSPolicyModelImpl) setPolicyErrorConditions(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	gateway gatewayv1.Gateway,
+	reason gatewayv1.PolicyConditionReason,
+	message string,
+) error {
+	return m.setPolicyConditions(
+		ctx,
+		policy,
+		gateway,
+		backendTLSPolicyCondition(
+			policy.Generation,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionFalse,
+			reason,
+			message,
+		),
+		backendTLSPolicyCondition(
+			policy.Generation,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionFalse,
+			reason,
+			message,
+		),
+	)
+}
+
+func backendTLSPolicyCondition(
+	observedGeneration int64,
+	conditionType gatewayv1.PolicyConditionType,
+	status metav1.ConditionStatus,
+	reason gatewayv1.PolicyConditionReason,
+	message string,
+) metav1.Condition {
+	return metav1.Condition{
+		Type:               string(conditionType),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            message,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: metav1.Now(),
+	}
+}
+
+func (m *backendTLSPolicyModelImpl) setPolicyConditions(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	gateway gatewayv1.Gateway,
+	conditions ...metav1.Condition,
+) error {
+	var policyToUpdate gatewayv1.BackendTLSPolicy
+	if err := m.k8sClient.Get(ctx, apitypes.NamespacedName{
+		Namespace: policy.Namespace,
+		Name:      policy.Name,
+	}, &policyToUpdate); err != nil {
+		return fmt.Errorf("failed to get BackendTLSPolicy %s/%s before status update: %w",
+			policy.Namespace,
+			policy.Name,
+			err,
+		)
+	}
+	gatewayNamespace := gatewayv1.Namespace(gateway.Namespace)
+	ancestorRef := gatewayv1.ParentReference{
+		Group:     lo.ToPtr(gatewayv1.Group(gatewayv1.GroupName)),
+		Kind:      lo.ToPtr(gatewayv1.Kind("Gateway")),
+		Namespace: &gatewayNamespace,
+		Name:      gatewayv1.ObjectName(gateway.Name),
+	}
+	controllerName := gatewayv1.GatewayController(ControllerClassName)
+	ancestorIndex := -1
+	for i := range policyToUpdate.Status.Ancestors {
+		ancestor := policyToUpdate.Status.Ancestors[i]
+		if ancestor.ControllerName == controllerName &&
+			parentRefsEqual(ancestor.AncestorRef, ancestorRef) {
+			ancestorIndex = i
+			break
+		}
+	}
+	if ancestorIndex == -1 {
+		policyToUpdate.Status.Ancestors = append(policyToUpdate.Status.Ancestors, gatewayv1.PolicyAncestorStatus{
+			AncestorRef:    ancestorRef,
+			ControllerName: controllerName,
+			Conditions:     conditions,
+		})
+	} else {
+		for _, condition := range conditions {
+			meta.SetStatusCondition(&policyToUpdate.Status.Ancestors[ancestorIndex].Conditions, condition)
+		}
+	}
+	if err := m.k8sClient.Status().Update(ctx, &policyToUpdate); err != nil {
+		return fmt.Errorf("failed to update BackendTLSPolicy %s/%s status: %w",
+			policy.Namespace,
+			policy.Name,
+			err,
+		)
+	}
+	return nil
+}
+
+func parentRefsEqual(left, right gatewayv1.ParentReference) bool {
+	return lo.FromPtr(left.Group) == lo.FromPtr(right.Group) &&
+		lo.FromPtr(left.Kind) == lo.FromPtr(right.Kind) &&
+		lo.FromPtr(left.Namespace) == lo.FromPtr(right.Namespace) &&
+		left.Name == right.Name &&
+		lo.FromPtr(left.SectionName) == lo.FromPtr(right.SectionName) &&
+		lo.FromPtr(left.Port) == lo.FromPtr(right.Port)
+}
+
+func (m *backendTLSPolicyModelImpl) cleanupDeletingPolicy(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+) error {
+	if !controllerutil.ContainsFinalizer(&policy, BackendTLSPolicyProgrammedFinalizer) {
+		return nil
+	}
+	compartmentIDs := lo.SliceToMap(backendTLSPolicyCompartmentIDs(policy), func(id string) (string, struct{}) {
+		return id, struct{}{}
+	})
+	if len(compartmentIDs) == 0 {
+		discoveredCompartments, err := m.discoverBackendTLSPolicyCleanupCompartments(ctx)
+		if err != nil {
+			return err
+		}
+		compartmentIDs = discoveredCompartments
+	}
+	for _, compartmentID := range lo.Keys(compartmentIDs) {
+		if err := m.deleteOwnedCABundles(ctx, policy, compartmentID); err != nil {
+			return err
+		}
+	}
+	policyToUpdate := policy.DeepCopy()
+	controllerutil.RemoveFinalizer(policyToUpdate, BackendTLSPolicyProgrammedFinalizer)
+	delete(policyToUpdate.Annotations, BackendTLSPolicyCompartmentsAnnotation)
+	if err := m.k8sClient.Update(ctx, policyToUpdate); err != nil {
+		return fmt.Errorf("failed to remove BackendTLSPolicy finalizer: %w", err)
+	}
+	return nil
+}
+
+func (m *backendTLSPolicyModelImpl) discoverBackendTLSPolicyCleanupCompartments(
+	ctx context.Context,
+) (map[string]struct{}, error) {
+	var gateways gatewayv1.GatewayList
+	if err := m.k8sClient.List(ctx, &gateways); err != nil {
+		return nil, fmt.Errorf("failed to list Gateways for BackendTLSPolicy cleanup: %w", err)
+	}
+	compartmentIDs := map[string]struct{}{}
+	for _, gateway := range gateways.Items {
+		compartmentID, err := m.backendTLSPolicyCleanupCompartment(ctx, gateway)
+		if err != nil {
+			return nil, err
+		}
+		if compartmentID == "" {
+			continue
+		}
+		compartmentIDs[compartmentID] = struct{}{}
+	}
+	return compartmentIDs, nil
+}
+
+func (m *backendTLSPolicyModelImpl) backendTLSPolicyCleanupCompartment(
+	ctx context.Context,
+	gateway gatewayv1.Gateway,
+) (string, error) {
+	if gateway.Spec.Infrastructure == nil || gateway.Spec.Infrastructure.ParametersRef == nil {
+		return "", nil
+	}
+	var config types.GatewayConfig
+	configKey := apitypes.NamespacedName{
+		Namespace: gateway.Namespace,
+		Name:      gateway.Spec.Infrastructure.ParametersRef.Name,
+	}
+	if getErr := m.k8sClient.Get(ctx, configKey, &config); getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			return "", nil
+		}
+		return "", fmt.Errorf(
+			"failed to get GatewayConfig %s for BackendTLSPolicy cleanup: %w",
+			configKey.String(),
+			getErr,
+		)
+	}
+	lbResp, err := m.loadBalancerClient.GetLoadBalancer(ctx, loadbalancer.GetLoadBalancerRequest{
+		LoadBalancerId: &config.Spec.LoadBalancerID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get Load Balancer %s for BackendTLSPolicy cleanup: %w",
+			config.Spec.LoadBalancerID, err)
+	}
+	return lo.FromPtr(lbResp.LoadBalancer.CompartmentId), nil
+}
+
+func (m *backendTLSPolicyModelImpl) deleteOwnedCABundles(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	compartmentID string,
+) error {
+	if compartmentID == "" {
+		return nil
+	}
+	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
+		CompartmentId:  &compartmentID,
+		LifecycleState: certificatesmanagement.ListCaBundlesLifecycleStateActive,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list OCI CA bundles for BackendTLSPolicy cleanup: %w", err)
+	}
+	for _, bundle := range listResp.Items {
+		if !isOwnedBackendTLSCABundle(bundle.FreeformTags, policy) {
+			continue
+		}
+		m.logger.InfoContext(ctx, "Deleting OCI CA bundle for BackendTLSPolicy",
+			slog.String("policy", fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)),
+			slog.String("caBundleName", lo.FromPtr(bundle.Name)),
+		)
+		if _, err = m.certsClient.DeleteCaBundle(ctx, certificatesmanagement.DeleteCaBundleRequest{
+			CaBundleId: bundle.Id,
+		}); err != nil {
+			return fmt.Errorf("failed to delete OCI CA bundle %s: %w", lo.FromPtr(bundle.Name), err)
+		}
+	}
+	return nil
+}
+
+type backendTLSPolicyModelDeps struct {
+	dig.In `ignore-unexported:"true"`
+
+	RootLogger                *slog.Logger
+	K8sClient                 k8sClient
+	OciLoadBalancerClient     ociLoadBalancerClient
+	OciCertificatesMgmtClient ociCertificatesManagementClient
+}
+
+func newBackendTLSPolicyModel(deps backendTLSPolicyModelDeps) *backendTLSPolicyModelImpl {
+	return &backendTLSPolicyModelImpl{
+		logger:             deps.RootLogger.WithGroup("backend-tls-policy-model"),
+		k8sClient:          deps.K8sClient,
+		loadBalancerClient: deps.OciLoadBalancerClient,
+		certsClient:        deps.OciCertificatesMgmtClient,
+	}
+}

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -1396,6 +1396,48 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		require.NotContains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
 	})
 
+	t.Run("cleanup keeps finalizer when OCI CA bundle is still associated", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-associated-bundle", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		policy.Annotations = map[string]string{BackendTLSPolicyCompartmentsAnnotation: compartmentID}
+		certsClient := newStubCertificatesManagementClient()
+		ownedID := "ocid1.cabundle.oc1..associated"
+		ownedName := "associated"
+		certsClient.bundles[ownedName] = certificatesmanagement.CaBundleSummary{
+			Id:           &ownedID,
+			Name:         &ownedName,
+			FreeformTags: backendTLSCABundleTags(policy, "hash"),
+		}
+		certsClient.deleteErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusConflict),
+			ociapi.RandomServiceErrorWithCode("IncorrectState"),
+			ociapi.RandomServiceErrorWithMessage(
+				"A dependency exists between the child entity Association and the parent entity "+ownedID+".",
+			),
+		)
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.ErrorIs(t, err, errBackendTLSCABundleStillAssociated)
+		assert.Len(t, certsClient.deleteCalls, 1)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "cleanup-associated-bundle",
+		}, &updated))
+		require.Contains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
+	})
+
 	t.Run("cleanup skips incomplete gateway state and returns CA delete errors", func(t *testing.T) {
 		policy := backendTLSPolicy(namespace, "cleanup-branches", serviceName, "tls", baseOptions, "ca")
 		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"math/big"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -372,6 +373,31 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 	t.Run("returns sentinel when no policy matches backend service", func(t *testing.T) {
 		otherNamespacePolicy := backendTLSPolicy("other", "other-namespace", serviceName, "tls", baseOptions, "ca")
 		model, _ := makeModel(t, newStubCertificatesManagementClient(), &service, &otherNamespacePolicy)
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorIs(t, err, errBackendTLSPolicyNotFound)
+	})
+
+	t.Run("lists policies only in backend service namespace", func(t *testing.T) {
+		k8sClient := NewMockk8sClient(t)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+		k8sClient.EXPECT().
+			List(t.Context(), &gatewayv1.BackendTLSPolicyList{}, mock.Anything).
+			RunAndReturn(func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				listOptions := &client.ListOptions{}
+				for _, opt := range opts {
+					opt.ApplyToList(listOptions)
+				}
+				assert.Equal(t, namespace, listOptions.Namespace)
+				reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.BackendTLSPolicy{}))
+				return nil
+			})
 
 		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
 
@@ -1591,6 +1617,53 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		}, &updated))
 		require.Len(t, updated.Status.Ancestors, 1)
 		require.Equal(t, metav1.ConditionTrue, updated.Status.Ancestors[0].Conditions[0].Status)
+	})
+
+	t.Run("setPolicyCondition skips status update when condition is unchanged", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "unchanged-status", serviceName, "tls", baseOptions, "ca")
+		policy.Generation = 7
+		gatewayNamespace := gatewayv1.Namespace(gateway.Namespace)
+		policy.Status.Ancestors = []gatewayv1.PolicyAncestorStatus{{
+			AncestorRef: gatewayv1.ParentReference{
+				Group:     lo.ToPtr(gatewayv1.Group(gatewayv1.GroupName)),
+				Kind:      lo.ToPtr(gatewayv1.Kind("Gateway")),
+				Namespace: &gatewayNamespace,
+				Name:      gatewayv1.ObjectName(gateway.Name),
+			},
+			ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			Conditions: []metav1.Condition{{
+				Type:               string(gatewayv1.PolicyConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.PolicyReasonAccepted),
+				Message:            "accepted",
+				ObservedGeneration: policy.Generation,
+				LastTransitionTime: metav1.Now(),
+			}},
+		}}
+		k8sClient := NewMockk8sClient(t)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+		k8sClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: namespace, Name: "unchanged-status"}, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.BackendTLSPolicy) = policy
+				return nil
+			})
+
+		err := model.setPolicyCondition(
+			t.Context(),
+			policy,
+			gateway,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+			"accepted",
+		)
+
+		require.NoError(t, err)
 	})
 
 	t.Run("wraps direct Kubernetes write and lookup errors", func(t *testing.T) {

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -404,6 +405,33 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 				reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.BackendTLSPolicy{}))
 				return nil
 			})
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorIs(t, err, errBackendTLSPolicyNotFound)
+	})
+
+	t.Run("treats missing BackendTLSPolicy CRD as no matching policy", func(t *testing.T) {
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient: &failingListClient{err: &meta.NoKindMatchError{
+				GroupKind: schema.GroupKind{Group: gatewayv1.GroupName, Kind: "BackendTLSPolicy"},
+			}},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorIs(t, err, errBackendTLSPolicyNotFound)
+	})
+
+	t.Run("ignores deleting policies", func(t *testing.T) {
+		deletingPolicy := backendTLSPolicy(namespace, "deleting", serviceName, "tls", baseOptions, "ca")
+		deletionTime := metav1.Now()
+		deletingPolicy.DeletionTimestamp = &deletionTime
+		deletingPolicy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		model, _ := makeModel(t, newStubCertificatesManagementClient(), &service, &deletingPolicy)
 
 		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
 
@@ -1240,6 +1268,41 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		_, err = model.resolveForBackendRef(t.Context(), resolveParams)
 
 		require.ErrorContains(t, err, "cannot be resolved")
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("accepts pre-managed OCI CA bundle option without ConfigMap CA refs", func(t *testing.T) {
+		existingCAID := "ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		options := lo.Assign(
+			map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{},
+			baseOptions,
+			map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				BackendTLSOptionTrustedCABundleOCIDs: gatewayv1.AnnotationValue(existingCAID),
+			},
+		)
+		policy := backendTLSPolicy(namespace, "oci-ca-only", serviceName, "tls", options)
+		certsClient := newStubCertificatesManagementClient()
+		lbClient := NewMockociLoadBalancerClient(t)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient: fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(&service, &policy).
+				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+				Build(),
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: certsClient,
+		})
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+
+		sslConfig, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.NoError(t, err)
+		require.NotNil(t, sslConfig)
+		require.Equal(t, []string{existingCAID}, sslConfig.TrustedCertificateAuthorityIds)
 		assert.Empty(t, certsClient.createCalls)
 	})
 

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"reflect"
@@ -43,6 +44,7 @@ type stubCertificatesManagementClient struct {
 	deleteCalls        []certificatesmanagement.DeleteCaBundleRequest
 	getErrByID         map[string]error
 	createErr          error
+	createErrByName    map[string]error
 	createState        certificatesmanagement.CaBundleLifecycleStateEnum
 	listErr            error
 	listEmptyResponses int
@@ -53,8 +55,9 @@ type stubCertificatesManagementClient struct {
 
 func newStubCertificatesManagementClient() *stubCertificatesManagementClient {
 	return &stubCertificatesManagementClient{
-		bundles:    map[string]certificatesmanagement.CaBundleSummary{},
-		getErrByID: map[string]error{},
+		bundles:         map[string]certificatesmanagement.CaBundleSummary{},
+		getErrByID:      map[string]error{},
+		createErrByName: map[string]error{},
 	}
 }
 
@@ -66,9 +69,12 @@ func (s *stubCertificatesManagementClient) CreateCaBundle(
 	if s.createErr != nil {
 		return certificatesmanagement.CreateCaBundleResponse{}, s.createErr
 	}
+	name := lo.FromPtr(request.CreateCaBundleDetails.Name)
+	if err := s.createErrByName[name]; err != nil {
+		return certificatesmanagement.CreateCaBundleResponse{}, err
+	}
 	s.nextID++
 	id := "ocid1.cabundle.oc1..created" + string(rune('a'+s.nextID))
-	name := lo.FromPtr(request.CreateCaBundleDetails.Name)
 	lifecycleState := s.createState
 	if lifecycleState == "" {
 		lifecycleState = certificatesmanagement.CaBundleLifecycleStateActive
@@ -820,6 +826,24 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		}), "not ready")
 	})
 
+	t.Run("uses stable BackendTLSPolicy object identity for OCI CA bundle names", func(t *testing.T) {
+		creationTime := metav1.NewTime(time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC))
+
+		assert.Equal(t, "policy-uid", backendTLSPolicyObjectIdentity(gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{UID: apitypes.UID("policy-uid"), CreationTimestamp: creationTime},
+		}))
+		assert.Equal(
+			t,
+			creationTime.UTC().Format(time.RFC3339Nano),
+			backendTLSPolicyObjectIdentity(gatewayv1.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: creationTime, Generation: 7},
+			}),
+		)
+		assert.Equal(t, "7", backendTLSPolicyObjectIdentity(gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{Generation: 7},
+		}))
+	})
+
 	t.Run("reuses owned OCI CA bundle after create already exists conflict", func(t *testing.T) {
 		policy := backendTLSPolicy(namespace, "create-conflict", serviceName, "tls", baseOptions, "ca")
 		targetRef := policy.Spec.TargetRefs[0]
@@ -848,6 +872,35 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		assert.Equal(t, bundleID, caID)
 		assert.Len(t, certsClient.createCalls, 1)
 		assert.Empty(t, certsClient.updateCalls)
+	})
+
+	t.Run("creates usable OCI CA bundle when deleted legacy name still conflicts", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "create-conflict-deleted", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		legacyName := legacyBackendTLSCABundleName(policy, targetRef, ref)
+		caPEM := testCAPEM(t)
+		deletedID := "ocid1.cabundle.oc1..deleted"
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.createErrByName[legacyName] = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusBadRequest),
+			ociapi.RandomServiceErrorWithCode("InvalidParameter"),
+			ociapi.RandomServiceErrorWithMessage("A CA bundle with the name '"+legacyName+"' already exists."),
+		)
+		certsClient.bundles[legacyName] = certificatesmanagement.CaBundleSummary{
+			Id:             &deletedID,
+			Name:           &legacyName,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleted,
+			FreeformTags:   backendTLSCABundleTags(policy, sha256Hex(caPEM)),
+		}
+		model, _ := makeModel(t, certsClient)
+
+		caID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, caPEM)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, caID)
+		require.Len(t, certsClient.createCalls, 1)
+		assert.NotEqual(t, legacyName, lo.FromPtr(certsClient.createCalls[0].CreateCaBundleDetails.Name))
 	})
 
 	t.Run("rejects unowned OCI CA bundle after create already exists conflict", func(t *testing.T) {
@@ -1779,6 +1832,25 @@ func assertBackendTLSPolicyCondition(
 	require.NotNil(t, condition)
 	assert.Equal(t, status, condition.Status)
 	assert.Equal(t, string(reason), condition.Reason)
+}
+
+func legacyBackendTLSCABundleName(
+	policy gatewayv1.BackendTLSPolicy,
+	targetRef gatewayv1.LocalPolicyTargetReferenceWithSectionName,
+	ref gatewayv1.LocalObjectReference,
+) string {
+	hashInput := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s/%s/%s",
+		policy.Namespace,
+		policy.Name,
+		targetRef.Group,
+		targetRef.Kind,
+		targetRef.Name,
+		lo.FromPtr(targetRef.SectionName),
+		ref.Group,
+		ref.Kind,
+		ref.Name,
+	)
+	return backendTLSCABundleNamePrefix + sha256Hex(hashInput)[:24]
 }
 
 func testCAPEM(t *testing.T) string {

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -1,0 +1,1519 @@
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaswdr/faker/v2"
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
+	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/types"
+)
+
+type stubCertificatesManagementClient struct {
+	bundles     map[string]certificatesmanagement.CaBundleSummary
+	createCalls []certificatesmanagement.CreateCaBundleRequest
+	updateCalls []certificatesmanagement.UpdateCaBundleRequest
+	deleteCalls []certificatesmanagement.DeleteCaBundleRequest
+	getErrByID  map[string]error
+	createErr   error
+	listErr     error
+	updateErr   error
+	deleteErr   error
+	nextID      int
+}
+
+func newStubCertificatesManagementClient() *stubCertificatesManagementClient {
+	return &stubCertificatesManagementClient{
+		bundles:    map[string]certificatesmanagement.CaBundleSummary{},
+		getErrByID: map[string]error{},
+	}
+}
+
+func (s *stubCertificatesManagementClient) CreateCaBundle(
+	_ context.Context,
+	request certificatesmanagement.CreateCaBundleRequest,
+) (certificatesmanagement.CreateCaBundleResponse, error) {
+	s.createCalls = append(s.createCalls, request)
+	if s.createErr != nil {
+		return certificatesmanagement.CreateCaBundleResponse{}, s.createErr
+	}
+	s.nextID++
+	id := "ocid1.cabundle.oc1..created" + string(rune('a'+s.nextID))
+	name := lo.FromPtr(request.CreateCaBundleDetails.Name)
+	bundle := certificatesmanagement.CaBundleSummary{
+		Id:             &id,
+		Name:           &name,
+		CompartmentId:  request.CreateCaBundleDetails.CompartmentId,
+		LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		FreeformTags:   request.CreateCaBundleDetails.FreeformTags,
+	}
+	s.bundles[name] = bundle
+	return certificatesmanagement.CreateCaBundleResponse{
+		CaBundle: certificatesmanagement.CaBundle{
+			Id:             &id,
+			Name:           &name,
+			CompartmentId:  request.CreateCaBundleDetails.CompartmentId,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   request.CreateCaBundleDetails.FreeformTags,
+		},
+	}, nil
+}
+
+func (s *stubCertificatesManagementClient) GetCaBundle(
+	_ context.Context,
+	request certificatesmanagement.GetCaBundleRequest,
+) (certificatesmanagement.GetCaBundleResponse, error) {
+	if err := s.getErrByID[lo.FromPtr(request.CaBundleId)]; err != nil {
+		return certificatesmanagement.GetCaBundleResponse{}, err
+	}
+	return certificatesmanagement.GetCaBundleResponse{
+		CaBundle: certificatesmanagement.CaBundle{
+			Id:             request.CaBundleId,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		},
+	}, nil
+}
+
+func (s *stubCertificatesManagementClient) ListCaBundles(
+	_ context.Context,
+	request certificatesmanagement.ListCaBundlesRequest,
+) (certificatesmanagement.ListCaBundlesResponse, error) {
+	if s.listErr != nil {
+		return certificatesmanagement.ListCaBundlesResponse{}, s.listErr
+	}
+	items := make([]certificatesmanagement.CaBundleSummary, 0)
+	if request.Name != nil {
+		if bundle, ok := s.bundles[lo.FromPtr(request.Name)]; ok {
+			items = append(items, bundle)
+		}
+	} else {
+		for _, bundle := range s.bundles {
+			items = append(items, bundle)
+		}
+	}
+	return certificatesmanagement.ListCaBundlesResponse{
+		CaBundleCollection: certificatesmanagement.CaBundleCollection{Items: items},
+	}, nil
+}
+
+func (s *stubCertificatesManagementClient) UpdateCaBundle(
+	_ context.Context,
+	request certificatesmanagement.UpdateCaBundleRequest,
+) (certificatesmanagement.UpdateCaBundleResponse, error) {
+	s.updateCalls = append(s.updateCalls, request)
+	if s.updateErr != nil {
+		return certificatesmanagement.UpdateCaBundleResponse{}, s.updateErr
+	}
+	for name, bundle := range s.bundles {
+		if lo.FromPtr(bundle.Id) == lo.FromPtr(request.CaBundleId) {
+			bundle.FreeformTags = request.UpdateCaBundleDetails.FreeformTags
+			s.bundles[name] = bundle
+			break
+		}
+	}
+	return certificatesmanagement.UpdateCaBundleResponse{}, nil
+}
+
+func (s *stubCertificatesManagementClient) DeleteCaBundle(
+	_ context.Context,
+	request certificatesmanagement.DeleteCaBundleRequest,
+) (certificatesmanagement.DeleteCaBundleResponse, error) {
+	s.deleteCalls = append(s.deleteCalls, request)
+	if s.deleteErr != nil {
+		return certificatesmanagement.DeleteCaBundleResponse{}, s.deleteErr
+	}
+	return certificatesmanagement.DeleteCaBundleResponse{}, nil
+}
+
+func TestBackendTLSPolicyModel(t *testing.T) {
+	t.Run("resolves multiple ConfigMap CA refs into OCI backend SSL config", func(t *testing.T) {
+		fakeData := faker.New()
+		namespace := fakeData.Lorem().Word()
+		serviceName := fakeData.Lorem().Word()
+		compartmentID := "ocid1.compartment.oc1.." + fakeData.UUID().V4()
+		lbID := "ocid1.loadbalancer.oc1.." + fakeData.UUID().V4()
+		gateway := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "edge"}}
+		service := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName},
+			Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{
+				Name:       "tls",
+				Port:       8443,
+				TargetPort: intstr.FromInt(8443),
+			}}},
+		}
+		options := map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+			BackendTLSOptionHostnameValidation:   backendTLSHostnameValidationDisabled,
+			BackendTLSOptionProtocols:            "TLSv1.2,TLSv1.3",
+			BackendTLSOptionCipherSuiteName:      "oci-tls-12-ssl-cipher-suite-v3",
+			BackendTLSOptionVerifyDepth:          "4",
+			BackendTLSOptionSessionResumption:    "true",
+			BackendTLSOptionTrustedCABundleOCIDs: "ocid1.cabundle.oc1..existing",
+		}
+		policy := backendTLSPolicy(namespace, "backend-tls", serviceName, "tls", options, "ca-one", "ca-two")
+		caOne := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca-one"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		caTwo := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca-two"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy, &service, &caOne, &caTwo).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().
+			GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadbalancer.LoadBalancer{
+				CompartmentId: &compartmentID,
+			}}, nil)
+		certsClient := newStubCertificatesManagementClient()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		sslConfig, err := model.resolveForBackendRef(t.Context(), resolveBackendTLSPolicyParams{
+			gateway: gateway,
+			config:  types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: lbID}},
+			service: service,
+			backendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: gatewayv1.ObjectName(serviceName),
+					Port: lo.ToPtr(gatewayv1.PortNumber(8443)),
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, sslConfig)
+		assert.True(t, lo.FromPtr(sslConfig.VerifyPeerCertificate))
+		assert.Equal(t, 4, lo.FromPtr(sslConfig.VerifyDepth))
+		assert.ElementsMatch(t, []string{"TLSv1.2", "TLSv1.3"}, sslConfig.Protocols)
+		assert.Equal(t, "oci-tls-12-ssl-cipher-suite-v3", lo.FromPtr(sslConfig.CipherSuiteName))
+		assert.True(t, lo.FromPtr(sslConfig.HasSessionResumption))
+		assert.Len(t, certsClient.createCalls, 2)
+		assert.Contains(t, sslConfig.TrustedCertificateAuthorityIds, "ocid1.cabundle.oc1..existing")
+		assert.Len(t, sslConfig.TrustedCertificateAuthorityIds, 3)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "backend-tls",
+		}, &updated))
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+		)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionTrue,
+			gatewayv1.BackendTLSPolicyReasonResolvedRefs,
+		)
+	})
+
+	t.Run("rejects policy without explicit OCI hostname validation opt out", func(t *testing.T) {
+		fakeData := faker.New()
+		namespace := fakeData.Lorem().Word()
+		serviceName := fakeData.Lorem().Word()
+		backendService := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}
+		policy := backendTLSPolicy(namespace, "backend-tls", serviceName, "", nil, "ca")
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy, &backendService, &ca).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveBackendTLSPolicyParams{
+			gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "edge"}},
+			config:  types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: "lb"}},
+			service: backendService,
+			backendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName(serviceName),
+			}},
+		})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, BackendTLSOptionHostnameValidation)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "backend-tls",
+		}, &updated))
+		require.Len(t, updated.Status.Ancestors, 1)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionFalse,
+			gatewayv1.PolicyReasonInvalid,
+		)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionFalse,
+			gatewayv1.PolicyReasonInvalid,
+		)
+	})
+}
+
+func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
+	fakeData := faker.New()
+	namespace := "btls-" + fakeData.Lorem().Word()
+	serviceName := "svc-" + fakeData.Lorem().Word()
+	compartmentID := "ocid1.compartment.oc1.." + fakeData.UUID().V4()
+	lbID := "ocid1.loadbalancer.oc1.." + fakeData.UUID().V4()
+	baseOptions := map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+		BackendTLSOptionHostnameValidation: backendTLSHostnameValidationDisabled,
+	}
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Name: "tls", Port: 8443}}},
+	}
+	gateway := gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "edge"},
+		Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{
+			ParametersRef: &gatewayv1.LocalParametersReference{
+				Group: gatewayv1.Group(types.GroupName),
+				Kind:  gatewayv1.Kind(ConfigRefKind),
+				Name:  "edge-config",
+			},
+		}},
+	}
+	config := types.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "edge-config"},
+		Spec:       types.GatewayConfigSpec{LoadBalancerID: lbID},
+	}
+
+	makeModel := func(
+		t *testing.T,
+		certsClient *stubCertificatesManagementClient,
+		objects ...client.Object,
+	) (*backendTLSPolicyModelImpl, *MockociLoadBalancerClient) {
+		t.Helper()
+		lbClient := NewMockociLoadBalancerClient(t)
+		return newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient: fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(objects...).
+				Build(),
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: certsClient,
+		}), lbClient
+	}
+	resolveParams := resolveBackendTLSPolicyParams{
+		gateway: gateway,
+		config:  config,
+		service: service,
+		backendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+			Name: gatewayv1.ObjectName(serviceName),
+			Port: lo.ToPtr(gatewayv1.PortNumber(8443)),
+		}},
+	}
+
+	t.Run("returns sentinel when no policy matches backend service", func(t *testing.T) {
+		otherNamespacePolicy := backendTLSPolicy("other", "other-namespace", serviceName, "tls", baseOptions, "ca")
+		model, _ := makeModel(t, newStubCertificatesManagementClient(), &service, &otherNamespacePolicy)
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorIs(t, err, errBackendTLSPolicyNotFound)
+	})
+
+	t.Run("selects oldest policy and marks lower precedence policy conflicted", func(t *testing.T) {
+		oldPolicy := backendTLSPolicy(namespace, "old", serviceName, "tls", baseOptions, "ca")
+		newPolicy := backendTLSPolicy(namespace, "new", serviceName, "tls", baseOptions, "ca")
+		oldPolicy.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Hour))
+		newPolicy.CreationTimestamp = metav1.Now()
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&service, &oldPolicy, &newPolicy, &ca).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		sslConfig, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.NoError(t, err)
+		require.NotNil(t, sslConfig)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "new",
+		}, &updated))
+		require.Len(t, updated.Status.Ancestors, 1)
+		assert.Equal(t, string(gatewayv1.PolicyReasonConflicted), updated.Status.Ancestors[0].Conditions[0].Reason)
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "old",
+		}, &updated))
+		require.Len(t, updated.Status.Ancestors, 1)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+		)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionTrue,
+			gatewayv1.BackendTLSPolicyReasonResolvedRefs,
+		)
+	})
+
+	t.Run("rejects target sectionName that does not exist on service", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "missing-section", serviceName, "missing", baseOptions, "ca")
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&service, &policy).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "sectionName")
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "missing-section",
+		}, &updated))
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionFalse,
+			gatewayv1.PolicyReasonTargetNotFound,
+		)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionFalse,
+			gatewayv1.PolicyReasonTargetNotFound,
+		)
+	})
+
+	t.Run("rejects unsupported target kind for backend service", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "bad-target-kind", serviceName, "", baseOptions, "ca")
+		policy.Spec.TargetRefs[0].Group = "apps"
+		policy.Spec.TargetRefs[0].Kind = "Deployment"
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&service, &policy).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "must reference a core Service")
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "bad-target-kind",
+		}, &updated))
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionFalse,
+			gatewayv1.BackendTLSPolicyReasonInvalidKind,
+		)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionFalse,
+			gatewayv1.BackendTLSPolicyReasonInvalidKind,
+		)
+	})
+
+	t.Run("rejects unsupported validation and option shapes", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			mutate func(*gatewayv1.BackendTLSPolicy)
+			want   string
+		}{
+			{
+				name: "well known CA certificates",
+				mutate: func(policy *gatewayv1.BackendTLSPolicy) {
+					wellKnown := gatewayv1.WellKnownCACertificatesType("System")
+					policy.Spec.Validation.WellKnownCACertificates = &wellKnown
+				},
+				want: "wellKnownCACertificates",
+			},
+			{
+				name: "subject alternative names",
+				mutate: func(policy *gatewayv1.BackendTLSPolicy) {
+					policy.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{{
+						Hostname: "backend.example.com",
+					}}
+				},
+				want: "subjectAltNames",
+			},
+			{
+				name: "unsupported option",
+				mutate: func(policy *gatewayv1.BackendTLSPolicy) {
+					policy.Spec.Options["example.com/unsupported"] = "true"
+				},
+				want: "unsupported BackendTLSPolicy option",
+			},
+			{
+				name: "missing CA refs",
+				mutate: func(policy *gatewayv1.BackendTLSPolicy) {
+					policy.Spec.Validation.CACertificateRefs = nil
+				},
+				want: "at least one caCertificateRef",
+			},
+			{
+				name: "invalid verify depth",
+				mutate: func(policy *gatewayv1.BackendTLSPolicy) {
+					policy.Spec.Options[BackendTLSOptionVerifyDepth] = "nope"
+				},
+				want: BackendTLSOptionVerifyDepth,
+			},
+			{
+				name: "invalid session resumption",
+				mutate: func(policy *gatewayv1.BackendTLSPolicy) {
+					policy.Spec.Options[BackendTLSOptionSessionResumption] = "maybe"
+				},
+				want: BackendTLSOptionSessionResumption,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				options := lo.Assign(map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{}, baseOptions)
+				policy := backendTLSPolicy(namespace, tt.name, serviceName, "tls", options, "ca")
+				tt.mutate(&policy)
+				ca := corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+					Data:       map[string]string{"ca.crt": testCAPEM(t)},
+				}
+				model, _ := makeModel(t, newStubCertificatesManagementClient(), &service, &policy, &ca)
+
+				_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.want)
+			})
+		}
+	})
+
+	t.Run("rejects invalid CA references", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			policy gatewayv1.BackendTLSPolicy
+			ca     *corev1.ConfigMap
+			want   string
+		}{
+			{
+				name: "wrong kind",
+				policy: func() gatewayv1.BackendTLSPolicy {
+					p := backendTLSPolicy(namespace, "wrong-kind", serviceName, "tls", baseOptions, "ca")
+					p.Spec.Validation.CACertificateRefs[0].Kind = "Secret"
+					return p
+				}(),
+				want: "must reference a core ConfigMap",
+			},
+			{
+				name:   "missing configmap",
+				policy: backendTLSPolicy(namespace, "missing", serviceName, "tls", baseOptions, "ca"),
+				want:   "was not found",
+			},
+			{
+				name:   "missing data key",
+				policy: backendTLSPolicy(namespace, "missing-key", serviceName, "tls", baseOptions, "ca"),
+				ca:     &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"}},
+				want:   "missing ca.crt",
+			},
+			{
+				name:   "invalid pem",
+				policy: backendTLSPolicy(namespace, "invalid-pem", serviceName, "tls", baseOptions, "ca"),
+				ca: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+					Data:       map[string]string{"ca.crt": "not-pem"},
+				},
+				want: "no CA certificates",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				objects := []client.Object{&service, &tt.policy}
+				if tt.ca != nil {
+					objects = append(objects, tt.ca)
+				}
+				model, _ := makeModel(t, newStubCertificatesManagementClient(), objects...)
+
+				_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.want)
+			})
+		}
+	})
+
+	t.Run("does not create OCI CA bundles until all refs and options are valid", func(t *testing.T) {
+		policy := backendTLSPolicy(
+			namespace,
+			"partial-invalid",
+			serviceName,
+			"tls",
+			baseOptions,
+			"ca-one",
+			"ca-missing",
+		)
+		caOne := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca-one"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		certsClient := newStubCertificatesManagementClient()
+		model, _ := makeModel(t, certsClient, &service, &policy, &caOne)
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorContains(t, err, "caCertificateRef ConfigMap")
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("does not create OCI CA bundles when finalizer update fails", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "finalizer-error", serviceName, "tls", baseOptions, "ca")
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		baseClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&service, &policy, &ca).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+		certsClient := newStubCertificatesManagementClient()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 &failingUpdateClient{k8sClient: baseClient, err: errors.New("update failed")},
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorContains(t, err, "failed to add BackendTLSPolicy finalizer")
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("updates owned OCI CA bundle when PEM changes", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "update", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		certsClient := newStubCertificatesManagementClient()
+		bundleID := "ocid1.cabundle.oc1..owned"
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:           &bundleID,
+			Name:         &name,
+			FreeformTags: backendTLSCABundleTags(policy, "old-hash"),
+		}
+		model, _ := makeModel(t, certsClient)
+
+		caID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, testCAPEM(t))
+
+		require.NoError(t, err)
+		assert.Equal(t, bundleID, caID)
+		assert.Len(t, certsClient.updateCalls, 1)
+	})
+
+	t.Run("reuses owned OCI CA bundle when hash matches", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "reuse", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		caPEM := testCAPEM(t)
+		certsClient := newStubCertificatesManagementClient()
+		bundleID := "ocid1.cabundle.oc1..reuse"
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:           &bundleID,
+			Name:         &name,
+			FreeformTags: backendTLSCABundleTags(policy, sha256Hex(caPEM)),
+		}
+		model, _ := makeModel(t, certsClient)
+
+		caID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, caPEM)
+
+		require.NoError(t, err)
+		assert.Equal(t, bundleID, caID)
+		assert.Empty(t, certsClient.createCalls)
+		assert.Empty(t, certsClient.updateCalls)
+	})
+
+	t.Run("updates OCI CA bundle when referenced ConfigMap CA changes", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "rotate", serviceName, "tls", baseOptions, "ca")
+		oldPEM := testCAPEM(t)
+		newPEM := testCAPEM(t)
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		bundleID := "ocid1.cabundle.oc1..rotate"
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:           &bundleID,
+			Name:         &name,
+			FreeformTags: backendTLSCABundleTags(policy, sha256Hex(oldPEM)),
+		}
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+			Data:       map[string]string{"ca.crt": newPEM},
+		}
+		model, lbClient := makeModel(t, certsClient, &service, &policy, &ca)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+
+		sslConfig, err := model.resolveAcceptedPolicy(t.Context(), backendTLSPolicyCandidate{
+			policy:    policy,
+			targetRef: targetRef,
+		}, resolveParams)
+
+		require.NoError(t, err)
+		require.NotNil(t, sslConfig)
+		assert.Len(t, certsClient.updateCalls, 1)
+		assert.Equal(t, newPEM, lo.FromPtr(certsClient.updateCalls[0].UpdateCaBundleDetails.CaBundlePem))
+	})
+
+	t.Run("rejects unowned existing OCI CA bundle", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "unowned", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		certsClient := newStubCertificatesManagementClient()
+		bundleID := "ocid1.cabundle.oc1..unowned"
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{Id: &bundleID, Name: &name}
+		model, _ := makeModel(t, certsClient)
+
+		_, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, testCAPEM(t))
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "not owned")
+	})
+
+	t.Run("cleans up owned OCI CA bundles and removes finalizer", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		certsClient := newStubCertificatesManagementClient()
+		ownedID := "ocid1.cabundle.oc1..owned"
+		ownedName := "owned"
+		certsClient.bundles[ownedName] = certificatesmanagement.CaBundleSummary{
+			Id:           &ownedID,
+			Name:         &ownedName,
+			FreeformTags: backendTLSCABundleTags(policy, "hash"),
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy, &gateway, &config).
+			Build()
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.NoError(t, err)
+		assert.Len(t, certsClient.deleteCalls, 1)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "cleanup",
+		}, &updated))
+		assert.NotContains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
+	})
+
+	t.Run("wraps OCI and Kubernetes errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "oci-errors", serviceName, "tls", baseOptions, "ca")
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		model, lbClient := makeModel(t, newStubCertificatesManagementClient(), &service, &policy, &ca)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{}, errors.New("oci unavailable"))
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to get Load Balancer")
+	})
+
+	t.Run("covers direct branch helpers and OCI CA errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "branches", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		servicePort := corev1.ServicePort{Name: "tls", Port: 8443}
+
+		_, matched := backendTLSPolicyTargetMatchesService(
+			gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "apps",
+					Kind:  "Service",
+					Name:  gatewayv1.ObjectName(serviceName),
+				},
+			},
+			service,
+			resolveParams.backendRef,
+		)
+		require.False(t, matched)
+		_, matched = backendTLSPolicyTargetMatchesService(
+			gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "",
+					Kind:  "Service",
+					Name:  gatewayv1.ObjectName(serviceName),
+				},
+				SectionName: lo.ToPtr(gatewayv1.SectionName("missing")),
+			},
+			corev1.Service{Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{servicePort}}},
+			resolveParams.backendRef,
+		)
+		require.False(t, matched)
+		require.True(t, backendTLSPolicyTargetRefUnsupportedKind(
+			gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "apps",
+					Kind:  "Deployment",
+					Name:  gatewayv1.ObjectName(serviceName),
+				},
+			},
+			service,
+		))
+		require.False(t, backendTLSPolicyTargetRefUnsupportedKind(
+			gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "apps",
+					Kind:  "Deployment",
+					Name:  gatewayv1.ObjectName("other"),
+				},
+			},
+			service,
+		))
+		require.False(t, backendTLSPolicyTargetRefMissingServicePort(
+			gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "",
+					Kind:  "Service",
+					Name:  gatewayv1.ObjectName(serviceName),
+				},
+				SectionName: lo.ToPtr(gatewayv1.SectionName("tls")),
+			},
+			service,
+		))
+		require.False(t, backendTLSPolicyTargetRefMissingServicePort(
+			gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "",
+					Kind:  "Service",
+					Name:  gatewayv1.ObjectName(serviceName),
+				},
+			},
+			service,
+		))
+		require.True(t, backendTLSPolicyTargetRefMissingServicePort(
+			gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "",
+					Kind:  "Service",
+					Name:  gatewayv1.ObjectName(serviceName),
+				},
+				SectionName: lo.ToPtr(gatewayv1.SectionName("missing")),
+			},
+			service,
+		))
+
+		left := backendTLSPolicy(namespace, "a", serviceName, "tls", baseOptions, "ca")
+		right := backendTLSPolicy(namespace, "b", serviceName, "tls", baseOptions, "ca")
+		left.CreationTimestamp = right.CreationTimestamp
+		candidates := []backendTLSPolicyCandidate{{policy: right}, {policy: left}}
+		sortBackendTLSPolicyCandidates(candidates)
+		require.Equal(t, "a", candidates[0].policy.Name)
+		sectionName := backendTLSCABundleName(policy, targetRef, ref)
+		wholeServiceTargetRef := targetRef
+		wholeServiceTargetRef.SectionName = nil
+		wholeServiceName := backendTLSCABundleName(policy, wholeServiceTargetRef, ref)
+		require.NotEqual(t, sectionName, wholeServiceName)
+		require.Len(t, sectionName, len(backendTLSCABundleNamePrefix)+24)
+		require.True(t, strings.HasPrefix(sectionName, backendTLSCABundleNamePrefix))
+		require.True(t, parentRefsEqual(
+			gatewayv1.ParentReference{Name: "edge"},
+			gatewayv1.ParentReference{Name: "edge"},
+		))
+		require.False(t, parentRefsEqual(
+			gatewayv1.ParentReference{Name: "edge"},
+			gatewayv1.ParentReference{Name: "other"},
+		))
+
+		require.ErrorContains(t, validateCABundlePEM(nonCAPEM(t)), "not a CA certificate")
+		require.ErrorContains(t, validateCABundlePEM(testCAPEM(t)+"trailing"), "unexpected trailing data")
+		privateKeyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("abc")}))
+		require.ErrorContains(t, validateCABundlePEM(privateKeyPEM), "unexpected PEM block")
+		badCertPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("abc")}))
+		require.ErrorContains(t, validateCABundlePEM(badCertPEM), "failed to parse")
+
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.listErr = errors.New("list failed")
+		model, _ := makeModel(t, certsClient)
+		_, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, testCAPEM(t))
+		require.ErrorContains(t, err, "failed to list OCI CA bundles")
+
+		certsClient = newStubCertificatesManagementClient()
+		certsClient.createErr = errors.New("create failed")
+		model, _ = makeModel(t, certsClient)
+		_, err = model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, testCAPEM(t))
+		require.ErrorContains(t, err, "failed to create OCI CA bundle")
+
+		certsClient = newStubCertificatesManagementClient()
+		certsClient.updateErr = errors.New("update failed")
+		bundleName := backendTLSCABundleName(policy, targetRef, ref)
+		bundleID := "ocid1.cabundle.oc1..updateerr"
+		certsClient.bundles[bundleName] = certificatesmanagement.CaBundleSummary{
+			Id:           &bundleID,
+			Name:         &bundleName,
+			FreeformTags: backendTLSCABundleTags(policy, "old"),
+		}
+		model, _ = makeModel(t, certsClient)
+		_, err = model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, testCAPEM(t))
+		require.ErrorContains(t, err, "failed to update OCI CA bundle")
+
+		require.NoError(t, model.deleteOwnedCABundles(t.Context(), policy, ""))
+		certsClient.deleteErr = errors.New("delete failed")
+		err = model.deleteOwnedCABundles(t.Context(), policy, compartmentID)
+		require.ErrorContains(t, err, "failed to delete OCI CA bundle")
+
+		certsClient = newStubCertificatesManagementClient()
+		unownedID := "ocid1.cabundle.oc1..unownedcleanup"
+		unownedName := "unowned"
+		certsClient.bundles[unownedName] = certificatesmanagement.CaBundleSummary{
+			Id:           &unownedID,
+			Name:         &unownedName,
+			FreeformTags: map[string]string{backendTLSManagedByTag: "someone-else"},
+		}
+		model, _ = makeModel(t, certsClient)
+		require.NoError(t, model.deleteOwnedCABundles(t.Context(), policy, compartmentID))
+		require.Empty(t, certsClient.deleteCalls)
+
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		require.NoError(t, model.ensurePolicyFinalizerAndCompartment(t.Context(), policy, ""))
+
+		noFinalizerPolicy := backendTLSPolicy(namespace, "add-finalizer", serviceName, "tls", baseOptions, "ca")
+		k8sClient := fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(&noFinalizerPolicy).Build()
+		model = newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+		require.NoError(t, model.ensurePolicyFinalizerAndCompartment(t.Context(), noFinalizerPolicy, compartmentID))
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "add-finalizer",
+		}, &updated))
+		require.Contains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
+		require.Equal(t, compartmentID, updated.Annotations[BackendTLSPolicyCompartmentsAnnotation])
+	})
+
+	t.Run("rejects missing LB compartment and invalid existing CA bundle option", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "lb-compartment", serviceName, "tls", baseOptions, "ca")
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		model, lbClient := makeModel(t, newStubCertificatesManagementClient(), &service, &policy, &ca)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadbalancer.LoadBalancer{}}, nil)
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorContains(t, err, "failed to resolve Load Balancer compartment")
+
+		policy = backendTLSPolicy(namespace, "bad-option-ca", serviceName, "tls", lo.Assign(
+			map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{},
+			baseOptions,
+			map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				BackendTLSOptionTrustedCABundleOCIDs: "ocid1.cabundle.oc1..missing",
+			},
+		), "ca")
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.getErrByID["ocid1.cabundle.oc1..missing"] = errors.New("not found")
+		model, _ = makeModel(t, certsClient, &service, &policy, &ca)
+
+		_, err = model.resolveForBackendRef(t.Context(), resolveParams)
+
+		require.ErrorContains(t, err, "cannot be resolved")
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("cleanup no-ops without finalizer and wraps list errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-no-finalizer", serviceName, "tls", baseOptions, "ca")
+		model, _ := makeModel(t, newStubCertificatesManagementClient(), &policy)
+		require.NoError(t, model.cleanupDeletingPolicy(t.Context(), policy))
+
+		model = newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 &failingListClient{err: errors.New("list failed")},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.ErrorContains(t, err, "failed to list Gateways")
+	})
+
+	t.Run("cleanup wraps GatewayConfig lookup errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-config-error", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		gatewayWithConfig := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "config-error"},
+			Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{Name: "config-error"},
+			}},
+		}
+		baseClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy, &gatewayWithConfig).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient: &failingBackendTLSPolicyClient{
+				k8sClient: baseClient,
+				err:       errors.New("get failed"),
+			},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.ErrorContains(t, err, "failed to get GatewayConfig")
+	})
+
+	t.Run("cleanup removes finalizer when no gateway references a load balancer", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-no-gateway-lb", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.NoError(t, err)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "cleanup-no-gateway-lb",
+		}, &updated))
+		require.NotContains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
+	})
+
+	t.Run("cleanup uses recorded compartments when gateway is gone", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-recorded-compartment", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		policy.Annotations = map[string]string{
+			BackendTLSPolicyCompartmentsAnnotation: " " + compartmentID + ", " + compartmentID + " ",
+		}
+		certsClient := newStubCertificatesManagementClient()
+		ownedID := "ocid1.cabundle.oc1..recorded"
+		ownedName := "recorded"
+		certsClient.bundles[ownedName] = certificatesmanagement.CaBundleSummary{
+			Id:           &ownedID,
+			Name:         &ownedName,
+			FreeformTags: backendTLSCABundleTags(policy, "hash"),
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.NoError(t, err)
+		require.Len(t, certsClient.deleteCalls, 1)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "cleanup-recorded-compartment",
+		}, &updated))
+		require.NotContains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
+		require.NotContains(t, updated.Annotations, BackendTLSPolicyCompartmentsAnnotation)
+	})
+
+	t.Run("cleanup prefers recorded compartments over live load balancer lookup", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-recorded-over-live", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		policy.Annotations = map[string]string{BackendTLSPolicyCompartmentsAnnotation: compartmentID}
+		gatewayWithDeletedLB := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "deleted-lb"},
+			Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{Name: "deleted-lb-config"},
+			}},
+		}
+		deletedLBConfig := types.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "deleted-lb-config"},
+			Spec:       types.GatewayConfigSpec{LoadBalancerID: "deleted-lb"},
+		}
+		certsClient := newStubCertificatesManagementClient()
+		ownedID := "ocid1.cabundle.oc1..recordedlive"
+		ownedName := "recorded-live"
+		certsClient.bundles[ownedName] = certificatesmanagement.CaBundleSummary{
+			Id:           &ownedID,
+			Name:         &ownedName,
+			FreeformTags: backendTLSCABundleTags(policy, "hash"),
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy, &gatewayWithDeletedLB, &deletedLBConfig).
+			Build()
+		lbClient := NewMockociLoadBalancerClient(t)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.NoError(t, err)
+		require.Len(t, certsClient.deleteCalls, 1)
+	})
+
+	t.Run("cleanup skips incomplete gateway state and returns CA delete errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-branches", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		gatewayNoInfra := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "no-infra"}}
+		gatewayMissingConfig := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "missing-config"},
+			Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{Name: "missing"},
+			}},
+		}
+		gatewayDeleteError := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "delete-error"},
+			Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{Name: "delete-error-config"},
+			}},
+		}
+		deleteErrorConfig := types.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "delete-error-config"},
+			Spec:       types.GatewayConfigSpec{LoadBalancerID: "delete-error"},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(
+				&policy,
+				&gatewayNoInfra,
+				&gatewayMissingConfig,
+				&gatewayDeleteError,
+				&deleteErrorConfig,
+			).
+			Build()
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().
+			GetLoadBalancer(t.Context(), mock.MatchedBy(func(request loadbalancer.GetLoadBalancerRequest) bool {
+				return lo.FromPtr(request.LoadBalancerId) == "delete-error"
+			})).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.listErr = errors.New("ca list failed")
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.ErrorContains(t, err, "failed to list OCI CA bundles")
+	})
+
+	t.Run("cleanup returns load balancer lookup errors and keeps finalizer", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-lb-error", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		gatewayLBError := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "lb-error"},
+			Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{Name: "lb-error-config"},
+			}},
+		}
+		lbErrorConfig := types.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "lb-error-config"},
+			Spec:       types.GatewayConfigSpec{LoadBalancerID: "lb-error"},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy, &gatewayLBError, &lbErrorConfig).
+			Build()
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().
+			GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{}, errors.New("lb get failed"))
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.ErrorContains(t, err, "failed to get Load Balancer lb-error for BackendTLSPolicy cleanup")
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "cleanup-lb-error",
+		}, &updated))
+		require.Contains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
+	})
+
+	t.Run("cleanup wraps finalizer removal errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-update-error", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		baseClient := fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(&policy).Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 &failingUpdateClient{k8sClient: baseClient, err: errors.New("update failed")},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.ErrorContains(t, err, "failed to remove BackendTLSPolicy finalizer")
+	})
+
+	t.Run("setPolicyCondition updates existing ancestor status", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "existing-status", serviceName, "tls", baseOptions, "ca")
+		gatewayNamespace := gatewayv1.Namespace(gateway.Namespace)
+		policy.Status.Ancestors = []gatewayv1.PolicyAncestorStatus{{
+			AncestorRef: gatewayv1.ParentReference{
+				Group:     lo.ToPtr(gatewayv1.Group(gatewayv1.GroupName)),
+				Kind:      lo.ToPtr(gatewayv1.Kind("Gateway")),
+				Namespace: &gatewayNamespace,
+				Name:      gatewayv1.ObjectName(gateway.Name),
+			},
+			ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			Conditions: []metav1.Condition{{
+				Type:   string(gatewayv1.PolicyConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.PolicyReasonInvalid),
+			}},
+		}}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		err := model.setPolicyCondition(
+			t.Context(),
+			policy,
+			gateway,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+			"accepted",
+		)
+
+		require.NoError(t, err)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "existing-status",
+		}, &updated))
+		require.Len(t, updated.Status.Ancestors, 1)
+		require.Equal(t, metav1.ConditionTrue, updated.Status.Ancestors[0].Conditions[0].Status)
+	})
+
+	t.Run("wraps direct Kubernetes write and lookup errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "k8s-errors", serviceName, "tls", baseOptions, "ca")
+		backendService := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 &failingListClient{err: errors.New("policy list failed")},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		_, err := model.resolveForBackendRef(t.Context(), resolveBackendTLSPolicyParams{
+			gateway: gateway,
+			config:  config,
+			service: backendService,
+			backendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName(serviceName),
+			}},
+		})
+		require.ErrorContains(t, err, "failed to list BackendTLSPolicies")
+
+		model = newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 &failingUpdateClient{err: errors.New("update failed")},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+		err = model.ensurePolicyFinalizerAndCompartment(t.Context(), policy, compartmentID)
+		require.ErrorContains(t, err, "failed to add BackendTLSPolicy finalizer")
+
+		model = newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 &failingBackendTLSPolicyClient{err: errors.New("get failed")},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+		err = model.setPolicyCondition(
+			t.Context(),
+			policy,
+			gateway,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+			"accepted",
+		)
+		require.ErrorContains(t, err, "failed to get BackendTLSPolicy")
+
+		model = newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 &failingBackendTLSPolicyClient{err: errors.New("configmap get failed")},
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+		_, err = model.resolveCACertificateRefPEM(
+			t.Context(),
+			policy,
+			gatewayv1.LocalObjectReference{Group: "", Kind: "ConfigMap", Name: "ca"},
+		)
+		require.ErrorContains(t, err, "failed to get caCertificateRef ConfigMap")
+	})
+}
+
+func backendTLSPolicy(
+	namespace string,
+	name string,
+	serviceName string,
+	sectionName string,
+	options map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue,
+	caRefs ...string,
+) gatewayv1.BackendTLSPolicy {
+	targetRef := gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+		LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+			Group: "",
+			Kind:  "Service",
+			Name:  gatewayv1.ObjectName(serviceName),
+		},
+	}
+	if sectionName != "" {
+		targetSectionName := gatewayv1.SectionName(sectionName)
+		targetRef.SectionName = &targetSectionName
+	}
+	refs := lo.Map(caRefs, func(name string, _ int) gatewayv1.LocalObjectReference {
+		return gatewayv1.LocalObjectReference{Group: "", Kind: "ConfigMap", Name: gatewayv1.ObjectName(name)}
+	})
+	return gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              name,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{targetRef},
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				Hostname:          "backend.example.com",
+				CACertificateRefs: refs,
+			},
+			Options: options,
+		},
+	}
+}
+
+func assertBackendTLSPolicyCondition(
+	t *testing.T,
+	policy gatewayv1.BackendTLSPolicy,
+	conditionType gatewayv1.PolicyConditionType,
+	status metav1.ConditionStatus,
+	reason gatewayv1.PolicyConditionReason,
+) {
+	t.Helper()
+
+	require.Len(t, policy.Status.Ancestors, 1)
+	condition := meta.FindStatusCondition(policy.Status.Ancestors[0].Conditions, string(conditionType))
+	require.NotNil(t, condition)
+	assert.Equal(t, status, condition.Status)
+	assert.Equal(t, string(reason), condition.Reason)
+}
+
+func testCAPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func nonCAPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "not-ca"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+type failingListClient struct {
+	k8sClient
+
+	err error
+}
+
+func (c *failingListClient) List(
+	_ context.Context,
+	_ client.ObjectList,
+	_ ...client.ListOption,
+) error {
+	return c.err
+}
+
+type failingUpdateClient struct {
+	k8sClient
+
+	err error
+}
+
+func (c *failingUpdateClient) Update(
+	_ context.Context,
+	_ client.Object,
+	_ ...client.UpdateOption,
+) error {
+	return c.err
+}

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"math/big"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -30,20 +31,23 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
 	"github.com/gemyago/oke-gateway-api/internal/types"
 )
 
 type stubCertificatesManagementClient struct {
-	bundles     map[string]certificatesmanagement.CaBundleSummary
-	createCalls []certificatesmanagement.CreateCaBundleRequest
-	updateCalls []certificatesmanagement.UpdateCaBundleRequest
-	deleteCalls []certificatesmanagement.DeleteCaBundleRequest
-	getErrByID  map[string]error
-	createErr   error
-	listErr     error
-	updateErr   error
-	deleteErr   error
-	nextID      int
+	bundles            map[string]certificatesmanagement.CaBundleSummary
+	createCalls        []certificatesmanagement.CreateCaBundleRequest
+	updateCalls        []certificatesmanagement.UpdateCaBundleRequest
+	deleteCalls        []certificatesmanagement.DeleteCaBundleRequest
+	getErrByID         map[string]error
+	createErr          error
+	createState        certificatesmanagement.CaBundleLifecycleStateEnum
+	listErr            error
+	listEmptyResponses int
+	updateErr          error
+	deleteErr          error
+	nextID             int
 }
 
 func newStubCertificatesManagementClient() *stubCertificatesManagementClient {
@@ -64,11 +68,15 @@ func (s *stubCertificatesManagementClient) CreateCaBundle(
 	s.nextID++
 	id := "ocid1.cabundle.oc1..created" + string(rune('a'+s.nextID))
 	name := lo.FromPtr(request.CreateCaBundleDetails.Name)
+	lifecycleState := s.createState
+	if lifecycleState == "" {
+		lifecycleState = certificatesmanagement.CaBundleLifecycleStateActive
+	}
 	bundle := certificatesmanagement.CaBundleSummary{
 		Id:             &id,
 		Name:           &name,
 		CompartmentId:  request.CreateCaBundleDetails.CompartmentId,
-		LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		LifecycleState: lifecycleState,
 		FreeformTags:   request.CreateCaBundleDetails.FreeformTags,
 	}
 	s.bundles[name] = bundle
@@ -77,7 +85,7 @@ func (s *stubCertificatesManagementClient) CreateCaBundle(
 			Id:             &id,
 			Name:           &name,
 			CompartmentId:  request.CreateCaBundleDetails.CompartmentId,
-			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			LifecycleState: lifecycleState,
 			FreeformTags:   request.CreateCaBundleDetails.FreeformTags,
 		},
 	}, nil
@@ -104,6 +112,12 @@ func (s *stubCertificatesManagementClient) ListCaBundles(
 ) (certificatesmanagement.ListCaBundlesResponse, error) {
 	if s.listErr != nil {
 		return certificatesmanagement.ListCaBundlesResponse{}, s.listErr
+	}
+	if s.listEmptyResponses > 0 {
+		s.listEmptyResponses--
+		return certificatesmanagement.ListCaBundlesResponse{
+			CaBundleCollection: certificatesmanagement.CaBundleCollection{Items: nil},
+		}, nil
 	}
 	items := make([]certificatesmanagement.CaBundleSummary, 0)
 	if request.Name != nil {
@@ -723,6 +737,120 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		assert.Empty(t, certsClient.updateCalls)
 	})
 
+	t.Run("waits for existing owned OCI CA bundle to become active", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "creating", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		caPEM := testCAPEM(t)
+		certsClient := newStubCertificatesManagementClient()
+		bundleID := "ocid1.cabundle.oc1..creating"
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             &bundleID,
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateCreating,
+			FreeformTags:   backendTLSCABundleTags(policy, sha256Hex(caPEM)),
+		}
+		model, _ := makeModel(t, certsClient)
+
+		_, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, caPEM)
+
+		require.ErrorContains(t, err, "not ready")
+		assert.Empty(t, certsClient.createCalls)
+		assert.Empty(t, certsClient.updateCalls)
+	})
+
+	t.Run("waits when newly created OCI CA bundle is not active yet", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "create-wait", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.createState = certificatesmanagement.CaBundleLifecycleStateCreating
+		model, _ := makeModel(t, certsClient)
+
+		_, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, testCAPEM(t))
+
+		require.ErrorContains(t, err, "not ready")
+		assert.Len(t, certsClient.createCalls, 1)
+	})
+
+	t.Run("classifies OCI CA bundle lifecycle states for backend TLS", func(t *testing.T) {
+		name := "managed-ca"
+		require.NoError(t, ensureBackendTLSCABundleUsable(certificatesmanagement.CaBundleSummary{
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		}))
+		require.ErrorContains(t, ensureBackendTLSCABundleUsable(certificatesmanagement.CaBundleSummary{
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleting,
+		}), "cannot be reused")
+		require.ErrorContains(t, ensureBackendTLSCABundleUsable(certificatesmanagement.CaBundleSummary{
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateFailed,
+		}), "not ready")
+		require.ErrorContains(t, ensureBackendTLSCABundleUsable(certificatesmanagement.CaBundleSummary{
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateEnum("UNKNOWN"),
+		}), "not ready")
+	})
+
+	t.Run("reuses owned OCI CA bundle after create already exists conflict", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "create-conflict", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		caPEM := testCAPEM(t)
+		bundleID := "ocid1.cabundle.oc1..conflict"
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.createErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusBadRequest),
+			ociapi.RandomServiceErrorWithCode("InvalidParameter"),
+			ociapi.RandomServiceErrorWithMessage("A CA bundle with the name '"+name+"' already exists."),
+		)
+		certsClient.listEmptyResponses = 1
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             &bundleID,
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   backendTLSCABundleTags(policy, sha256Hex(caPEM)),
+		}
+		model, _ := makeModel(t, certsClient)
+
+		caID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, caPEM)
+
+		require.NoError(t, err)
+		assert.Equal(t, bundleID, caID)
+		assert.Len(t, certsClient.createCalls, 1)
+		assert.Empty(t, certsClient.updateCalls)
+	})
+
+	t.Run("rejects unowned OCI CA bundle after create already exists conflict", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "create-conflict-unowned", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		bundleID := "ocid1.cabundle.oc1..unowned"
+		certsClient := newStubCertificatesManagementClient()
+		certsClient.createErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusBadRequest),
+			ociapi.RandomServiceErrorWithCode("InvalidParameter"),
+			ociapi.RandomServiceErrorWithMessage("A CA bundle with the name '"+name+"' already exists."),
+		)
+		certsClient.listEmptyResponses = 1
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             &bundleID,
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		}
+		model, _ := makeModel(t, certsClient)
+
+		_, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, testCAPEM(t))
+
+		require.ErrorContains(t, err, "not owned")
+		assert.Len(t, certsClient.createCalls, 1)
+		assert.Empty(t, certsClient.updateCalls)
+	})
+
 	t.Run("updates OCI CA bundle when referenced ConfigMap CA changes", func(t *testing.T) {
 		policy := backendTLSPolicy(namespace, "rotate", serviceName, "tls", baseOptions, "ca")
 		oldPEM := testCAPEM(t)
@@ -1183,6 +1311,89 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Len(t, certsClient.deleteCalls, 1)
+	})
+
+	t.Run("cleanup ignores deleted owned OCI CA bundles", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-deleted-bundle", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		policy.Annotations = map[string]string{BackendTLSPolicyCompartmentsAnnotation: compartmentID}
+		certsClient := newStubCertificatesManagementClient()
+		ownedID := "ocid1.cabundle.oc1..deleted"
+		ownedName := "deleted"
+		certsClient.bundles[ownedName] = certificatesmanagement.CaBundleSummary{
+			Id:             &ownedID,
+			Name:           &ownedName,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleted,
+			FreeformTags:   backendTLSCABundleTags(policy, "hash"),
+		}
+		deletingID := "ocid1.cabundle.oc1..deleting"
+		deletingName := "deleting"
+		certsClient.bundles[deletingName] = certificatesmanagement.CaBundleSummary{
+			Id:             &deletingID,
+			Name:           &deletingName,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleting,
+			FreeformTags:   backendTLSCABundleTags(policy, "hash"),
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.NoError(t, err)
+		assert.Empty(t, certsClient.deleteCalls)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "cleanup-deleted-bundle",
+		}, &updated))
+		require.NotContains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
+	})
+
+	t.Run("cleanup treats missing OCI CA bundle as already deleted", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cleanup-missing-bundle", serviceName, "tls", baseOptions, "ca")
+		policy.Finalizers = []string{BackendTLSPolicyProgrammedFinalizer}
+		policy.Annotations = map[string]string{BackendTLSPolicyCompartmentsAnnotation: compartmentID}
+		certsClient := newStubCertificatesManagementClient()
+		ownedID := "ocid1.cabundle.oc1..missing"
+		ownedName := "missing"
+		certsClient.bundles[ownedName] = certificatesmanagement.CaBundleSummary{
+			Id:           &ownedID,
+			Name:         &ownedName,
+			FreeformTags: backendTLSCABundleTags(policy, "hash"),
+		}
+		certsClient.deleteErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+			ociapi.RandomServiceErrorWithCode("NotAuthorizedOrNotFound"),
+		)
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: certsClient,
+		})
+
+		err := model.cleanupDeletingPolicy(t.Context(), policy)
+
+		require.NoError(t, err)
+		assert.Len(t, certsClient.deleteCalls, 1)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "cleanup-missing-bundle",
+		}, &updated))
+		require.NotContains(t, updated.Finalizers, BackendTLSPolicyProgrammedFinalizer)
 	})
 
 	t.Run("cleanup skips incomplete gateway state and returns CA delete errors", func(t *testing.T) {

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -22,6 +22,30 @@ const (
 	// ListenerTLSOptionOCICertificateOCID configures an existing OCI Certificates Service certificate for a listener.
 	ListenerTLSOptionOCICertificateOCID = "oci.oraclecloud.com/certificate-ocid"
 
+	// BackendTLSPolicyProgrammedFinalizer is used to clean up controller-managed OCI CA bundles.
+	BackendTLSPolicyProgrammedFinalizer = "oke-gateway-api.gemyago.github.io/backend-tls-policy-programmed"
+
+	// BackendTLSPolicyCompartmentsAnnotation stores OCI compartments with controller-managed CA bundles.
+	BackendTLSPolicyCompartmentsAnnotation = "oke-gateway-api.gemyago.github.io/backend-tls-policy-compartments"
+
+	// BackendTLSOptionHostnameValidation acknowledges OCI backend TLS does not enforce hostname/SAN validation.
+	BackendTLSOptionHostnameValidation = "oci.oraclecloud.com/backend-hostname-validation"
+
+	// BackendTLSOptionTrustedCABundleOCIDs adds existing OCI Certificates Management CA bundle OCIDs.
+	BackendTLSOptionTrustedCABundleOCIDs = "oci.oraclecloud.com/trusted-ca-bundle-ocids"
+
+	// BackendTLSOptionProtocols configures OCI backend SSL protocols as a comma-separated list.
+	BackendTLSOptionProtocols = "oci.oraclecloud.com/tls-protocols"
+
+	// BackendTLSOptionCipherSuiteName configures OCI backend SSL cipher suite name.
+	BackendTLSOptionCipherSuiteName = "oci.oraclecloud.com/cipher-suite-name"
+
+	// BackendTLSOptionVerifyDepth configures OCI backend SSL peer certificate verification depth.
+	BackendTLSOptionVerifyDepth = "oci.oraclecloud.com/verify-depth"
+
+	// BackendTLSOptionSessionResumption configures OCI backend SSL session resumption.
+	BackendTLSOptionSessionResumption = "oci.oraclecloud.com/session-resumption"
+
 	// HTTPRouteProgrammingRevisionAnnotation is the annotation for the http route programming revision.
 	// The revision may be incremented if additional programming steps are introduced by the controller.
 	HTTPRouteProgrammingRevisionAnnotation = "oke-gateway-api.gemyago.github.io/http-route-programming-revision"

--- a/internal/app/grpcroute_controller.go
+++ b/internal/app/grpcroute_controller.go
@@ -39,6 +39,12 @@ func NewGRPCRouteController(deps GRPCRouteControllerDeps) *GRPCRouteController {
 	}
 }
 
+func (r *GRPCRouteController) SetBackendTLSPolicyEnabled(enabled bool) {
+	if model, ok := r.grpcRouteModel.(interface{ setBackendTLSPolicyEnabled(bool) }); ok {
+		model.setBackendTLSPolicyEnabled(enabled)
+	}
+}
+
 func (r *GRPCRouteController) reconcileResolvedRoute(
 	ctx context.Context,
 	resolvedData resolvedGRPCRouteDetails,

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -151,6 +151,21 @@ func TestGRPCRouteController(t *testing.T) {
 		}
 	}
 
+	t.Run("sets BackendTLSPolicy availability on concrete model", func(t *testing.T) {
+		model := &grpcRouteModelImpl{}
+		controller := NewGRPCRouteController(GRPCRouteControllerDeps{
+			RootLogger:       diag.RootTestLogger(),
+			GRPCRouteModel:   model,
+			HTTPBackendModel: NewMockhttpBackendModel(t),
+		})
+
+		controller.SetBackendTLSPolicyEnabled(false)
+		require.True(t, model.backendTLSDisabled)
+
+		controller.SetBackendTLSPolicyEnabled(true)
+		require.False(t, model.backendTLSDisabled)
+	})
+
 	t.Run("programs route and syncs endpoints", func(t *testing.T) {
 		route := makeRoute()
 		resolved := makeResolved(route)

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -133,6 +133,7 @@ type grpcRouteModelImpl struct {
 	gatewayModel         gatewayModel
 	resourcesModel       resourcesModel
 	ociLoadBalancerModel ociLoadBalancerModel
+	backendTLSPolicy     backendTLSPolicyModel
 }
 
 func (m *grpcRouteModelImpl) resolveRouteParentRefData(
@@ -441,12 +442,15 @@ func (m *grpcRouteModelImpl) programRoute(
 
 	routePolicyParams := programL7RoutePolicyParams{
 		loadBalancerID:      params.config.Spec.LoadBalancerID,
+		gateway:             params.gateway,
+		config:              params.config,
 		routeName:           params.grpcRoute.Name,
 		routeNamespace:      params.grpcRoute.Namespace,
 		backendRefs:         grpcRouteBackendRefs(params.grpcRoute),
 		knownBackends:       params.knownBackends,
 		matchedListeners:    params.matchedListeners,
 		previousPolicyRules: previousRules,
+		backendTLSPolicy:    m.backendTLSPolicy,
 		ruleCount:           len(params.grpcRoute.Spec.Rules),
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeGRPCRoutingRule(ctx, makeGRPCRoutingRuleParams{
@@ -635,6 +639,7 @@ type grpcRouteModelDeps struct {
 	GatewayModel   gatewayModel
 	OciLBModel     ociLoadBalancerModel
 	ResourcesModel resourcesModel
+	BackendTLS     backendTLSPolicyModel
 }
 
 func newGRPCRouteModel(deps grpcRouteModelDeps) *grpcRouteModelImpl {
@@ -644,5 +649,6 @@ func newGRPCRouteModel(deps grpcRouteModelDeps) *grpcRouteModelImpl {
 		gatewayModel:         deps.GatewayModel,
 		ociLoadBalancerModel: deps.OciLBModel,
 		resourcesModel:       deps.ResourcesModel,
+		backendTLSPolicy:     deps.BackendTLS,
 	}
 }

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -134,6 +134,7 @@ type grpcRouteModelImpl struct {
 	resourcesModel       resourcesModel
 	ociLoadBalancerModel ociLoadBalancerModel
 	backendTLSPolicy     backendTLSPolicyModel
+	backendTLSDisabled   bool
 }
 
 func (m *grpcRouteModelImpl) resolveRouteParentRefData(
@@ -451,6 +452,7 @@ func (m *grpcRouteModelImpl) programRoute(
 		matchedListeners:    params.matchedListeners,
 		previousPolicyRules: previousRules,
 		backendTLSPolicy:    m.backendTLSPolicy,
+		backendTLSDisabled:  m.backendTLSDisabled,
 		ruleCount:           len(params.grpcRoute.Spec.Rules),
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeGRPCRoutingRule(ctx, makeGRPCRoutingRuleParams{
@@ -629,6 +631,10 @@ func (m *grpcRouteModelImpl) setProgrammed(
 	}
 
 	return nil
+}
+
+func (m *grpcRouteModelImpl) setBackendTLSPolicyEnabled(enabled bool) {
+	m.backendTLSDisabled = !enabled
 }
 
 type grpcRouteModelDeps struct {

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1093,6 +1093,56 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		)
 	})
 
+	t.Run("programRoute removes stale backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newGRPCRouteModel(deps)
+		model.backendTLSPolicy = &stubBackendTLSPolicyModel{resolveErr: errBackendTLSPolicyNotFound}
+		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+		config := makeRandomGatewayConfig()
+		backendRef := makeGRPCBackendRef()
+		listener := gatewayv1.Listener{Name: gatewayv1.SectionName("grpc"), Port: 50051}
+		route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+			route.Spec.Rules = []gatewayv1.GRPCRouteRule{{
+				BackendRefs: []gatewayv1.GRPCBackendRef{backendRef},
+			}}
+		})
+		service := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(backendRef.Name)},
+		}
+		ruleName := "grpc_rule_" + fake.Lorem().Word()
+		routingRule := loadbalancer.RoutingRule{Name: &ruleName}
+
+		ociLBModel.EXPECT().
+			reconcileBackendSet(t.Context(), mock.MatchedBy(func(params reconcileBackendSetParams) bool {
+				return params.loadBalancerID == config.Spec.LoadBalancerID &&
+					params.service.Name == service.Name &&
+					params.backendRef.Name == backendRef.Name &&
+					params.manageSSLConfig &&
+					params.sslConfig == nil
+			})).
+			Return(nil).
+			Once()
+		ociLBModel.EXPECT().makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
+			grpcRoute:          route,
+			grpcRouteRuleIndex: 0,
+		}).Return(routingRule, nil).Once()
+		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+			loadBalancerID: config.Spec.LoadBalancerID,
+			listenerName:   string(listener.Name),
+			policyRules:    []loadbalancer.RoutingRule{routingRule},
+		}).Return(nil).Once()
+
+		_, err := model.programRoute(t.Context(), programGRPCRouteParams{
+			config:           config,
+			grpcRoute:        route,
+			knownBackends:    map[string]corev1.Service{service.Namespace + "/" + service.Name: service},
+			matchedListeners: []gatewayv1.Listener{listener},
+		})
+
+		require.NoError(t, err)
+	})
+
 	t.Run("ensureGRPCListenersProtocol updates matched listeners to HTTP2", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1093,7 +1093,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		)
 	})
 
-	t.Run("programRoute removes stale backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
+	t.Run("programRoute leaves backend SSL unmanaged without matching policy", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
@@ -1118,7 +1118,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				return params.loadBalancerID == config.Spec.LoadBalancerID &&
 					params.service.Name == service.Name &&
 					params.backendRef.Name == backendRef.Name &&
-					params.manageSSLConfig &&
+					!params.manageSSLConfig &&
 					params.sslConfig == nil
 			})).
 			Return(nil).

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1093,7 +1093,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		)
 	})
 
-	t.Run("programRoute leaves backend SSL unmanaged without matching policy", func(t *testing.T) {
+	t.Run("programRoute clears backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
@@ -1118,7 +1118,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				return params.loadBalancerID == config.Spec.LoadBalancerID &&
 					params.service.Name == service.Name &&
 					params.backendRef.Name == backendRef.Name &&
-					!params.manageSSLConfig &&
+					params.manageSSLConfig &&
 					params.sslConfig == nil
 			})).
 			Return(nil).

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -38,6 +38,12 @@ func NewHTTPRouteController(deps HTTPRouteControllerDeps) *HTTPRouteController {
 	}
 }
 
+func (r *HTTPRouteController) SetBackendTLSPolicyEnabled(enabled bool) {
+	if model, ok := r.httpRouteModel.(interface{ setBackendTLSPolicyEnabled(bool) }); ok {
+		model.setBackendTLSPolicyEnabled(enabled)
+	}
+}
+
 // Returns true if backends sync is required.
 func (r *HTTPRouteController) reconcileResolvedRoute(
 	ctx context.Context,

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -27,6 +27,21 @@ func TestHTTPRouteController(t *testing.T) {
 		}
 	}
 
+	t.Run("sets BackendTLSPolicy availability on concrete model", func(t *testing.T) {
+		model := &httpRouteModelImpl{}
+		controller := NewHTTPRouteController(HTTPRouteControllerDeps{
+			RootLogger:       diag.RootTestLogger(),
+			HTTPRouteModel:   model,
+			HTTPBackendModel: NewMockhttpBackendModel(t),
+		})
+
+		controller.SetBackendTLSPolicyEnabled(false)
+		require.True(t, model.backendTLSDisabled)
+
+		controller.SetBackendTLSPolicyEnabled(true)
+		require.False(t, model.backendTLSDisabled)
+	})
+
 	t.Run("Reconcile", func(t *testing.T) {
 		t.Run("RelevantRoute", func(t *testing.T) {
 			fake := faker.New()

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -129,6 +129,7 @@ type programL7RoutePolicyParams struct {
 	ruleCount           int
 	makeRoutingRule     func(ruleIndex int) (loadbalancer.RoutingRule, error)
 	backendTLSPolicy    backendTLSPolicyModel
+	backendTLSDisabled  bool
 }
 
 type setL7RouteProgrammedParams struct {
@@ -566,6 +567,7 @@ type httpRouteModelImpl struct {
 	resourcesModel       resourcesModel
 	ociLoadBalancerModel ociLoadBalancerModel
 	backendTLSPolicy     backendTLSPolicyModel
+	backendTLSDisabled   bool
 }
 
 // resolveRouteParentRefData attempts to resolve a single parent reference for an HTTPRoute.
@@ -1005,7 +1007,7 @@ func resolveL7BackendSSLConfig(
 	service v1.Service,
 	backendRef gatewayv1.BackendRef,
 ) (*loadbalancer.SslConfigurationDetails, bool, error) {
-	if params.backendTLSPolicy == nil {
+	if params.backendTLSDisabled || params.backendTLSPolicy == nil {
 		return nil, false, nil
 	}
 	sslConfig, err := params.backendTLSPolicy.resolveForBackendRef(ctx, resolveBackendTLSPolicyParams{
@@ -1044,6 +1046,7 @@ func (m *httpRouteModelImpl) programRoute(
 		matchedListeners:    params.matchedListeners,
 		previousPolicyRules: previousRules,
 		backendTLSPolicy:    m.backendTLSPolicy,
+		backendTLSDisabled:  m.backendTLSDisabled,
 		ruleCount:           len(params.httpRoute.Spec.Rules),
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeRoutingRule(ctx, makeRoutingRuleParams{
@@ -1140,7 +1143,6 @@ func (m *httpRouteModelImpl) deprovisionRoute(
 	return nil
 }
 
-//nolint:unparam // The error return is part of the interface contract used by controller tests.
 func (m *httpRouteModelImpl) isProgrammingRequired(
 	details resolvedRouteDetails,
 ) (bool, error) {
@@ -1251,4 +1253,8 @@ func newHTTPRouteModel(deps httpRouteModelDeps) *httpRouteModelImpl {
 		resourcesModel:       deps.ResourcesModel,
 		backendTLSPolicy:     deps.BackendTLS,
 	}
+}
+
+func (m *httpRouteModelImpl) setBackendTLSPolicyEnabled(enabled bool) {
+	m.backendTLSDisabled = !enabled
 }

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -1015,7 +1015,7 @@ func resolveL7BackendSSLConfig(
 		backendRef: backendRef,
 	})
 	if errors.Is(err, errBackendTLSPolicyNotFound) {
-		return nil, false, nil
+		return nil, true, nil
 	}
 	return sslConfig, true, err
 }

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -117,6 +118,8 @@ type rejectL7RouteParams struct {
 
 type programL7RoutePolicyParams struct {
 	loadBalancerID      string
+	gateway             gatewayv1.Gateway
+	config              types.GatewayConfig
 	routeName           string
 	routeNamespace      string
 	backendRefs         []gatewayv1.BackendRef
@@ -125,6 +128,7 @@ type programL7RoutePolicyParams struct {
 	previousPolicyRules []programmedHTTPRoutePolicyRule
 	ruleCount           int
 	makeRoutingRule     func(ruleIndex int) (loadbalancer.RoutingRule, error)
+	backendTLSPolicy    backendTLSPolicyModel
 }
 
 type setL7RouteProgrammedParams struct {
@@ -561,6 +565,7 @@ type httpRouteModelImpl struct {
 	gatewayModel         gatewayModel
 	resourcesModel       resourcesModel
 	ociLoadBalancerModel ociLoadBalancerModel
+	backendTLSPolicy     backendTLSPolicyModel
 }
 
 // resolveRouteParentRefData attempts to resolve a single parent reference for an HTTPRoute.
@@ -924,11 +929,17 @@ func programL7RoutePolicy(
 		if !ok {
 			return nil, fmt.Errorf("resolved backend service %s not found", serviceName)
 		}
-		err := ociLoadBalancerModel.reconcileBackendSet(ctx, reconcileBackendSetParams{
-			loadBalancerID: params.loadBalancerID,
-			service:        service,
-			routeNS:        params.routeNamespace,
-			backendRef:     backendRef,
+		backendSSLConfig, _, err := resolveL7BackendSSLConfig(ctx, params, service, backendRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve BackendTLSPolicy for service %s: %w", key, err)
+		}
+		err = ociLoadBalancerModel.reconcileBackendSet(ctx, reconcileBackendSetParams{
+			loadBalancerID:  params.loadBalancerID,
+			service:         service,
+			routeNS:         params.routeNamespace,
+			backendRef:      backendRef,
+			sslConfig:       backendSSLConfig,
+			manageSSLConfig: params.backendTLSPolicy != nil,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to reconcile backend set for service %s: %w", key, err)
@@ -988,6 +999,27 @@ func programL7RoutePolicy(
 	return programmedHTTPRoutePolicyRulesAnnotation(params.matchedListeners, policyRuleNames), nil
 }
 
+func resolveL7BackendSSLConfig(
+	ctx context.Context,
+	params programL7RoutePolicyParams,
+	service v1.Service,
+	backendRef gatewayv1.BackendRef,
+) (*loadbalancer.SslConfigurationDetails, bool, error) {
+	if params.backendTLSPolicy == nil {
+		return nil, false, nil
+	}
+	sslConfig, err := params.backendTLSPolicy.resolveForBackendRef(ctx, resolveBackendTLSPolicyParams{
+		gateway:    params.gateway,
+		config:     params.config,
+		service:    service,
+		backendRef: backendRef,
+	})
+	if errors.Is(err, errBackendTLSPolicyNotFound) {
+		return nil, false, nil
+	}
+	return sslConfig, true, err
+}
+
 func (m *httpRouteModelImpl) programRoute(
 	ctx context.Context,
 	params programRouteParams,
@@ -999,12 +1031,15 @@ func (m *httpRouteModelImpl) programRoute(
 
 	programmedPolicyRules, err := programL7RoutePolicy(ctx, m.ociLoadBalancerModel, programL7RoutePolicyParams{
 		loadBalancerID:      params.config.Spec.LoadBalancerID,
+		gateway:             params.gateway,
+		config:              params.config,
 		routeName:           params.httpRoute.Name,
 		routeNamespace:      params.httpRoute.Namespace,
 		backendRefs:         httpRouteBackendRefs(params.httpRoute),
 		knownBackends:       params.knownBackends,
 		matchedListeners:    params.matchedListeners,
 		previousPolicyRules: previousRules,
+		backendTLSPolicy:    m.backendTLSPolicy,
 		ruleCount:           len(params.httpRoute.Spec.Rules),
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeRoutingRule(ctx, makeRoutingRuleParams{
@@ -1199,6 +1234,7 @@ type httpRouteModelDeps struct {
 	GatewayModel   gatewayModel
 	OciLBModel     ociLoadBalancerModel
 	ResourcesModel resourcesModel
+	BackendTLS     backendTLSPolicyModel
 }
 
 // newHTTPRouteModel creates a new instance of httpRouteModel.
@@ -1209,5 +1245,6 @@ func newHTTPRouteModel(deps httpRouteModelDeps) *httpRouteModelImpl {
 		gatewayModel:         deps.GatewayModel,
 		ociLoadBalancerModel: deps.OciLBModel,
 		resourcesModel:       deps.ResourcesModel,
+		backendTLSPolicy:     deps.BackendTLS,
 	}
 }

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -929,7 +929,7 @@ func programL7RoutePolicy(
 		if !ok {
 			return nil, fmt.Errorf("resolved backend service %s not found", serviceName)
 		}
-		backendSSLConfig, _, err := resolveL7BackendSSLConfig(ctx, params, service, backendRef)
+		backendSSLConfig, manageSSLConfig, err := resolveL7BackendSSLConfig(ctx, params, service, backendRef)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve BackendTLSPolicy for service %s: %w", key, err)
 		}
@@ -939,7 +939,7 @@ func programL7RoutePolicy(
 			routeNS:         params.routeNamespace,
 			backendRef:      backendRef,
 			sslConfig:       backendSSLConfig,
-			manageSSLConfig: params.backendTLSPolicy != nil,
+			manageSSLConfig: manageSSLConfig,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to reconcile backend set for service %s: %w", key, err)

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -1017,6 +1017,10 @@ func resolveL7BackendSSLConfig(
 	if errors.Is(err, errBackendTLSPolicyNotFound) {
 		return nil, true, nil
 	}
+	var statusErr backendTLSPolicyStatusError
+	if errors.As(err, &statusErr) {
+		return nil, true, nil
+	}
 	return sslConfig, true, err
 }
 

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1514,6 +1514,57 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes stale backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
+			fake := faker.New()
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			config := makeRandomGatewayConfig()
+			service := makeRandomService()
+			backendRef := makeRandomBackendRef(
+				randomBackendRefWithNameOpt(service.Name),
+				randomBackendRefWithNamespaceOpt(service.Namespace),
+			)
+			routeNamespace := "route-" + fake.Lorem().Word()
+			listener := makeRandomListener()
+			rule := makeRandomOCIRoutingRule()
+			serviceKey := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}.String()
+
+			ociLBModel.EXPECT().
+				reconcileBackendSet(t.Context(), mock.MatchedBy(func(params reconcileBackendSetParams) bool {
+					return params.loadBalancerID == config.Spec.LoadBalancerID &&
+						params.service.Name == service.Name &&
+						params.backendRef.Name == backendRef.Name &&
+						params.manageSSLConfig &&
+						params.sslConfig == nil
+				})).
+				Return(nil).
+				Once()
+			ociLBModel.EXPECT().
+				commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+					loadBalancerID: config.Spec.LoadBalancerID,
+					listenerName:   string(listener.Name),
+					policyRules:    []loadbalancer.RoutingRule{rule},
+				}).
+				Return(nil).
+				Once()
+
+			rules, err := programL7RoutePolicy(t.Context(), ociLBModel, programL7RoutePolicyParams{
+				loadBalancerID:   config.Spec.LoadBalancerID,
+				routeName:        "http-" + fake.Lorem().Word(),
+				routeNamespace:   routeNamespace,
+				backendRefs:      []gatewayv1.BackendRef{backendRef.BackendRef},
+				knownBackends:    map[string]corev1.Service{serviceKey: service},
+				matchedListeners: []gatewayv1.Listener{listener},
+				backendTLSPolicy: &stubBackendTLSPolicyModel{resolveErr: errBackendTLSPolicyNotFound},
+				ruleCount:        1,
+				makeRoutingRule: func(int) (loadbalancer.RoutingRule, error) {
+					return rule, nil
+				},
+			})
+
+			require.NoError(t, err)
+			require.Len(t, rules, 1)
+		})
+
 		t.Run("deduplicates backend set reconciliation for the same backend ref", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newHTTPRouteModel(deps)
@@ -2359,5 +2410,78 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.Error(t, err)
 			assert.ErrorIs(t, err, wantErr)
 		})
+	})
+}
+
+func TestResolveL7BackendSSLConfig(t *testing.T) {
+	service := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "backend"}}
+	backendRef := gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+		Name: gatewayv1.ObjectName("backend"),
+	}}
+
+	t.Run("does not manage SSL config without BackendTLSPolicy model", func(t *testing.T) {
+		sslConfig, managed, err := resolveL7BackendSSLConfig(
+			t.Context(),
+			programL7RoutePolicyParams{},
+			service,
+			backendRef,
+		)
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.False(t, managed)
+	})
+
+	t.Run("does not manage SSL config when no policy matches", func(t *testing.T) {
+		sslConfig, managed, err := resolveL7BackendSSLConfig(
+			t.Context(),
+			programL7RoutePolicyParams{
+				backendTLSPolicy: &stubBackendTLSPolicyModel{resolveErr: errBackendTLSPolicyNotFound},
+			},
+			service,
+			backendRef,
+		)
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.False(t, managed)
+	})
+
+	t.Run("returns resolved SSL config", func(t *testing.T) {
+		verifyDepth := 2
+		wantConfig := &loadbalancer.SslConfigurationDetails{VerifyDepth: &verifyDepth}
+		backendTLS := &stubBackendTLSPolicyModel{
+			resolveFunc: func(params resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				require.Equal(t, service.Name, params.service.Name)
+				return wantConfig, nil
+			},
+		}
+		sslConfig, managed, err := resolveL7BackendSSLConfig(
+			t.Context(),
+			programL7RoutePolicyParams{
+				backendTLSPolicy: backendTLS,
+			},
+			service,
+			backendRef,
+		)
+
+		require.NoError(t, err)
+		require.True(t, managed)
+		require.Same(t, wantConfig, sslConfig)
+	})
+
+	t.Run("returns resolution errors", func(t *testing.T) {
+		wantErr := errors.New("policy invalid")
+		_, managed, err := resolveL7BackendSSLConfig(
+			t.Context(),
+			programL7RoutePolicyParams{
+				backendTLSPolicy: &stubBackendTLSPolicyModel{resolveErr: wantErr},
+			},
+			service,
+			backendRef,
+		)
+
+		require.ErrorIs(t, err, wantErr)
+		require.True(t, managed)
 	})
 }

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -2447,6 +2447,34 @@ func TestResolveL7BackendSSLConfig(t *testing.T) {
 		require.True(t, managed)
 	})
 
+	t.Run("manages nil SSL config when matching policy is invalid", func(t *testing.T) {
+		fake := faker.New()
+		invalidPolicy := gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "policy-" + fake.Lorem().Word(),
+				Name:      "policy-" + fake.Lorem().Word(),
+			},
+		}
+		sslConfig, managed, err := resolveL7BackendSSLConfig(
+			t.Context(),
+			programL7RoutePolicyParams{
+				backendTLSPolicy: &stubBackendTLSPolicyModel{
+					resolveErr: backendTLSPolicyStatusError{
+						policy:  invalidPolicy,
+						reason:  gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+						message: "CA certificate reference was not found",
+					},
+				},
+			},
+			service,
+			backendRef,
+		)
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.True(t, managed)
+	})
+
 	t.Run("returns resolved SSL config", func(t *testing.T) {
 		verifyDepth := 2
 		wantConfig := &loadbalancer.SslConfigurationDetails{VerifyDepth: &verifyDepth}

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1514,7 +1514,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run("removes stale backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
+		t.Run("does not manage backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
 			fake := faker.New()
 			ociLBModel := NewMockociLoadBalancerModel(t)
 			config := makeRandomGatewayConfig()
@@ -1533,7 +1533,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 					return params.loadBalancerID == config.Spec.LoadBalancerID &&
 						params.service.Name == service.Name &&
 						params.backendRef.Name == backendRef.Name &&
-						params.manageSSLConfig &&
+						!params.manageSSLConfig &&
 						params.sslConfig == nil
 				})).
 				Return(nil).

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -2432,6 +2432,27 @@ func TestResolveL7BackendSSLConfig(t *testing.T) {
 		require.False(t, managed)
 	})
 
+	t.Run("does not resolve SSL config when BackendTLSPolicy support is disabled", func(t *testing.T) {
+		sslConfig, managed, err := resolveL7BackendSSLConfig(
+			t.Context(),
+			programL7RoutePolicyParams{
+				backendTLSDisabled: true,
+				backendTLSPolicy: &stubBackendTLSPolicyModel{
+					resolveFunc: func(resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+						require.Fail(t, "disabled BackendTLSPolicy support should not resolve policies")
+						return nil, errors.New("unexpected policy resolution")
+					},
+				},
+			},
+			service,
+			backendRef,
+		)
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.False(t, managed)
+	})
+
 	t.Run("manages nil SSL config when no policy matches", func(t *testing.T) {
 		sslConfig, managed, err := resolveL7BackendSSLConfig(
 			t.Context(),

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1514,7 +1514,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run("does not manage backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
+		t.Run("clears backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
 			fake := faker.New()
 			ociLBModel := NewMockociLoadBalancerModel(t)
 			config := makeRandomGatewayConfig()
@@ -1533,7 +1533,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 					return params.loadBalancerID == config.Spec.LoadBalancerID &&
 						params.service.Name == service.Name &&
 						params.backendRef.Name == backendRef.Name &&
-						!params.manageSSLConfig &&
+						params.manageSSLConfig &&
 						params.sslConfig == nil
 				})).
 				Return(nil).
@@ -2432,7 +2432,7 @@ func TestResolveL7BackendSSLConfig(t *testing.T) {
 		require.False(t, managed)
 	})
 
-	t.Run("does not manage SSL config when no policy matches", func(t *testing.T) {
+	t.Run("manages nil SSL config when no policy matches", func(t *testing.T) {
 		sslConfig, managed, err := resolveL7BackendSSLConfig(
 			t.Context(),
 			programL7RoutePolicyParams{
@@ -2444,7 +2444,7 @@ func TestResolveL7BackendSSLConfig(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Nil(t, sslConfig)
-		require.False(t, managed)
+		require.True(t, managed)
 	})
 
 	t.Run("returns resolved SSL config", func(t *testing.T) {

--- a/internal/app/l4_controller_test.go
+++ b/internal/app/l4_controller_test.go
@@ -312,6 +312,20 @@ func TestTCPRouteController(t *testing.T) {
 func TestTLSRouteController(t *testing.T) {
 	req := reconcile.Request{NamespacedName: apitypes.NamespacedName{Namespace: "media", Name: "rtmps"}}
 
+	t.Run("sets BackendTLSPolicy availability on concrete model", func(t *testing.T) {
+		model := &tlsRouteModelImpl{}
+		controller := NewTLSRouteController(TLSRouteControllerDeps{
+			RootLogger:    diag.RootTestLogger(),
+			TLSRouteModel: model,
+		})
+
+		controller.SetBackendTLSPolicyEnabled(false)
+		require.True(t, model.backendTLSDisabled)
+
+		controller.SetBackendTLSPolicyEnabled(true)
+		require.False(t, model.backendTLSDisabled)
+	})
+
 	t.Run("programs resolved route", func(t *testing.T) {
 		model := &stubTLSRouteModel{resolved: []resolvedTLSRouteDetails{{tlsRoute: gatewayv1.TLSRoute{}}}}
 		controller := NewTLSRouteController(TLSRouteControllerDeps{

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -45,10 +45,12 @@ type reconcileDefaultBackendParams struct {
 }
 
 type reconcileBackendSetParams struct {
-	loadBalancerID string
-	service        corev1.Service
-	routeNS        string
-	backendRef     gatewayv1.BackendRef
+	loadBalancerID  string
+	service         corev1.Service
+	routeNS         string
+	backendRef      gatewayv1.BackendRef
+	sslConfig       *loadbalancer.SslConfigurationDetails
+	manageSSLConfig bool
 }
 
 type deprovisionBackendSetParams struct {
@@ -214,9 +216,48 @@ func loadBalancerBackendSetMatches(
 	current loadbalancer.BackendSet,
 	policy string,
 	healthChecker loadbalancer.HealthCheckerDetails,
+	sslConfig ...*loadbalancer.SslConfigurationDetails,
 ) bool {
+	desiredSSLConfig := firstSSLConfig(sslConfig)
 	return lo.FromPtr(current.Policy) == policy &&
-		loadBalancerHealthCheckerMatches(current.HealthChecker, healthChecker)
+		loadBalancerHealthCheckerMatches(current.HealthChecker, healthChecker) &&
+		loadBalancerSSLConfigurationsEqual(
+			sslConfigurationDetailsFromBackendSet(current.SslConfiguration),
+			desiredSSLConfig,
+		)
+}
+
+func firstSSLConfig(configs []*loadbalancer.SslConfigurationDetails) *loadbalancer.SslConfigurationDetails {
+	if len(configs) == 0 {
+		return nil
+	}
+	return configs[0]
+}
+
+func loadBalancerSSLConfigurationsEqual(
+	current *loadbalancer.SslConfigurationDetails,
+	desired *loadbalancer.SslConfigurationDetails,
+) bool {
+	if current == nil || desired == nil {
+		return current == nil && desired == nil
+	}
+	return lo.FromPtr(current.VerifyDepth) == lo.FromPtr(desired.VerifyDepth) &&
+		lo.FromPtr(current.VerifyPeerCertificate) == lo.FromPtr(desired.VerifyPeerCertificate) &&
+		lo.FromPtr(current.HasSessionResumption) == lo.FromPtr(desired.HasSessionResumption) &&
+		lo.FromPtr(current.CertificateName) == lo.FromPtr(desired.CertificateName) &&
+		lo.FromPtr(current.CipherSuiteName) == lo.FromPtr(desired.CipherSuiteName) &&
+		current.ServerOrderPreference == desired.ServerOrderPreference &&
+		stringSlicesEqual(current.Protocols, desired.Protocols) &&
+		stringSlicesEqual(current.CertificateIds, desired.CertificateIds) &&
+		stringSlicesEqual(current.TrustedCertificateAuthorityIds, desired.TrustedCertificateAuthorityIds)
+}
+
+func stringSlicesEqual(left []string, right []string) bool {
+	left = append([]string(nil), left...)
+	right = append([]string(nil), right...)
+	sort.Strings(left)
+	sort.Strings(right)
+	return strings.Join(left, "\x00") == strings.Join(right, "\x00")
 }
 
 func loadBalancerBackendSetHealthChecker(port int) loadbalancer.HealthCheckerDetails {
@@ -233,7 +274,9 @@ func (m *ociLoadBalancerModelImpl) updateBackendSetConfig(
 	backendSet loadbalancer.BackendSet,
 	policy string,
 	healthChecker loadbalancer.HealthCheckerDetails,
+	sslConfig ...*loadbalancer.SslConfigurationDetails,
 ) error {
+	desiredSSLConfig := firstSSLConfig(sslConfig)
 	m.logger.InfoContext(ctx, "Updating backend set configuration",
 		slog.String("loadBalancerId", loadBalancerID),
 		slog.String("backendSetName", backendSetName),
@@ -251,7 +294,7 @@ func (m *ociLoadBalancerModelImpl) updateBackendSetConfig(
 			HealthChecker:                           &healthChecker,
 			SessionPersistenceConfiguration:         backendSet.SessionPersistenceConfiguration,
 			LbCookieSessionPersistenceConfiguration: backendSet.LbCookieSessionPersistenceConfiguration,
-			SslConfiguration:                        sslConfigurationDetailsFromBackendSet(backendSet.SslConfiguration),
+			SslConfiguration:                        desiredSSLConfig,
 		},
 	})
 	if err != nil {
@@ -321,7 +364,8 @@ func (m *ociLoadBalancerModelImpl) reconcileDefaultBackendSet(
 	desiredPolicy := "ROUND_ROBIN"
 	desiredHealthChecker := loadBalancerBackendSetHealthChecker(defaultBackendSetPort)
 	if existingBackendSet, ok := params.knownBackendSets[defaultBackendSetName]; ok {
-		if !loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, desiredHealthChecker) {
+		existingSSLConfig := sslConfigurationDetailsFromBackendSet(existingBackendSet.SslConfiguration)
+		if !loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, desiredHealthChecker, existingSSLConfig) {
 			if err := m.updateBackendSetConfig(
 				ctx,
 				params.loadBalancerID,
@@ -329,6 +373,7 @@ func (m *ociLoadBalancerModelImpl) reconcileDefaultBackendSet(
 				existingBackendSet,
 				desiredPolicy,
 				desiredHealthChecker,
+				existingSSLConfig,
 			); err != nil {
 				return loadbalancer.BackendSet{}, err
 			}
@@ -725,7 +770,11 @@ func (m *ociLoadBalancerModelImpl) reconcileExistingBackendSet(
 	desiredPolicy string,
 	desiredHealthChecker loadbalancer.HealthCheckerDetails,
 ) error {
-	if !loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, desiredHealthChecker) {
+	desiredSSLConfig := params.sslConfig
+	if !params.manageSSLConfig {
+		desiredSSLConfig = sslConfigurationDetailsFromBackendSet(existingBackendSet.SslConfiguration)
+	}
+	if !loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, desiredHealthChecker, desiredSSLConfig) {
 		if err := m.updateBackendSetConfig(
 			ctx,
 			params.loadBalancerID,
@@ -733,6 +782,7 @@ func (m *ociLoadBalancerModelImpl) reconcileExistingBackendSet(
 			existingBackendSet,
 			desiredPolicy,
 			desiredHealthChecker,
+			desiredSSLConfig,
 		); err != nil {
 			return err
 		}
@@ -982,9 +1032,10 @@ func (m *ociLoadBalancerModelImpl) reconcileBackendSet(
 	createRes, err := m.ociClient.CreateBackendSet(ctx, loadbalancer.CreateBackendSetRequest{
 		LoadBalancerId: &params.loadBalancerID,
 		CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
-			Name:          &backendSetName,
-			Policy:        new(desiredPolicy),
-			HealthChecker: &desiredHealthChecker,
+			Name:             &backendSetName,
+			Policy:           new(desiredPolicy),
+			HealthChecker:    &desiredHealthChecker,
+			SslConfiguration: lo.Ternary(params.manageSSLConfig, params.sslConfig, nil),
 		},
 	})
 

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -1956,6 +1956,56 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("keeps backend health check when adding backend TLS SSL config", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+
+			service := makeRandomService()
+			params := makeParams(service, fake.UUID().V4())
+			params.manageSSLConfig = true
+			verifyDepth := 2
+			params.sslConfig = &loadbalancer.SslConfigurationDetails{
+				VerifyDepth: &verifyDepth,
+			}
+			wantBsName := backendSetNameFromParams(params)
+			existingBs := makeRandomOCIBackendSet(func(bs *loadbalancer.BackendSet) {
+				bs.Name = new(wantBsName)
+				bs.Policy = new("ROUND_ROBIN")
+				bs.HealthChecker = &loadbalancer.HealthChecker{
+					Protocol: new("TCP"),
+					Port:     new(int(lo.FromPtr(params.backendRef.Port))),
+				}
+				bs.SslConfiguration = nil
+			})
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			workRequestID := fake.UUID().V4()
+
+			ociLoadBalancerClient.EXPECT().GetBackendSet(t.Context(), loadbalancer.GetBackendSetRequest{
+				BackendSetName: &wantBsName,
+				LoadBalancerId: &params.loadBalancerID,
+			}).Return(loadbalancer.GetBackendSetResponse{
+				BackendSet: existingBs,
+			}, nil).Once()
+			ociLoadBalancerClient.EXPECT().UpdateBackendSet(
+				t.Context(),
+				mock.MatchedBy(func(req loadbalancer.UpdateBackendSetRequest) bool {
+					return assert.Equal(t, "TCP", lo.FromPtr(req.HealthChecker.Protocol)) &&
+						assert.Equal(t, int(lo.FromPtr(params.backendRef.Port)), lo.FromPtr(req.HealthChecker.Port)) &&
+						assert.Equal(t, verifyDepth, lo.FromPtr(req.SslConfiguration.VerifyDepth))
+				}),
+			).Return(loadbalancer.UpdateBackendSetResponse{
+				OpcWorkRequestId: &workRequestID,
+			}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			err := model.reconcileBackendSet(t.Context(), params)
+
+			require.NoError(t, err)
+		})
+
 		t.Run("fails when get backend set fails", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
@@ -4864,7 +4914,7 @@ func Test_ociListerPolicyRuleName(t *testing.T) {
 func Test_listenerPolicyName(t *testing.T) {
 	t.Run("preserves existing valid listener policy names", func(t *testing.T) {
 		fake := faker.New()
-		listenerName := "listener_" + fake.Lorem().Word()
+		listenerName := fake.Numerify("listener_########")
 
 		got := listenerPolicyName(listenerName)
 

--- a/internal/app/ports.go
+++ b/internal/app/ports.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,6 +86,23 @@ type noopWorkRequestsWatcher struct{}
 
 func (noopWorkRequestsWatcher) WaitFor(context.Context, string) error {
 	return nil
+}
+
+type ociCertificatesManagementClient interface {
+	CreateCaBundle(ctx context.Context, request certificatesmanagement.CreateCaBundleRequest) (
+		response certificatesmanagement.CreateCaBundleResponse, err error)
+
+	GetCaBundle(ctx context.Context, request certificatesmanagement.GetCaBundleRequest) (
+		response certificatesmanagement.GetCaBundleResponse, err error)
+
+	ListCaBundles(ctx context.Context, request certificatesmanagement.ListCaBundlesRequest) (
+		response certificatesmanagement.ListCaBundlesResponse, err error)
+
+	UpdateCaBundle(ctx context.Context, request certificatesmanagement.UpdateCaBundleRequest) (
+		response certificatesmanagement.UpdateCaBundleResponse, err error)
+
+	DeleteCaBundle(ctx context.Context, request certificatesmanagement.DeleteCaBundleRequest) (
+		response certificatesmanagement.DeleteCaBundleResponse, err error)
 }
 
 // ociNetworkLoadBalancerClient defines the interface for OCI Network Load Balancer operations.

--- a/internal/app/register.go
+++ b/internal/app/register.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 	"go.uber.org/dig"
@@ -15,6 +16,7 @@ func Register(container *dig.Container) error {
 		func(c client.Client) k8sClient { return c },
 		func(c loadbalancer.LoadBalancerClient) ociLoadBalancerClient { return c },
 		func(c networkloadbalancer.NetworkLoadBalancerClient) ociNetworkLoadBalancerClient { return c },
+		func(c certificatesmanagement.CertificatesManagementClient) ociCertificatesManagementClient { return c },
 		func(w *ociapi.WorkRequestsWatcher) workRequestsWatcher { return w },
 		di.ConstructorWithOpts{
 			Constructor: func(w *ociapi.NetworkLoadBalancerWorkRequestsWatcher) workRequestsWatcher { return w },
@@ -28,6 +30,7 @@ func Register(container *dig.Container) error {
 		NewTCPRouteController,
 		NewUDPRouteController,
 		NewTLSRouteController,
+		NewBackendTLSPolicyController,
 		newNetworkLoadBalancerOperationLocks,
 		di.ProvideFactoryAs[resourcesModel](newResourcesModel),
 		di.ProvideFactoryAs[gatewayModel](newGatewayModel),
@@ -38,6 +41,7 @@ func Register(container *dig.Container) error {
 		di.ProvideFactoryAs[udpRouteModel](newUDPRouteModel),
 		di.ProvideFactoryAs[tlsRouteModel](newTLSRouteModel),
 		di.ProvideFactoryAs[ociLoadBalancerModel](newOciLoadBalancerModel),
+		di.ProvideFactoryAs[backendTLSPolicyModel](newBackendTLSPolicyModel),
 		newOciLoadBalancerRoutingRulesMapper,
 		di.ProvideAs[*ociLoadBalancerRoutingRulesMapperImpl, ociLoadBalancerRoutingRulesMapper],
 		di.ProvideFactoryAs[httpBackendModel](newHTTPBackendModel),

--- a/internal/app/tlsroute_controller.go
+++ b/internal/app/tlsroute_controller.go
@@ -35,6 +35,12 @@ func NewTLSRouteController(deps TLSRouteControllerDeps) *TLSRouteController {
 	}
 }
 
+func (r *TLSRouteController) SetBackendTLSPolicyEnabled(enabled bool) {
+	if model, ok := r.tlsRouteModel.(interface{ setBackendTLSPolicyEnabled(bool) }); ok {
+		model.setBackendTLSPolicyEnabled(enabled)
+	}
+}
+
 func (r *TLSRouteController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	r.logger.InfoContext(ctx, fmt.Sprintf("Processing reconciliation for TLSRoute %s", req.NamespacedName))
 

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -72,6 +72,7 @@ type tlsRouteModelImpl struct {
 	ociNetworkLoadBalancerAPI ociNetworkLoadBalancerClient
 	ociLoadBalancerModel      ociLoadBalancerModel
 	ociLoadBalancerAPI        ociLoadBalancerClient
+	backendTLSPolicy          backendTLSPolicyModel
 	workRequestsWatcher       workRequestsWatcher
 	nlbWorkRequestsWatcher    workRequestsWatcher
 	operationLocks            *networkLoadBalancerOperationLocks
@@ -629,14 +630,31 @@ func (m *tlsRouteModelImpl) programLoadBalancerTerminateRoute(
 	if err != nil {
 		return err
 	}
-	if err = m.reconcileLoadBalancerBackendSet(
-		ctx,
-		loadBalancerID,
-		backendSetName,
-		lb.BackendSets[backendSetName],
-		backends,
-		healthCheckPort,
-	); err != nil {
+	backendSSLConfig, manageBackendSSLConfig, err := m.loadBalancerBackendTLSConfigForRoute(ctx, details)
+	if err != nil {
+		return err
+	}
+	if manageBackendSSLConfig {
+		err = m.reconcileLoadBalancerBackendSet(
+			ctx,
+			loadBalancerID,
+			backendSetName,
+			lb.BackendSets[backendSetName],
+			backends,
+			healthCheckPort,
+			backendSSLConfig,
+		)
+	} else {
+		err = m.reconcileLoadBalancerBackendSet(
+			ctx,
+			loadBalancerID,
+			backendSetName,
+			lb.BackendSets[backendSetName],
+			backends,
+			healthCheckPort,
+		)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -682,6 +700,69 @@ func (m *tlsRouteModelImpl) loadBalancerBackendsForRoute(
 			Drain:     backend.IsDrain,
 		}
 	}), nil
+}
+
+func (m *tlsRouteModelImpl) loadBalancerBackendTLSConfigForRoute(
+	ctx context.Context,
+	details resolvedTLSRouteDetails,
+) (*loadbalancer.SslConfigurationDetails, bool, error) {
+	if m.backendTLSPolicy == nil {
+		return nil, false, nil
+	}
+	var resolved *loadbalancer.SslConfigurationDetails
+	resolvedSet := false
+	for _, rule := range details.tlsRoute.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			if l4BackendRefWeight(backendRef) == 0 {
+				continue
+			}
+			sslConfig, err := m.loadBalancerBackendTLSConfigForRef(ctx, details, backendRef)
+			if errors.Is(err, errBackendTLSPolicyNotFound) {
+				sslConfig = nil
+				err = nil
+			}
+			if err != nil {
+				return nil, true, fmt.Errorf("failed to resolve BackendTLSPolicy for TLSRoute backend %s: %w",
+					tcpRouteBackendRefName(backendRef, details.tlsRoute.Namespace).String(),
+					err,
+				)
+			}
+			if !resolvedSet {
+				resolved = sslConfig
+				resolvedSet = true
+				continue
+			}
+			if !loadBalancerSSLConfigurationsEqual(resolved, sslConfig) {
+				return nil, true, newTLSRouteResolvedRefsStatusError(
+					gatewayv1.RouteReasonUnsupportedValue,
+					"ALB TLSRoute uses one backend set; all backendRefs must resolve to the same BackendTLSPolicy SSL configuration",
+				)
+			}
+		}
+	}
+	return resolved, true, nil
+}
+
+func (m *tlsRouteModelImpl) loadBalancerBackendTLSConfigForRef(
+	ctx context.Context,
+	details resolvedTLSRouteDetails,
+	backendRef gatewayv1.BackendRef,
+) (*loadbalancer.SslConfigurationDetails, error) {
+	fullName := tcpRouteBackendRefName(backendRef, details.tlsRoute.Namespace)
+	var service corev1.Service
+	if err := m.client.Get(ctx, fullName, &service); err != nil {
+		return nil, fmt.Errorf("failed to get TLSRoute backend Service %s: %w", fullName.String(), err)
+	}
+	sslConfig, err := m.backendTLSPolicy.resolveForBackendRef(ctx, resolveBackendTLSPolicyParams{
+		gateway:    details.gatewayDetails.gateway,
+		config:     details.gatewayDetails.config,
+		service:    service,
+		backendRef: backendRef,
+	})
+	if errors.Is(err, errBackendTLSPolicyNotFound) {
+		return nil, errBackendTLSPolicyNotFound
+	}
+	return sslConfig, err
 }
 
 func (m *tlsRouteModelImpl) routeHealthCheckPort(
@@ -766,13 +847,18 @@ func (m *tlsRouteModelImpl) reconcileLoadBalancerBackendSet(
 	existingBackendSet loadbalancer.BackendSet,
 	backends []loadbalancer.BackendDetails,
 	healthCheckPort int,
+	sslConfig ...*loadbalancer.SslConfigurationDetails,
 ) error {
+	desiredSSLConfig := firstSSLConfig(sslConfig)
 	healthChecker := loadBalancerBackendSetHealthChecker(healthCheckPort)
 	desiredPolicy := tlsRouteBackendSetPolicy
 	if existingBackendSet.Name != nil {
-		if loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, healthChecker) &&
+		if loadBalancerBackendSetMatches(existingBackendSet, desiredPolicy, healthChecker, desiredSSLConfig) &&
 			loadBalancerBackendsEqual(existingBackendSet.Backends, backends) &&
-			existingBackendSet.SslConfiguration == nil {
+			loadBalancerSSLConfigurationsEqual(
+				sslConfigurationDetailsFromBackendSet(existingBackendSet.SslConfiguration),
+				desiredSSLConfig,
+			) {
 			return nil
 		}
 		m.logger.InfoContext(ctx, "Updating TLSRoute backend set",
@@ -786,9 +872,10 @@ func (m *tlsRouteModelImpl) reconcileLoadBalancerBackendSet(
 			LoadBalancerId: new(loadBalancerID),
 			BackendSetName: new(backendSetName),
 			UpdateBackendSetDetails: loadbalancer.UpdateBackendSetDetails{
-				Policy:        new(desiredPolicy),
-				Backends:      backends,
-				HealthChecker: &healthChecker,
+				Policy:           new(desiredPolicy),
+				Backends:         backends,
+				HealthChecker:    &healthChecker,
+				SslConfiguration: desiredSSLConfig,
 			},
 		})
 		if err != nil {
@@ -806,10 +893,11 @@ func (m *tlsRouteModelImpl) reconcileLoadBalancerBackendSet(
 	createRes, err := m.ociLoadBalancerAPI.CreateBackendSet(ctx, loadbalancer.CreateBackendSetRequest{
 		LoadBalancerId: new(loadBalancerID),
 		CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
-			Name:          new(backendSetName),
-			Policy:        new(desiredPolicy),
-			HealthChecker: &healthChecker,
-			Backends:      backends,
+			Name:             new(backendSetName),
+			Policy:           new(desiredPolicy),
+			HealthChecker:    &healthChecker,
+			Backends:         backends,
+			SslConfiguration: desiredSSLConfig,
 		},
 	})
 	if err != nil {
@@ -1538,6 +1626,7 @@ type tlsRouteModelDeps struct {
 	WorkRequestsWatcher       workRequestsWatcher
 	NLBWorkRequestsWatcher    workRequestsWatcher `name:"networkLoadBalancerWorkRequestsWatcher"`
 	OperationLocks            *networkLoadBalancerOperationLocks
+	BackendTLS                backendTLSPolicyModel
 }
 
 func newTLSRouteModel(deps tlsRouteModelDeps) *tlsRouteModelImpl {
@@ -1560,6 +1649,7 @@ func newTLSRouteModel(deps tlsRouteModelDeps) *tlsRouteModelImpl {
 		ociNetworkLoadBalancerAPI: deps.OciNetworkLoadBalancerAPI,
 		ociLoadBalancerModel:      deps.OciLoadBalancerModel,
 		ociLoadBalancerAPI:        deps.OciLoadBalancerAPI,
+		backendTLSPolicy:          deps.BackendTLS,
 		workRequestsWatcher:       watcher,
 		nlbWorkRequestsWatcher:    nlbWatcher,
 		operationLocks:            operationLocks,

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -73,6 +73,7 @@ type tlsRouteModelImpl struct {
 	ociLoadBalancerModel      ociLoadBalancerModel
 	ociLoadBalancerAPI        ociLoadBalancerClient
 	backendTLSPolicy          backendTLSPolicyModel
+	backendTLSDisabled        bool
 	workRequestsWatcher       workRequestsWatcher
 	nlbWorkRequestsWatcher    workRequestsWatcher
 	operationLocks            *networkLoadBalancerOperationLocks
@@ -706,7 +707,7 @@ func (m *tlsRouteModelImpl) loadBalancerBackendTLSConfigForRoute(
 	ctx context.Context,
 	details resolvedTLSRouteDetails,
 ) (*loadbalancer.SslConfigurationDetails, bool, error) {
-	if m.backendTLSPolicy == nil {
+	if m.backendTLSDisabled || m.backendTLSPolicy == nil {
 		return nil, false, nil
 	}
 	var resolved *loadbalancer.SslConfigurationDetails
@@ -763,6 +764,10 @@ func (m *tlsRouteModelImpl) loadBalancerBackendTLSConfigForRef(
 		return nil, errBackendTLSPolicyNotFound
 	}
 	return sslConfig, err
+}
+
+func (m *tlsRouteModelImpl) setBackendTLSPolicyEnabled(enabled bool) {
+	m.backendTLSDisabled = !enabled
 }
 
 func (m *tlsRouteModelImpl) routeHealthCheckPort(

--- a/internal/app/tlsroute_model_test.go
+++ b/internal/app/tlsroute_model_test.go
@@ -806,11 +806,31 @@ func TestTLSRouteBackendTLSPolicyConfig(t *testing.T) {
 		return fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(objects...).Build()
 	}
 
-	t.Run("does not manage backend SSL when BackendTLSPolicy support is disabled", func(t *testing.T) {
+	t.Run("does not manage backend SSL without BackendTLSPolicy model", func(t *testing.T) {
 		model := newTLSRouteModel(tlsRouteModelDeps{
 			RootLogger: diag.RootTestLogger(),
 			K8sClient:  makeClient("rtmp"),
 		})
+
+		sslConfig, managed, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("rtmp"))
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.False(t, managed)
+	})
+
+	t.Run("does not resolve backend SSL when BackendTLSPolicy support is disabled", func(t *testing.T) {
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("rtmp"),
+			BackendTLS: &stubBackendTLSPolicyModel{
+				resolveFunc: func(resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+					require.Fail(t, "disabled BackendTLSPolicy support should not resolve policies")
+					return nil, errors.New("unexpected policy resolution")
+				},
+			},
+		})
+		model.setBackendTLSPolicyEnabled(false)
 
 		sslConfig, managed, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("rtmp"))
 

--- a/internal/app/tlsroute_model_test.go
+++ b/internal/app/tlsroute_model_test.go
@@ -774,6 +774,190 @@ func TestTLSRouteLoadBalancerBackendsEqual(t *testing.T) {
 	))
 }
 
+func TestTLSRouteBackendTLSPolicyConfig(t *testing.T) {
+	namespace := "media"
+	makeDetails := func(serviceNames ...string) resolvedTLSRouteDetails {
+		backendRefs := lo.Map(serviceNames, func(name string, _ int) gatewayv1.BackendRef {
+			return gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName(name),
+				Port: lo.ToPtr(gatewayv1.PortNumber(8443)),
+			}}
+		})
+		return resolvedTLSRouteDetails{
+			gatewayDetails: resolvedGatewayDetails{
+				gateway: *newRandomGateway(func(gateway *gatewayv1.Gateway) {
+					gateway.Namespace = namespace
+					gateway.Name = "edge"
+				}),
+				config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: "lb-id"}},
+			},
+			tlsRoute: gatewayv1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "rtmps"},
+				Spec: gatewayv1.TLSRouteSpec{Rules: []gatewayv1.TLSRouteRule{{
+					BackendRefs: backendRefs,
+				}}},
+			},
+		}
+	}
+	makeClient := func(services ...string) k8sClient {
+		objects := lo.Map(services, func(name string, _ int) client.Object {
+			return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+		})
+		return fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).WithObjects(objects...).Build()
+	}
+
+	t.Run("does not manage backend SSL when BackendTLSPolicy support is disabled", func(t *testing.T) {
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("rtmp"),
+		})
+
+		sslConfig, managed, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("rtmp"))
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.False(t, managed)
+	})
+
+	t.Run("manages backend SSL as nil when no policy matches", func(t *testing.T) {
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("rtmp"),
+			BackendTLS: &stubBackendTLSPolicyModel{resolveErr: errBackendTLSPolicyNotFound},
+		})
+
+		sslConfig, managed, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("rtmp"))
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.True(t, managed)
+	})
+
+	t.Run("returns matching backend SSL config", func(t *testing.T) {
+		verifyDepth := 4
+		wantConfig := &loadbalancer.SslConfigurationDetails{VerifyDepth: &verifyDepth}
+		backendTLS := &stubBackendTLSPolicyModel{
+			resolveFunc: func(params resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				require.Equal(t, "rtmp", params.service.Name)
+				return wantConfig, nil
+			},
+		}
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("rtmp"),
+			BackendTLS: backendTLS,
+		})
+
+		sslConfig, managed, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("rtmp"))
+
+		require.NoError(t, err)
+		require.True(t, managed)
+		require.Same(t, wantConfig, sslConfig)
+	})
+
+	t.Run("rejects differing backend SSL configs in one backend set", func(t *testing.T) {
+		backendTLS := &stubBackendTLSPolicyModel{
+			resolveFunc: func(params resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				verifyDepth := 1
+				if params.service.Name == "two" {
+					verifyDepth = 2
+				}
+				return &loadbalancer.SslConfigurationDetails{VerifyDepth: &verifyDepth}, nil
+			},
+		}
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("one", "two"),
+			BackendTLS: backendTLS,
+		})
+
+		_, _, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("one", "two"))
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "all backendRefs must resolve to the same")
+	})
+
+	t.Run("rejects mixed backend policy presence in one backend set", func(t *testing.T) {
+		verifyDepth := 1
+		backendTLS := &stubBackendTLSPolicyModel{
+			resolveFunc: func(params resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				if params.service.Name == "plain" {
+					return nil, errBackendTLSPolicyNotFound
+				}
+				return &loadbalancer.SslConfigurationDetails{VerifyDepth: &verifyDepth}, nil
+			},
+		}
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("plain", "tls"),
+			BackendTLS: backendTLS,
+		})
+
+		_, _, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("plain", "tls"))
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "all backendRefs must resolve to the same")
+	})
+
+	t.Run("rejects mixed backend policy presence when policy backend is first", func(t *testing.T) {
+		verifyDepth := 1
+		backendTLS := &stubBackendTLSPolicyModel{
+			resolveFunc: func(params resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				if params.service.Name == "plain" {
+					return nil, errBackendTLSPolicyNotFound
+				}
+				return &loadbalancer.SslConfigurationDetails{VerifyDepth: &verifyDepth}, nil
+			},
+		}
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("tls", "plain"),
+			BackendTLS: backendTLS,
+		})
+
+		_, _, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("tls", "plain"))
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "all backendRefs must resolve to the same")
+	})
+
+	t.Run("skips zero weight backend refs", func(t *testing.T) {
+		details := makeDetails("rtmp")
+		zeroWeight := int32(0)
+		details.tlsRoute.Spec.Rules[0].BackendRefs[0].Weight = &zeroWeight
+		backendTLS := &stubBackendTLSPolicyModel{
+			resolveFunc: func(resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				require.Fail(t, "zero-weight backend should not resolve BackendTLSPolicy")
+				return nil, errors.New("unexpected BackendTLSPolicy resolution")
+			},
+		}
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient("rtmp"),
+			BackendTLS: backendTLS,
+		})
+
+		sslConfig, managed, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), details)
+
+		require.NoError(t, err)
+		require.Nil(t, sslConfig)
+		require.True(t, managed)
+	})
+
+	t.Run("returns missing backend service errors", func(t *testing.T) {
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  makeClient(),
+			BackendTLS: &stubBackendTLSPolicyModel{},
+		})
+
+		_, _, err := model.loadBalancerBackendTLSConfigForRoute(t.Context(), makeDetails("missing"))
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to get TLSRoute backend Service")
+	})
+}
+
 func TestTLSRouteModelLoadBalancerListener(t *testing.T) {
 	mode := gatewayv1.TLSModeTerminate
 	listener := gatewayv1.Listener{

--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -809,6 +809,192 @@ func (m *WatchesModel) MapEndpointSliceToTLSRoute(ctx context.Context, obj clien
 	)
 }
 
+func (m *WatchesModel) MapBackendTLSPolicyToHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapBackendTLSPolicyToIndexedRoutes(ctx, obj, &gatewayv1.HTTPRouteList{},
+		httpRouteBackendServiceIndexKey, "HTTPRoutes")
+}
+
+func (m *WatchesModel) MapBackendTLSPolicyToGRPCRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapBackendTLSPolicyToIndexedRoutes(ctx, obj, &gatewayv1.GRPCRouteList{},
+		grpcRouteBackendServiceIndexKey, "GRPCRoutes")
+}
+
+func (m *WatchesModel) MapBackendTLSPolicyToTLSRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapBackendTLSPolicyToIndexedRoutes(ctx, obj, &gatewayv1.TLSRouteList{},
+		tlsRouteBackendServiceIndexKey, "TLSRoutes")
+}
+
+func (m *WatchesModel) MapConfigMapToHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapConfigMapToBackendTLSPolicyRoutes(
+		ctx,
+		obj,
+		func(policy gatewayv1.BackendTLSPolicy) []reconcile.Request {
+			return m.MapBackendTLSPolicyToHTTPRoute(ctx, &policy)
+		},
+	)
+}
+
+func (m *WatchesModel) MapConfigMapToGRPCRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapConfigMapToBackendTLSPolicyRoutes(
+		ctx,
+		obj,
+		func(policy gatewayv1.BackendTLSPolicy) []reconcile.Request {
+			return m.MapBackendTLSPolicyToGRPCRoute(ctx, &policy)
+		},
+	)
+}
+
+func (m *WatchesModel) MapConfigMapToTLSRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapConfigMapToBackendTLSPolicyRoutes(
+		ctx,
+		obj,
+		func(policy gatewayv1.BackendTLSPolicy) []reconcile.Request {
+			return m.MapBackendTLSPolicyToTLSRoute(ctx, &policy)
+		},
+	)
+}
+
+func (m *WatchesModel) MapServiceToHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapServiceToIndexedRoutes(ctx, obj, &gatewayv1.HTTPRouteList{},
+		httpRouteBackendServiceIndexKey, "HTTPRoutes")
+}
+
+func (m *WatchesModel) MapServiceToGRPCRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapServiceToIndexedRoutes(ctx, obj, &gatewayv1.GRPCRouteList{},
+		grpcRouteBackendServiceIndexKey, "GRPCRoutes")
+}
+
+func (m *WatchesModel) MapServiceToTLSRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapServiceToIndexedRoutes(ctx, obj, &gatewayv1.TLSRouteList{},
+		tlsRouteBackendServiceIndexKey, "TLSRoutes")
+}
+
+func (m *WatchesModel) mapBackendTLSPolicyToIndexedRoutes(
+	ctx context.Context,
+	obj client.Object,
+	routeList client.ObjectList,
+	indexKey string,
+	routeKind string,
+) []reconcile.Request {
+	policy, ok := obj.(*gatewayv1.BackendTLSPolicy)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-BackendTLSPolicy object", slog.Any("object", obj))
+		return nil
+	}
+	requestsByKey := make(map[client.ObjectKey]reconcile.Request)
+	for _, targetRef := range policy.Spec.TargetRefs {
+		if targetRef.Group != "" || targetRef.Kind != "Service" {
+			continue
+		}
+		serviceKey := path.Join(policy.Namespace, string(targetRef.Name))
+		if err := m.k8sClient.List(ctx, routeList, client.MatchingFields{indexKey: serviceKey}); err != nil {
+			m.logger.ErrorContext(ctx, fmt.Sprintf("Failed to list %s for BackendTLSPolicy change", routeKind),
+				slog.String("service", serviceKey),
+				diag.ErrAttr(err))
+			return nil
+		}
+		for _, route := range objectListItems(routeList) {
+			if route.GetDeletionTimestamp() != nil {
+				continue
+			}
+			key := client.ObjectKeyFromObject(route)
+			requestsByKey[key] = reconcile.Request{NamespacedName: key}
+		}
+	}
+	return lo.Values(requestsByKey)
+}
+
+func (m *WatchesModel) mapServiceToIndexedRoutes(
+	ctx context.Context,
+	obj client.Object,
+	routeList client.ObjectList,
+	indexKey string,
+	routeKind string,
+) []reconcile.Request {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-Service object", slog.Any("object", obj))
+		return nil
+	}
+	serviceKey := path.Join(service.Namespace, service.Name)
+	return m.mapServiceKeyToIndexedRoutes(ctx, serviceKey, routeList, indexKey, routeKind)
+}
+
+func (m *WatchesModel) mapServiceKeyToIndexedRoutes(
+	ctx context.Context,
+	serviceKey string,
+	routeList client.ObjectList,
+	indexKey string,
+	routeKind string,
+) []reconcile.Request {
+	if err := m.k8sClient.List(ctx, routeList, client.MatchingFields{indexKey: serviceKey}); err != nil {
+		m.logger.ErrorContext(ctx, fmt.Sprintf("Failed to list %s for Service change", routeKind),
+			slog.String("service", serviceKey),
+			diag.ErrAttr(err))
+		return nil
+	}
+	requestsByKey := make(map[client.ObjectKey]reconcile.Request)
+	for _, route := range objectListItems(routeList) {
+		if route.GetDeletionTimestamp() != nil {
+			continue
+		}
+		key := client.ObjectKeyFromObject(route)
+		requestsByKey[key] = reconcile.Request{NamespacedName: key}
+	}
+	return lo.Values(requestsByKey)
+}
+
+func (m *WatchesModel) mapConfigMapToBackendTLSPolicyRoutes(
+	ctx context.Context,
+	obj client.Object,
+	mapPolicy func(gatewayv1.BackendTLSPolicy) []reconcile.Request,
+) []reconcile.Request {
+	configMap, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ConfigMap object", slog.Any("object", obj))
+		return nil
+	}
+	var policyList gatewayv1.BackendTLSPolicyList
+	if err := m.k8sClient.List(ctx, &policyList, client.InNamespace(configMap.Namespace)); err != nil {
+		m.logger.ErrorContext(ctx, "Failed to list BackendTLSPolicies for ConfigMap change",
+			slog.String("configMap", client.ObjectKeyFromObject(configMap).String()),
+			diag.ErrAttr(err))
+		return nil
+	}
+	requestsByKey := make(map[client.ObjectKey]reconcile.Request)
+	for _, policy := range policyList.Items {
+		if !backendTLSPolicyReferencesConfigMap(policy, configMap.Name) {
+			continue
+		}
+		for _, request := range mapPolicy(policy) {
+			requestsByKey[request.NamespacedName] = request
+		}
+	}
+	return lo.Values(requestsByKey)
+}
+
+func objectListItems(list client.ObjectList) []client.Object {
+	switch typed := list.(type) {
+	case *gatewayv1.HTTPRouteList:
+		return lo.Map(typed.Items, func(item gatewayv1.HTTPRoute, _ int) client.Object { return &item })
+	case *gatewayv1.GRPCRouteList:
+		return lo.Map(typed.Items, func(item gatewayv1.GRPCRoute, _ int) client.Object { return &item })
+	case *gatewayv1.TLSRouteList:
+		return lo.Map(typed.Items, func(item gatewayv1.TLSRoute, _ int) client.Object { return &item })
+	default:
+		return nil
+	}
+}
+
+func backendTLSPolicyReferencesConfigMap(policy gatewayv1.BackendTLSPolicy, name string) bool {
+	for _, caRef := range policy.Spec.Validation.CACertificateRefs {
+		if caRef.Group == "" && caRef.Kind == "ConfigMap" && string(caRef.Name) == name {
+			return true
+		}
+	}
+	return false
+}
+
 func mapEndpointSliceToL4Route[T client.ObjectList](
 	ctx context.Context,
 	logger *slog.Logger,

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -2257,5 +2258,150 @@ func TestWatchesModel(t *testing.T) {
 
 			require.Nil(t, model.MapGatewayConfigToGateway(t.Context(), config))
 		})
+	})
+
+	t.Run("BackendTLSPolicy watches", func(t *testing.T) {
+		namespace := "iot"
+		serviceName := "backend"
+		serviceKey := "iot/backend"
+		httpRoute := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "http"}}
+		deletionTime := metav1.Now()
+		deletingHTTPRoute := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              "http-deleting",
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{"test-finalizer"},
+		}}
+		grpcRoute := &gatewayv1.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "grpc"}}
+		tlsRoute := &gatewayv1.TLSRoute{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "tls"}}
+		policy := &gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "backend-tls"},
+			Spec: gatewayv1.BackendTLSPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+					LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Group: "",
+						Kind:  "Service",
+						Name:  gatewayv1.ObjectName(serviceName),
+					},
+				}},
+				Validation: gatewayv1.BackendTLSPolicyValidation{
+					CACertificateRefs: []gatewayv1.LocalObjectReference{{
+						Group: "",
+						Kind:  "ConfigMap",
+						Name:  "ca",
+					}},
+				},
+			},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(httpRoute, deletingHTTPRoute, grpcRoute, tlsRoute, policy).
+			WithIndex(&gatewayv1.HTTPRoute{}, httpRouteBackendServiceIndexKey, func(_ client.Object) []string {
+				return []string{serviceKey}
+			}).
+			WithIndex(&gatewayv1.GRPCRoute{}, grpcRouteBackendServiceIndexKey, func(_ client.Object) []string {
+				return []string{serviceKey}
+			}).
+			WithIndex(&gatewayv1.TLSRoute{}, tlsRouteBackendServiceIndexKey, func(_ client.Object) []string {
+				return []string{serviceKey}
+			}).
+			Build()
+		model := NewWatchesModel(WatchesModelDeps{
+			K8sClient: k8sClient,
+			Logger:    diag.RootTestLogger(),
+		})
+
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "http"},
+		}}, model.MapBackendTLSPolicyToHTTPRoute(t.Context(), policy))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "grpc"},
+		}}, model.MapBackendTLSPolicyToGRPCRoute(t.Context(), policy))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "tls"},
+		}}, model.MapBackendTLSPolicyToTLSRoute(t.Context(), policy))
+
+		configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "ca"}}
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "http"},
+		}}, model.MapConfigMapToHTTPRoute(t.Context(), configMap))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "grpc"},
+		}}, model.MapConfigMapToGRPCRoute(t.Context(), configMap))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "tls"},
+		}}, model.MapConfigMapToTLSRoute(t.Context(), configMap))
+
+		service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: serviceName}}
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "http"},
+		}}, model.MapServiceToHTTPRoute(t.Context(), service))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "grpc"},
+		}}, model.MapServiceToGRPCRoute(t.Context(), service))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: "tls"},
+		}}, model.MapServiceToTLSRoute(t.Context(), service))
+
+		require.Nil(t, model.MapBackendTLSPolicyToHTTPRoute(t.Context(), &corev1.Service{}))
+		require.Nil(t, model.MapConfigMapToHTTPRoute(t.Context(), &corev1.Service{}))
+		require.Nil(t, model.MapServiceToHTTPRoute(t.Context(), &corev1.ConfigMap{}))
+		require.False(t, backendTLSPolicyReferencesConfigMap(*policy, "other"))
+		require.Nil(t, objectListItems(&corev1.ServiceList{}))
+	})
+
+	t.Run("BackendTLSPolicy watch error and skip paths", func(t *testing.T) {
+		deps := makeMockDeps(t)
+		model := NewWatchesModel(deps)
+		mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		policy := &gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "backend-tls"},
+			Spec: gatewayv1.BackendTLSPolicySpec{
+				TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+					{LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Group: "apps",
+						Kind:  "Deployment",
+						Name:  "ignored",
+					}},
+					{LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Group: "",
+						Kind:  "Service",
+						Name:  "backend",
+					}},
+				},
+				Validation: gatewayv1.BackendTLSPolicyValidation{
+					CACertificateRefs: []gatewayv1.LocalObjectReference{{
+						Group: "",
+						Kind:  "ConfigMap",
+						Name:  "ca",
+					}},
+				},
+			},
+		}
+		mockK8sClient.EXPECT().
+			List(t.Context(), &gatewayv1.HTTPRouteList{}, client.MatchingFields{
+				httpRouteBackendServiceIndexKey: "iot/backend",
+			}).
+			Return(errors.New("route list failed"))
+
+		require.Nil(t, model.MapBackendTLSPolicyToHTTPRoute(t.Context(), policy))
+
+		mockK8sClient.EXPECT().
+			List(t.Context(), &gatewayv1.BackendTLSPolicyList{}, client.InNamespace("iot")).
+			Return(errors.New("policy list failed"))
+
+		require.Nil(t, model.MapConfigMapToHTTPRoute(
+			t.Context(),
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "ca"}},
+		))
+
+		mockK8sClient.EXPECT().
+			List(t.Context(), &gatewayv1.HTTPRouteList{},
+				client.MatchingFields{httpRouteBackendServiceIndexKey: "iot/backend"}).
+			Return(errors.New("route list failed"))
+		require.Nil(t, model.MapServiceToHTTPRoute(
+			t.Context(),
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "backend"}},
+		))
 	})
 }

--- a/internal/config/default.json
+++ b/internal/config/default.json
@@ -29,6 +29,7 @@
     "reconcileUDPRoute": true,
     "reconcileTLSRoute": true,
     "reconcileHTTPRoute": true,
-    "reconcileGRPCRoute": true
+    "reconcileGRPCRoute": true,
+    "reconcileBackendTLSPolicy": true
   }
 }

--- a/internal/config/provide.go
+++ b/internal/config/provide.go
@@ -74,5 +74,6 @@ func Provide(container *dig.Container, cfg *viper.Viper) error {
 		provideConfigValue(cfg, "features.reconcileTLSRoute").asBool(),
 		provideConfigValue(cfg, "features.reconcileHTTPRoute").asBool(),
 		provideConfigValue(cfg, "features.reconcileGRPCRoute").asBool(),
+		provideConfigValue(cfg, "features.reconcileBackendTLSPolicy").asBool(),
 	)
 }

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -42,6 +42,7 @@ type StartManagerDeps struct {
 	TCPRouteCtrl     *app.TCPRouteController
 	UDPRouteCtrl     *app.UDPRouteController
 	TLSRouteCtrl     *app.TLSRouteController
+	BackendTLSCtrl   *app.BackendTLSPolicyController
 	WatchesModel     *app.WatchesModel
 	Config           *rest.Config
 
@@ -54,26 +55,45 @@ type StartManagerDeps struct {
 	ReconcileTLSRoute                   bool `name:"config.features.reconcileTLSRoute"`
 	ReconcileHTTPRoute                  bool `name:"config.features.reconcileHTTPRoute"`
 	ReconcileGRPCRoute                  bool `name:"config.features.reconcileGRPCRoute"`
+	ReconcileBackendTLSPolicy           bool `name:"config.features.reconcileBackendTLSPolicy"`
 }
 
 type experimentalRouteCapabilities struct {
-	TCPRoute bool
-	UDPRoute bool
+	TCPRoute         bool
+	UDPRoute         bool
+	BackendTLSPolicy bool
 }
 
 type resolvedExperimentalRouteCapabilities struct {
-	reconcileTCPRoute bool
-	reconcileUDPRoute bool
+	reconcileTCPRoute         bool
+	reconcileUDPRoute         bool
+	reconcileBackendTLSPolicy bool
+	backendTLSPolicyAvailable bool
 }
 
 type setupL4RouteControllerParams struct {
-	name        string
-	route       client.Object
-	mapEndpoint handler.MapFunc
-	mapGrant    handler.MapFunc
-	mapGateway  handler.MapFunc
-	mapSecret   handler.MapFunc
-	reconciler  reconcile.TypedReconciler[reconcile.Request]
+	name                string
+	route               client.Object
+	mapEndpoint         handler.MapFunc
+	mapGrant            handler.MapFunc
+	mapGateway          handler.MapFunc
+	mapSecret           handler.MapFunc
+	mapBackendTLSPolicy handler.MapFunc
+	mapConfigMap        handler.MapFunc
+	mapService          handler.MapFunc
+	reconciler          reconcile.TypedReconciler[reconcile.Request]
+}
+
+type setupL7RouteControllerParams struct {
+	name                       string
+	route                      client.Object
+	mapEndpoint                handler.MapFunc
+	pairedRoute                client.Object
+	mapPairedRoute             handler.MapFunc
+	mapBackendTLSPolicyToRoute handler.MapFunc
+	mapConfigMapToRoute        handler.MapFunc
+	mapServiceToRoute          handler.MapFunc
+	reconciler                 reconcile.TypedReconciler[reconcile.Request]
 }
 
 type controllerSetupTask struct {
@@ -114,10 +134,19 @@ func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRo
 	if err != nil {
 		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect UDPRoute availability: %w", err)
 	}
+	backendTLSPolicyAvailable, err := resourceKindAvailable(
+		mapper,
+		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "BackendTLSPolicy"},
+		"v1",
+	)
+	if err != nil {
+		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect BackendTLSPolicy availability: %w", err)
+	}
 
 	return experimentalRouteCapabilities{
-		TCPRoute: tcpRouteAvailable,
-		UDPRoute: udpRouteAvailable,
+		TCPRoute:         tcpRouteAvailable,
+		UDPRoute:         udpRouteAvailable,
+		BackendTLSPolicy: backendTLSPolicyAvailable,
 	}, nil
 }
 
@@ -160,16 +189,22 @@ func resolveExperimentalRouteCapabilities(
 	if deps.ReconcileUDPRoute && !experimentalRouteCRDs.UDPRoute {
 		logger.InfoContext(ctx, "UDPRoute CRD is not installed; UDPRoute support is disabled")
 	}
+	if deps.ReconcileBackendTLSPolicy && !experimentalRouteCRDs.BackendTLSPolicy {
+		logger.InfoContext(ctx, "BackendTLSPolicy CRD is not installed; BackendTLSPolicy support is disabled")
+	}
 
 	return resolvedExperimentalRouteCapabilities{
-		reconcileTCPRoute: deps.ReconcileTCPRoute && experimentalRouteCRDs.TCPRoute,
-		reconcileUDPRoute: deps.ReconcileUDPRoute && experimentalRouteCRDs.UDPRoute,
+		reconcileTCPRoute:         deps.ReconcileTCPRoute && experimentalRouteCRDs.TCPRoute,
+		reconcileUDPRoute:         deps.ReconcileUDPRoute && experimentalRouteCRDs.UDPRoute,
+		reconcileBackendTLSPolicy: deps.ReconcileBackendTLSPolicy && experimentalRouteCRDs.BackendTLSPolicy,
+		backendTLSPolicyAvailable: experimentalRouteCRDs.BackendTLSPolicy,
 	}, nil
 }
 
 func setupL4RouteController(
 	mgr manager.Manager,
 	params setupL4RouteControllerParams,
+	enableBackendTLSPolicy bool,
 	middlewares ...controllerMiddleware[reconcile.Request],
 ) error {
 	controllerBuilder := builder.ControllerManagedBy(mgr).
@@ -199,6 +234,24 @@ func setupL4RouteController(
 			handler.EnqueueRequestsFromMapFunc(params.mapSecret),
 			builder.WithPredicates(gatewaySecretPredicate()),
 		)
+	}
+	if enableBackendTLSPolicy && params.name == "tlsroute" {
+		controllerBuilder = controllerBuilder.
+			Watches(
+				&gatewayv1.BackendTLSPolicy{},
+				handler.EnqueueRequestsFromMapFunc(params.mapBackendTLSPolicy),
+				builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			).
+			Watches(
+				&corev1.ConfigMap{},
+				handler.EnqueueRequestsFromMapFunc(params.mapConfigMap),
+				builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			).
+			Watches(
+				&corev1.Service{},
+				handler.EnqueueRequestsFromMapFunc(params.mapService),
+				builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			)
 	}
 	return controllerBuilder.Complete(wireupReconciler(params.reconciler, middlewares...))
 }
@@ -267,12 +320,22 @@ func coreControllerSetupTasks(
 					Complete(wireupReconciler(deps.NLBGatewayCtrl, middlewares...))
 			},
 		},
+	}
+}
+
+func l7AndTLSControllerSetupTasks(
+	mgr manager.Manager,
+	deps StartManagerDeps,
+	experimentalRoutes resolvedExperimentalRouteCapabilities,
+	middlewares []controllerMiddleware[reconcile.Request],
+) []controllerSetupTask {
+	return []controllerSetupTask{
 		{
 			enabled:     deps.ReconcileHTTPRoute,
 			disabledLog: "HTTPRoute controller is disabled",
 			setupErr:    "failed to setup HTTPRoute controller: %w",
 			setup: func() error {
-				return setupHTTPRouteController(mgr, deps, middlewares)
+				return setupHTTPRouteController(mgr, deps, experimentalRoutes.reconcileBackendTLSPolicy, middlewares)
 			},
 		},
 		{
@@ -280,7 +343,7 @@ func coreControllerSetupTasks(
 			disabledLog: "GRPCRoute controller is disabled",
 			setupErr:    "failed to setup GRPCRoute controller: %w",
 			setup: func() error {
-				return setupGRPCRouteController(mgr, deps, middlewares)
+				return setupGRPCRouteController(mgr, deps, experimentalRoutes.reconcileBackendTLSPolicy, middlewares)
 			},
 		},
 		{
@@ -289,14 +352,28 @@ func coreControllerSetupTasks(
 			setupErr:    "failed to setup TLSRoute controller: %w",
 			setup: func() error {
 				return setupL4RouteController(mgr, setupL4RouteControllerParams{
-					name:        "tlsroute",
-					route:       &gatewayv1.TLSRoute{},
-					mapEndpoint: deps.WatchesModel.MapEndpointSliceToTLSRoute,
-					mapGrant:    deps.WatchesModel.MapReferenceGrantToTLSRoute,
-					mapGateway:  deps.WatchesModel.MapGatewayToTLSRoute,
-					mapSecret:   deps.WatchesModel.MapSecretToTLSRoute,
-					reconciler:  deps.TLSRouteCtrl,
-				}, middlewares...)
+					name:                "tlsroute",
+					route:               &gatewayv1.TLSRoute{},
+					mapEndpoint:         deps.WatchesModel.MapEndpointSliceToTLSRoute,
+					mapGrant:            deps.WatchesModel.MapReferenceGrantToTLSRoute,
+					mapGateway:          deps.WatchesModel.MapGatewayToTLSRoute,
+					mapSecret:           deps.WatchesModel.MapSecretToTLSRoute,
+					mapBackendTLSPolicy: deps.WatchesModel.MapBackendTLSPolicyToTLSRoute,
+					mapConfigMap:        deps.WatchesModel.MapConfigMapToTLSRoute,
+					mapService:          deps.WatchesModel.MapServiceToTLSRoute,
+					reconciler:          deps.TLSRouteCtrl,
+				}, experimentalRoutes.reconcileBackendTLSPolicy, middlewares...)
+			},
+		},
+		{
+			enabled:     experimentalRoutes.backendTLSPolicyAvailable,
+			disabledLog: "BackendTLSPolicy controller is disabled",
+			setupErr:    "failed to setup BackendTLSPolicy controller: %w",
+			setup: func() error {
+				return builder.ControllerManagedBy(mgr).
+					Named("backendtlspolicy").
+					For(&gatewayv1.BackendTLSPolicy{}).
+					Complete(wireupReconciler(deps.BackendTLSCtrl, middlewares...))
 			},
 		},
 	}
@@ -305,43 +382,79 @@ func coreControllerSetupTasks(
 func setupHTTPRouteController(
 	mgr manager.Manager,
 	deps StartManagerDeps,
+	enableBackendTLSPolicy bool,
 	middlewares []controllerMiddleware[reconcile.Request],
 ) error {
-	return builder.ControllerManagedBy(mgr).
-		Named("httproute").
-		For(&gatewayv1.HTTPRoute{}).
-		Watches(
-			&discoveryv1.EndpointSlice{},
-			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapEndpointSliceToHTTPRoute),
-		).
-		Watches(
-			&gatewayv1.GRPCRoute{},
-			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGRPCRouteToHTTPRoute),
-			builder.WithPredicates(l7RouteObjectPredicate()),
-		).
-		WithEventFilter(l7RouteObjectPredicate()).
-		Complete(wireupReconciler(deps.HTTPRouteCtrl, middlewares...))
+	return setupL7RouteController(mgr, setupL7RouteControllerParams{
+		name:                       "httproute",
+		route:                      &gatewayv1.HTTPRoute{},
+		mapEndpoint:                deps.WatchesModel.MapEndpointSliceToHTTPRoute,
+		pairedRoute:                &gatewayv1.GRPCRoute{},
+		mapPairedRoute:             deps.WatchesModel.MapGRPCRouteToHTTPRoute,
+		mapBackendTLSPolicyToRoute: deps.WatchesModel.MapBackendTLSPolicyToHTTPRoute,
+		mapConfigMapToRoute:        deps.WatchesModel.MapConfigMapToHTTPRoute,
+		mapServiceToRoute:          deps.WatchesModel.MapServiceToHTTPRoute,
+		reconciler:                 deps.HTTPRouteCtrl,
+	}, enableBackendTLSPolicy, middlewares)
 }
 
 func setupGRPCRouteController(
 	mgr manager.Manager,
 	deps StartManagerDeps,
+	enableBackendTLSPolicy bool,
 	middlewares []controllerMiddleware[reconcile.Request],
 ) error {
-	return builder.ControllerManagedBy(mgr).
-		Named("grpcroute").
-		For(&gatewayv1.GRPCRoute{}).
+	return setupL7RouteController(mgr, setupL7RouteControllerParams{
+		name:                       "grpcroute",
+		route:                      &gatewayv1.GRPCRoute{},
+		mapEndpoint:                deps.WatchesModel.MapEndpointSliceToGRPCRoute,
+		pairedRoute:                &gatewayv1.HTTPRoute{},
+		mapPairedRoute:             deps.WatchesModel.MapHTTPRouteToGRPCRoute,
+		mapBackendTLSPolicyToRoute: deps.WatchesModel.MapBackendTLSPolicyToGRPCRoute,
+		mapConfigMapToRoute:        deps.WatchesModel.MapConfigMapToGRPCRoute,
+		mapServiceToRoute:          deps.WatchesModel.MapServiceToGRPCRoute,
+		reconciler:                 deps.GRPCRouteCtrl,
+	}, enableBackendTLSPolicy, middlewares)
+}
+
+func setupL7RouteController(
+	mgr manager.Manager,
+	params setupL7RouteControllerParams,
+	enableBackendTLSPolicy bool,
+	middlewares []controllerMiddleware[reconcile.Request],
+) error {
+	controllerBuilder := builder.ControllerManagedBy(mgr).
+		Named(params.name).
+		For(params.route).
 		Watches(
 			&discoveryv1.EndpointSlice{},
-			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapEndpointSliceToGRPCRoute),
+			handler.EnqueueRequestsFromMapFunc(params.mapEndpoint),
 		).
 		Watches(
-			&gatewayv1.HTTPRoute{},
-			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapHTTPRouteToGRPCRoute),
+			params.pairedRoute,
+			handler.EnqueueRequestsFromMapFunc(params.mapPairedRoute),
 			builder.WithPredicates(l7RouteObjectPredicate()),
 		).
-		WithEventFilter(l7RouteObjectPredicate()).
-		Complete(wireupReconciler(deps.GRPCRouteCtrl, middlewares...))
+		WithEventFilter(l7RouteObjectPredicate())
+	if enableBackendTLSPolicy {
+		controllerBuilder = controllerBuilder.
+			Watches(
+				&gatewayv1.BackendTLSPolicy{},
+				handler.EnqueueRequestsFromMapFunc(params.mapBackendTLSPolicyToRoute),
+				builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			).
+			Watches(
+				&corev1.ConfigMap{},
+				handler.EnqueueRequestsFromMapFunc(params.mapConfigMapToRoute),
+				builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			).
+			Watches(
+				&corev1.Service{},
+				handler.EnqueueRequestsFromMapFunc(params.mapServiceToRoute),
+				builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			)
+	}
+	return controllerBuilder.Complete(wireupReconciler(params.reconciler, middlewares...))
 }
 
 func l4RouteControllerSetupTasks(
@@ -363,7 +476,7 @@ func l4RouteControllerSetupTasks(
 					mapGrant:    deps.WatchesModel.MapReferenceGrantToTCPRoute,
 					mapGateway:  deps.WatchesModel.MapGatewayToTCPRoute,
 					reconciler:  deps.TCPRouteCtrl,
-				}, middlewares...)
+				}, false, middlewares...)
 			},
 		},
 		{
@@ -378,7 +491,7 @@ func l4RouteControllerSetupTasks(
 					mapGrant:    deps.WatchesModel.MapReferenceGrantToUDPRoute,
 					mapGateway:  deps.WatchesModel.MapGatewayToUDPRoute,
 					reconciler:  deps.UDPRouteCtrl,
-				}, middlewares...)
+				}, false, middlewares...)
 			},
 		},
 	}
@@ -433,6 +546,7 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error {
 		newErrorHandlingMiddleware(deps.RootLogger),
 	}
 	tasks := coreControllerSetupTasks(mgr, deps, middlewares)
+	tasks = append(tasks, l7AndTLSControllerSetupTasks(mgr, deps, experimentalRoutes, middlewares)...)
 	tasks = append(tasks, l4RouteControllerSetupTasks(mgr, deps, experimentalRoutes, middlewares)...)
 	if err := runControllerSetupTasks(loggerCtx, logger, tasks); err != nil {
 		return err

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -367,7 +367,7 @@ func l7AndTLSControllerSetupTasks(
 		},
 		{
 			enabled:     experimentalRoutes.backendTLSPolicyAvailable,
-			disabledLog: "BackendTLSPolicy controller is disabled",
+			disabledLog: "BackendTLSPolicy controller is disabled because the CRD is not installed",
 			setupErr:    "failed to setup BackendTLSPolicy controller: %w",
 			setup: func() error {
 				return builder.ControllerManagedBy(mgr).

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -335,6 +335,7 @@ func l7AndTLSControllerSetupTasks(
 			disabledLog: "HTTPRoute controller is disabled",
 			setupErr:    "failed to setup HTTPRoute controller: %w",
 			setup: func() error {
+				deps.HTTPRouteCtrl.SetBackendTLSPolicyEnabled(experimentalRoutes.reconcileBackendTLSPolicy)
 				return setupHTTPRouteController(mgr, deps, experimentalRoutes.reconcileBackendTLSPolicy, middlewares)
 			},
 		},
@@ -343,6 +344,7 @@ func l7AndTLSControllerSetupTasks(
 			disabledLog: "GRPCRoute controller is disabled",
 			setupErr:    "failed to setup GRPCRoute controller: %w",
 			setup: func() error {
+				deps.GRPCRouteCtrl.SetBackendTLSPolicyEnabled(experimentalRoutes.reconcileBackendTLSPolicy)
 				return setupGRPCRouteController(mgr, deps, experimentalRoutes.reconcileBackendTLSPolicy, middlewares)
 			},
 		},
@@ -351,6 +353,7 @@ func l7AndTLSControllerSetupTasks(
 			disabledLog: "TLSRoute controller is disabled",
 			setupErr:    "failed to setup TLSRoute controller: %w",
 			setup: func() error {
+				deps.TLSRouteCtrl.SetBackendTLSPolicyEnabled(experimentalRoutes.reconcileBackendTLSPolicy)
 				return setupL4RouteController(mgr, setupL4RouteControllerParams{
 					name:                "tlsroute",
 					route:               &gatewayv1.TLSRoute{},

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -196,6 +196,30 @@ func TestResolveExperimentalRouteCapabilities(t *testing.T) {
 		assert.False(t, got.reconcileTCPRoute)
 		assert.False(t, got.reconcileUDPRoute)
 	})
+
+	t.Run("keeps BackendTLSPolicy controller available for cleanup when feature is disabled", func(t *testing.T) {
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+			{Group: gatewayv1.GroupName, Version: "v1"},
+		})
+		mapper.Add(schema.GroupVersionKind{
+			Group:   gatewayv1.GroupName,
+			Version: "v1",
+			Kind:    "BackendTLSPolicy",
+		}, meta.RESTScopeNamespace)
+
+		got, err := resolveExperimentalRouteCapabilities(
+			t.Context(),
+			diag.RootTestLogger(),
+			mapper,
+			StartManagerDeps{
+				ReconcileBackendTLSPolicy: false,
+			},
+		)
+
+		require.NoError(t, err)
+		assert.False(t, got.reconcileBackendTLSPolicy)
+		assert.True(t, got.backendTLSPolicyAvailable)
+	})
 }
 
 type failingRESTMapper struct {

--- a/internal/services/ociapi/clients.go
+++ b/internal/services/ociapi/clients.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
@@ -48,6 +49,24 @@ func newNetworkLoadBalancerClient(
 	if err != nil {
 		return networkloadbalancer.NetworkLoadBalancerClient{}, fmt.Errorf(
 			"failed to create network load balancer client: %w",
+			err,
+		)
+	}
+	return client, nil
+}
+
+func newCertificatesManagementClient(
+	deps LoadBalancerConfigDeps,
+) (certificatesmanagement.CertificatesManagementClient, error) {
+	if deps.Noop {
+		deps.RootLogger.Warn("OCI API client is in noop mode")
+		return certificatesmanagement.CertificatesManagementClient{}, nil
+	}
+
+	client, err := certificatesmanagement.NewCertificatesManagementClientWithConfigurationProvider(deps.ConfigProvider)
+	if err != nil {
+		return certificatesmanagement.CertificatesManagementClient{}, fmt.Errorf(
+			"failed to create certificates management client: %w",
 			err,
 		)
 	}

--- a/internal/services/ociapi/register.go
+++ b/internal/services/ociapi/register.go
@@ -13,6 +13,7 @@ func Register(container *dig.Container) error {
 		newConfigProvider,
 		newLoadBalancerClient,
 		newNetworkLoadBalancerClient,
+		newCertificatesManagementClient,
 		NewWorkRequestsWatcher,
 		NewNetworkLoadBalancerWorkRequestsWatcher,
 		func(c loadbalancer.LoadBalancerClient) workRequestsClient { return c },


### PR DESCRIPTION
## Adds Gateway API `BackendTLSPolicy` support.

Adds Gateway API BackendTLSPolicy support for configuring TLS from the OCI Load Balancer to backend services. This allows routes to terminate TLS at the listener while using TLS again for selected backend sets, including CA bundle configuration from Kubernetes ConfigMap references.

The controller reconciles backend TLS settings onto OCI backend sets, validates unsupported policy shapes, and cleans up OCI CA bundle resources when policies are removed.

### `BackendTLSPolicy` to existing TLS-enabled Service

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: BackendTLSPolicy
metadata:
  name: nebula-backend-tls
  namespace: nebula
spec:
  targetRefs:
    - group: ""
      kind: Service
      name: nebula
  validation:
    hostname: nebula.nebula.svc.cluster.local
    caCertificateRefs:
      - group: ""
        kind: ConfigMap
        name: nebula-ca-bundle
```

### TLS certificate needed by `BackendTLSPolicy`

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: nebula-ca-bundle
  namespace: nebula
data:
  ca.crt: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
```

### Listener that routes to TLS enabled backend 
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: nebula-api
  namespace: nebula
spec:
  parentRefs:
    - name: nebula-l7
      sectionName: https
  hostnames:
    - api.example.com
  rules:
    - backendRefs:
        - name: nebula
          port: 8443
```

This policy applies backend TLS to routes that target the nebula Service. The referenced CA bundle is uploaded to OCI and used by the backend set TLS configuration.