### PR TITLE
Adds support for configuring TLS cipher suites and protocol versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ Other patterns will result in an error.
 
 Please refer to [https](./docs/https.md) for more details.
 
+Gateway listener TLS options can configure OCI Load Balancer frontend cipher suites and TLS protocol versions. Set `oci.oraclecloud.com/cipher-suite-name` and `oci.oraclecloud.com/tls-protocols` under `Gateway.spec.listeners[].tls.options`; when omitted, OCI uses its listener defaults. See [deploy/manifests/examples/gateway-https-tls-options.yaml](./deploy/manifests/examples/gateway-https-tls-options.yaml) for an example.
+
+OCI documents supported predefined cipher suite names in [Predefined Load Balancer Cipher Suites](https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingciphersuites_topic-Predefined_Cipher_Suites.htm). OCI SSL configuration accepts `TLSv1`, `TLSv1.1`, `TLSv1.2`, and `TLSv1.3`; see the OCI Load Balancer [`SSLConfiguration`](https://docs.oracle.com/en-us/iaas/tools/python/latest/api/load_balancer/models/oci.load_balancer.models.SSLConfiguration.html) documentation for protocol values and defaults.
+
 ## GRPCRoute With OCI Load Balancer
 
 `GRPCRoute` uses the standard Gateway API CRDs and is reconciled on OCI Load Balancer with the other layer 7 routes. It is not implemented on OCI Network Load Balancer. Use `TCPRoute` if you only need gRPC passthrough to pods.

--- a/deploy/manifests/examples/gateway-https-tls-options.yaml
+++ b/deploy/manifests/examples/gateway-https-tls-options.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: oke-gateway
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - name: oke-gw-example-https-cert
+        options:
+          # OCI Load Balancer predefined or custom SSL cipher suite name.
+          oci.oraclecloud.com/cipher-suite-name: oci-tls-12-13-ssl-cipher-suite-v3
+          # Comma-separated OCI Load Balancer TLS protocol list.
+          oci.oraclecloud.com/tls-protocols: TLSv1.2,TLSv1.3

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -22,6 +22,12 @@ const (
 	// ListenerTLSOptionOCICertificateOCID configures an existing OCI Certificates Service certificate for a listener.
 	ListenerTLSOptionOCICertificateOCID = "oci.oraclecloud.com/certificate-ocid"
 
+	// ListenerTLSOptionProtocols configures OCI listener SSL protocols as a comma-separated list.
+	ListenerTLSOptionProtocols = "oci.oraclecloud.com/tls-protocols"
+
+	// ListenerTLSOptionCipherSuiteName configures OCI listener SSL cipher suite name.
+	ListenerTLSOptionCipherSuiteName = "oci.oraclecloud.com/cipher-suite-name"
+
 	// BackendTLSPolicyProgrammedFinalizer is used to clean up controller-managed OCI CA bundles.
 	BackendTLSPolicyProgrammedFinalizer = "oke-gateway-api.gemyago.github.io/backend-tls-policy-programmed"
 

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -252,6 +252,26 @@ func loadBalancerSSLConfigurationsEqual(
 		stringSlicesEqual(current.TrustedCertificateAuthorityIds, desired.TrustedCertificateAuthorityIds)
 }
 
+func loadBalancerListenerSSLConfigurationsEqual(
+	current *loadbalancer.SslConfigurationDetails,
+	desired *loadbalancer.SslConfigurationDetails,
+) bool {
+	if current == nil || desired == nil {
+		return current == nil && desired == nil
+	}
+	if lo.FromPtr(current.CertificateName) != lo.FromPtr(desired.CertificateName) ||
+		!stringSlicesEqual(current.CertificateIds, desired.CertificateIds) {
+		return false
+	}
+	if desired.CipherSuiteName != nil && lo.FromPtr(current.CipherSuiteName) != lo.FromPtr(desired.CipherSuiteName) {
+		return false
+	}
+	if len(desired.Protocols) > 0 && !stringSlicesEqual(current.Protocols, desired.Protocols) {
+		return false
+	}
+	return true
+}
+
 func stringSlicesEqual(left []string, right []string) bool {
 	left = append([]string(nil), left...)
 	right = append([]string(nil), right...)
@@ -823,6 +843,7 @@ func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
 		sslConfig = &loadbalancer.SslConfigurationDetails{
 			CertificateIds: []string{params.listenerCertificateID},
 		}
+		applyListenerTLSOptions(sslConfig, params.listenerSpec.TLS)
 	} else if params.listenerSpec.TLS != nil {
 		if len(params.listenerCertificates) == 0 {
 			return &resourceStatusError{
@@ -840,6 +861,7 @@ func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
 		sslConfig = &loadbalancer.SslConfigurationDetails{
 			CertificateName: cert.CertificateName,
 		}
+		applyListenerTLSOptions(sslConfig, params.listenerSpec.TLS)
 	}
 
 	if existingListener, ok := params.knownListeners[listenerName]; ok {
@@ -1744,26 +1766,10 @@ func makeOciListenerUpdateDetails(
 		hasChanges = true
 	}
 
-	existingCertName := ""
-	if params.existingListenerData.SslConfiguration != nil &&
-		params.existingListenerData.SslConfiguration.CertificateName != nil {
-		existingCertName = *params.existingListenerData.SslConfiguration.CertificateName
-	}
-	existingCertIDs := normalizeCertificateIDs(nil)
-	if params.existingListenerData.SslConfiguration != nil {
-		existingCertIDs = normalizeCertificateIDs(params.existingListenerData.SslConfiguration.CertificateIds)
-	}
-
-	newCertName := ""
-	if params.sslConfig != nil && params.sslConfig.CertificateName != nil {
-		newCertName = *params.sslConfig.CertificateName
-	}
-	newCertIDs := normalizeCertificateIDs(nil)
-	if params.sslConfig != nil {
-		newCertIDs = normalizeCertificateIDs(params.sslConfig.CertificateIds)
-	}
-
-	if existingCertName != newCertName || !slices.Equal(existingCertIDs, newCertIDs) {
+	if !loadBalancerListenerSSLConfigurationsEqual(
+		sslConfigurationDetailsFromBackendSet(params.existingListenerData.SslConfiguration),
+		params.sslConfig,
+	) {
 		hasChanges = true
 	}
 
@@ -1787,11 +1793,20 @@ func expectedHTTPListenerProtocol(existingListener loadbalancer.Listener) string
 	return ociListenerProtocolHTTP
 }
 
-func normalizeCertificateIDs(certificateIDs []string) []string {
-	if len(certificateIDs) == 0 {
-		return nil
+func applyListenerTLSOptions(
+	sslConfig *loadbalancer.SslConfigurationDetails,
+	tlsConfig *gatewayv1.ListenerTLSConfig,
+) {
+	if sslConfig == nil || tlsConfig == nil {
+		return
 	}
-	return certificateIDs
+	if protocols := splitCSVOption(tlsConfig.Options[ListenerTLSOptionProtocols]); len(protocols) > 0 {
+		sslConfig.Protocols = protocols
+	}
+	cipherSuite := strings.TrimSpace(string(tlsConfig.Options[ListenerTLSOptionCipherSuiteName]))
+	if cipherSuite != "" {
+		sslConfig.CipherSuiteName = &cipherSuite
+	}
 }
 
 type ociLoadBalancerModelDeps struct {

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -1049,8 +1049,15 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
+			cipherSuiteName := "oci-tls-12-13-ssl-cipher-suite-v3"
 			gwListener := makeRandomListener(
 				randomListenerWithHTTPSParamsOpt(),
+				func(listener *gatewayv1.Listener) {
+					listener.TLS.Options = map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+						ListenerTLSOptionCipherSuiteName: gatewayv1.AnnotationValue(cipherSuiteName),
+						ListenerTLSOptionProtocols:       "TLSv1.2,TLSv1.3",
+					}
+				},
 			)
 			lbListener := makeRandomOCIListener(
 				func(l *loadbalancer.Listener) {
@@ -1097,6 +1104,8 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					RoutingPolicyName:     new(routingPolicyName),
 					SslConfiguration: &loadbalancer.SslConfigurationDetails{
 						CertificateName: ociListenerCert.CertificateName,
+						CipherSuiteName: &cipherSuiteName,
+						Protocols:       []string{"TLSv1.2", "TLSv1.3"},
 					},
 				},
 			}).Return(loadbalancer.UpdateListenerResponse{
@@ -1215,8 +1224,15 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
+			cipherSuiteName := "oci-tls-13-ssl-cipher-suite-v3"
 			gwListener := makeRandomListener(
 				randomListenerWithHTTPSParamsOpt(),
+				func(listener *gatewayv1.Listener) {
+					listener.TLS.Options = map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+						ListenerTLSOptionCipherSuiteName: gatewayv1.AnnotationValue(cipherSuiteName),
+						ListenerTLSOptionProtocols:       "TLSv1.3",
+					}
+				},
 			)
 
 			ociListenerCert := makeRandomOCICertificate()
@@ -1280,6 +1296,8 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					RoutingPolicyName:     new(routingPolicyName),
 					SslConfiguration: &loadbalancer.SslConfigurationDetails{
 						CertificateName: ociListenerCert.CertificateName,
+						CipherSuiteName: &cipherSuiteName,
+						Protocols:       []string{"TLSv1.3"},
 					},
 				},
 			}).Return(loadbalancer.CreateListenerResponse{
@@ -5150,8 +5168,11 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 
 	makeSslConfigFromDetails := func(details *loadbalancer.SslConfigurationDetails) *loadbalancer.SslConfiguration {
 		return &loadbalancer.SslConfiguration{
-			CertificateName: details.CertificateName,
-			CertificateIds:  details.CertificateIds,
+			CertificateName:      details.CertificateName,
+			CertificateIds:       details.CertificateIds,
+			CipherSuiteName:      details.CipherSuiteName,
+			Protocols:            details.Protocols,
+			HasSessionResumption: details.HasSessionResumption,
 		}
 	}
 
@@ -5235,6 +5256,126 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
 				},
 				wantOk: true,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+			certName := fake.UUID().V4()
+			oldCipherSuite := "oci-default-ssl-cipher-suite-v1"
+			newCipherSuite := "oci-tls-12-13-ssl-cipher-suite-v3"
+			oldSslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateName: &certName,
+				CipherSuiteName: &oldCipherSuite,
+				Protocols:       []string{"TLSv1.2"},
+			}
+			newSslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateName: &certName,
+				CipherSuiteName: &newCipherSuite,
+				Protocols:       []string{"TLSv1.2", "TLSv1.3"},
+			}
+
+			return testCase{
+				name: "ssl config cipher suite and protocols change",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+						SslConfiguration:      makeSslConfigFromDetails(oldSslConfig),
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+					sslConfig:             newSslConfig,
+				},
+				want: loadbalancer.UpdateListenerDetails{
+					Protocol:              new("HTTP"),
+					Port:                  new(int(listenerSpec.Port)),
+					DefaultBackendSetName: new(defaultBackendSetName),
+					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+					SslConfiguration:      newSslConfig,
+				},
+				wantOk: true,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+			certName := fake.UUID().V4()
+			cipherSuite := "oci-tls-12-13-ssl-cipher-suite-v3"
+			sslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateName: &certName,
+				CipherSuiteName: &cipherSuite,
+				Protocols:       []string{"TLSv1.3", "TLSv1.2"},
+			}
+
+			return testCase{
+				name: "ssl config protocols match regardless of order",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+						SslConfiguration: &loadbalancer.SslConfiguration{
+							CertificateName: &certName,
+							CipherSuiteName: &cipherSuite,
+							Protocols:       []string{"TLSv1.2", "TLSv1.3"},
+						},
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+					sslConfig:             sslConfig,
+				},
+				want:   loadbalancer.UpdateListenerDetails{},
+				wantOk: false,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+			certName := fake.UUID().V4()
+			cipherSuite := "oci-default-ssl-cipher-suite-v1"
+			sslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateName: &certName,
+			}
+
+			return testCase{
+				name: "ssl config ignores OCI default cipher suite and protocols when desired options are absent",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+						SslConfiguration: &loadbalancer.SslConfiguration{
+							CertificateName: &certName,
+							CipherSuiteName: &cipherSuite,
+							Protocols:       []string{"TLSv1.2"},
+						},
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+					sslConfig:             sslConfig,
+				},
+				want:   loadbalancer.UpdateListenerDetails{},
+				wantOk: false,
 			}
 		},
 		func() testCase {
@@ -5505,6 +5646,49 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 				wantOk: false,
 			}
 		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+			certName := fake.UUID().V4()
+			cipherSuite := "oci-tls-12-13-ssl-cipher-suite-v3"
+			verifyDepth := 1
+			verifyPeerCertificate := false
+			sslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateName: &certName,
+				CipherSuiteName: &cipherSuite,
+				Protocols:       []string{"TLSv1.2", "TLSv1.3"},
+			}
+
+			return testCase{
+				name: "ssl config ignores OCI listener default fields",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+						SslConfiguration: &loadbalancer.SslConfiguration{
+							CertificateName:       &certName,
+							CipherSuiteName:       &cipherSuite,
+							Protocols:             []string{"TLSv1.2", "TLSv1.3"},
+							ServerOrderPreference: loadbalancer.SslConfigurationServerOrderPreferenceEnabled,
+							VerifyDepth:           &verifyDepth,
+							VerifyPeerCertificate: &verifyPeerCertificate,
+						},
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+					sslConfig:             sslConfig,
+				},
+				want:   loadbalancer.UpdateListenerDetails{},
+				wantOk: false,
+			}
+		},
 	}
 
 	for _, tc := range tests {
@@ -5515,4 +5699,44 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 			assert.Equal(t, tc.wantOk, gotOk)
 		})
 	}
+}
+
+func Test_applyListenerTLSOptions(t *testing.T) {
+	t.Run("does nothing without ssl config", func(_ *testing.T) {
+		applyListenerTLSOptions(nil, &gatewayv1.ListenerTLSConfig{
+			Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				ListenerTLSOptionProtocols: "TLSv1.3",
+			},
+		})
+	})
+
+	t.Run("keeps OCI defaults when options are absent", func(t *testing.T) {
+		certName := faker.New().UUID().V4()
+		sslConfig := &loadbalancer.SslConfigurationDetails{CertificateName: &certName}
+
+		applyListenerTLSOptions(sslConfig, nil)
+		applyListenerTLSOptions(sslConfig, &gatewayv1.ListenerTLSConfig{})
+
+		assert.Equal(t, certName, lo.FromPtr(sslConfig.CertificateName))
+		assert.Empty(t, sslConfig.Protocols)
+		assert.Nil(t, sslConfig.CipherSuiteName)
+	})
+
+	t.Run("applies cipher suite and TLS protocols", func(t *testing.T) {
+		fake := faker.New()
+		certName := fake.UUID().V4()
+		cipherSuiteName := "oci-tls-12-13-ssl-cipher-suite-v3"
+		sslConfig := &loadbalancer.SslConfigurationDetails{CertificateName: &certName}
+
+		applyListenerTLSOptions(sslConfig, &gatewayv1.ListenerTLSConfig{
+			Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				ListenerTLSOptionCipherSuiteName: gatewayv1.AnnotationValue(" " + cipherSuiteName + " "),
+				ListenerTLSOptionProtocols:       " TLSv1.2, TLSv1.3 ",
+			},
+		})
+
+		assert.Equal(t, certName, lo.FromPtr(sslConfig.CertificateName))
+		assert.Equal(t, cipherSuiteName, lo.FromPtr(sslConfig.CipherSuiteName))
+		assert.Equal(t, []string{"TLSv1.2", "TLSv1.3"}, sslConfig.Protocols)
+	})
 }

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -923,7 +923,9 @@ func (m *tlsRouteModelImpl) tlsListenerSSLConfig(
 ) (*loadbalancer.SslConfigurationDetails, error) {
 	listenerName := string(details.matchedListener.Name)
 	if certificateID := certificates.certificateIDsByListener[listenerName]; certificateID != "" {
-		return &loadbalancer.SslConfigurationDetails{CertificateIds: []string{certificateID}}, nil
+		sslConfig := &loadbalancer.SslConfigurationDetails{CertificateIds: []string{certificateID}}
+		applyListenerTLSOptions(sslConfig, details.matchedListener.TLS)
+		return sslConfig, nil
 	}
 	listenerCertificates := certificates.certificatesByListener[listenerName]
 	if len(listenerCertificates) == 0 {
@@ -935,7 +937,9 @@ func (m *tlsRouteModelImpl) tlsListenerSSLConfig(
 			),
 		)
 	}
-	return &loadbalancer.SslConfigurationDetails{CertificateName: listenerCertificates[0].CertificateName}, nil
+	sslConfig := &loadbalancer.SslConfigurationDetails{CertificateName: listenerCertificates[0].CertificateName}
+	applyListenerTLSOptions(sslConfig, details.matchedListener.TLS)
+	return sslConfig, nil
 }
 
 func (m *tlsRouteModelImpl) reconcileLoadBalancerTLSListener(
@@ -1012,21 +1016,10 @@ func makeOciTLSListenerUpdateDetails(
 	if lo.FromPtr(existingListener.RoutingPolicyName) != "" {
 		hasChanges = true
 	}
-	existingCertName := ""
-	existingCertIDs := normalizeCertificateIDs(nil)
-	if existingListener.SslConfiguration != nil {
-		existingCertName = lo.FromPtr(existingListener.SslConfiguration.CertificateName)
-		existingCertIDs = normalizeCertificateIDs(existingListener.SslConfiguration.CertificateIds)
-	}
-	newCertName := ""
-	newCertIDs := normalizeCertificateIDs(nil)
-	if sslConfig != nil {
-		newCertName = lo.FromPtr(sslConfig.CertificateName)
-		newCertIDs = normalizeCertificateIDs(sslConfig.CertificateIds)
-	}
-	if existingCertName != newCertName || !lo.EveryBy(newCertIDs, func(certID string) bool {
-		return lo.Contains(existingCertIDs, certID)
-	}) || len(existingCertIDs) != len(newCertIDs) {
+	if !loadBalancerListenerSSLConfigurationsEqual(
+		sslConfigurationDetailsFromBackendSet(existingListener.SslConfiguration),
+		sslConfig,
+	) {
 		hasChanges = true
 	}
 	if !hasChanges {

--- a/internal/app/tlsroute_model_test.go
+++ b/internal/app/tlsroute_model_test.go
@@ -988,6 +988,34 @@ func TestTLSRouteModelLoadBalancerListener(t *testing.T) {
 	}
 	sslConfig := &loadbalancer.SslConfigurationDetails{CertificateIds: []string{"ocid1.certificate.oc1..cert"}}
 
+	t.Run("builds ssl config with listener TLS options", func(t *testing.T) {
+		cipherSuiteName := "oci-tls-12-13-ssl-cipher-suite-v3"
+		model := newTLSRouteModel(tlsRouteModelDeps{RootLogger: diag.RootTestLogger()})
+		listenerWithOptions := listener
+		listenerWithOptions.TLS = &gatewayv1.ListenerTLSConfig{
+			Mode: &mode,
+			Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				ListenerTLSOptionCipherSuiteName: gatewayv1.AnnotationValue(cipherSuiteName),
+				ListenerTLSOptionProtocols:       "TLSv1.2,TLSv1.3",
+			},
+		}
+
+		got, err := model.tlsListenerSSLConfig(
+			resolvedTLSRouteDetails{matchedListener: listenerWithOptions},
+			reconcileListenersCertificatesResult{
+				certificateIDsByListener: map[string]string{
+					"rtmps": "ocid1.certificate.oc1..cert",
+				},
+			},
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []string{"ocid1.certificate.oc1..cert"}, got.CertificateIds)
+		assert.Equal(t, cipherSuiteName, lo.FromPtr(got.CipherSuiteName))
+		assert.Equal(t, []string{"TLSv1.2", "TLSv1.3"}, got.Protocols)
+	})
+
 	t.Run("updates changed listener", func(t *testing.T) {
 		ociClient := NewMockociLoadBalancerClient(t)
 		watcher := NewMockworkRequestsWatcher(t)
@@ -1018,12 +1046,33 @@ func TestTLSRouteModelLoadBalancerListener(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("skips matching listener", func(t *testing.T) {
+	t.Run("updates changed listener ssl cipher suite and protocols", func(t *testing.T) {
 		ociClient := NewMockociLoadBalancerClient(t)
+		watcher := NewMockworkRequestsWatcher(t)
 		model := newTLSRouteModel(tlsRouteModelDeps{
-			RootLogger:         diag.RootTestLogger(),
-			OciLoadBalancerAPI: ociClient,
+			RootLogger:          diag.RootTestLogger(),
+			OciLoadBalancerAPI:  ociClient,
+			WorkRequestsWatcher: watcher,
 		})
+		oldCipherSuiteName := "oci-default-ssl-cipher-suite-v1"
+		newCipherSuiteName := "oci-tls-12-13-ssl-cipher-suite-v3"
+		desiredSSLConfig := &loadbalancer.SslConfigurationDetails{
+			CertificateIds:  []string{"ocid1.certificate.oc1..cert"},
+			CipherSuiteName: &newCipherSuiteName,
+			Protocols:       []string{"TLSv1.2", "TLSv1.3"},
+		}
+		workRequestID := "wr-update-listener-ssl"
+		ociClient.EXPECT().
+			UpdateListener(t.Context(), mock.MatchedBy(func(request loadbalancer.UpdateListenerRequest) bool {
+				requestSSLConfig := request.UpdateListenerDetails.SslConfiguration
+				return lo.FromPtr(request.LoadBalancerId) == "lb-id" &&
+					lo.FromPtr(request.ListenerName) == "rtmps" &&
+					requestSSLConfig != nil &&
+					lo.FromPtr(requestSSLConfig.CipherSuiteName) == newCipherSuiteName &&
+					stringSlicesEqual(requestSSLConfig.Protocols, []string{"TLSv1.2", "TLSv1.3"})
+			})).
+			Return(loadbalancer.UpdateListenerResponse{OpcWorkRequestId: &workRequestID}, nil)
+		watcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil)
 
 		err := model.reconcileLoadBalancerTLSListener(t.Context(), "lb-id", "bs", loadbalancer.Listener{
 			Name:                  new("rtmps"),
@@ -1031,9 +1080,70 @@ func TestTLSRouteModelLoadBalancerListener(t *testing.T) {
 			Port:                  new(443),
 			DefaultBackendSetName: new("bs"),
 			SslConfiguration: &loadbalancer.SslConfiguration{
-				CertificateIds: []string{"ocid1.certificate.oc1..cert"},
+				CertificateIds:  []string{"ocid1.certificate.oc1..cert"},
+				CipherSuiteName: &oldCipherSuiteName,
+				Protocols:       []string{"TLSv1.2"},
 			},
-		}, listener, sslConfig)
+		}, listener, desiredSSLConfig)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("skips matching listener", func(t *testing.T) {
+		ociClient := NewMockociLoadBalancerClient(t)
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger:         diag.RootTestLogger(),
+			OciLoadBalancerAPI: ociClient,
+		})
+		cipherSuite := "oci-tls-12-13-ssl-cipher-suite-v3"
+		verifyDepth := 1
+		verifyPeerCertificate := false
+		desiredSSLConfig := &loadbalancer.SslConfigurationDetails{
+			CertificateIds:  []string{"ocid1.certificate.oc1..cert"},
+			CipherSuiteName: &cipherSuite,
+			Protocols:       []string{"TLSv1.2", "TLSv1.3"},
+		}
+
+		err := model.reconcileLoadBalancerTLSListener(t.Context(), "lb-id", "bs", loadbalancer.Listener{
+			Name:                  new("rtmps"),
+			Protocol:              new(tlsRouteLoadBalancerProtocol),
+			Port:                  new(443),
+			DefaultBackendSetName: new("bs"),
+			SslConfiguration: &loadbalancer.SslConfiguration{
+				CertificateIds:        []string{"ocid1.certificate.oc1..cert"},
+				CipherSuiteName:       &cipherSuite,
+				Protocols:             []string{"TLSv1.2", "TLSv1.3"},
+				ServerOrderPreference: loadbalancer.SslConfigurationServerOrderPreferenceEnabled,
+				VerifyDepth:           &verifyDepth,
+				VerifyPeerCertificate: &verifyPeerCertificate,
+			},
+		}, listener, desiredSSLConfig)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("skips matching listener with OCI default cipher suite and protocols", func(t *testing.T) {
+		ociClient := NewMockociLoadBalancerClient(t)
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger:         diag.RootTestLogger(),
+			OciLoadBalancerAPI: ociClient,
+		})
+		cipherSuite := "oci-default-ssl-cipher-suite-v1"
+		desiredSSLConfig := &loadbalancer.SslConfigurationDetails{
+			CertificateIds: []string{"ocid1.certificate.oc1..cert"},
+		}
+
+		err := model.reconcileLoadBalancerTLSListener(t.Context(), "lb-id", "bs", loadbalancer.Listener{
+			Name:                  new("rtmps"),
+			Protocol:              new(tlsRouteLoadBalancerProtocol),
+			Port:                  new(443),
+			DefaultBackendSetName: new("bs"),
+			SslConfiguration: &loadbalancer.SslConfiguration{
+				CertificateIds:  []string{"ocid1.certificate.oc1..cert"},
+				CipherSuiteName: &cipherSuite,
+				Protocols:       []string{"TLSv1.2"},
+			},
+		}, listener, desiredSSLConfig)
 
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
## Summary

Adds support for configuring OCI Load Balancer frontend TLS cipher suites and TLS protocol versions through standard Gateway API listener TLS options.

This uses `Gateway.spec.listeners[].tls.options` rather than adding custom CRD fields. The controller now applies these options when reconciling OCI Load Balancer HTTPS listeners and terminating TLSRoute listeners.

Closes #71.

### Example
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: example-gateway
  namespace: example
spec:
  gatewayClassName: oke-alb
  infrastructure:
    parametersRef:
      group: oke-gateway-api.gemyago.github.io
      kind: GatewayConfig
      name: example-gateway-config
  listeners:
    - name: https
      port: 443
      protocol: HTTPS
      tls:
        mode: Terminate
        certificateRefs:
          - kind: Secret
            name: example-tls
        options:
          oci.oraclecloud.com/cipher-suite-name: oci-tls-12-13-ssl-cipher-suite-v3
          oci.oraclecloud.com/tls-protocols: TLSv1.2,TLSv1.3
```

### Notes
- oci.oraclecloud.com/cipher-suite-name maps to OCI Load Balancer cipherSuiteName.
- oci.oraclecloud.com/tls-protocols maps to OCI Load Balancer protocols.
- When these options are omitted, OCI listener defaults remain unchanged.
- Existing listeners are updated when the configured cipher suite or protocol list changes.
- OCI-populated SSL defaults such as verifyDepth, verifyPeerCertificate, and serverOrderPreference are ignored during frontend listener drift comparison to avoid unnecessary repeated updates.
