### PR TITLE
Adds Gateway API ListenerSet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ update their status, or provision OCI resources for them.
 | `UDPRoute` | Supported on OCI Network Load Balancer |
 | `ReferenceGrant` | Supported for cross-namespace references used by supported routes and policies |
 | `BackendTLSPolicy` | Supported for OCI Load Balancer backend TLS; OCI Network Load Balancer uses passthrough routing instead |
-| `ListenerSet` | Not supported; ignored if installed |
+| `ListenerSet` | Supported for adding Gateway listeners across namespaces |
 | `XBackend`, `XBackendTrafficPolicy`, `XMesh` | Not supported; ignored if installed |
 
 ## Getting Started
@@ -35,7 +35,7 @@ kubectl apply --server-side=true \
   -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/standard-install.yaml
 ```
 The controller can run with only the standard CRDs. `HTTPRoute`, `GRPCRoute`, `TLSRoute`,
-`TCPRoute`, `UDPRoute`, and `BackendTLSPolicy` are standard in Gateway API v1.6.0.
+`TCPRoute`, `UDPRoute`, `BackendTLSPolicy`, and `ListenerSet` are standard in Gateway API v1.6.0.
 
 Prepare API key and config file (use actual values):
 ```ini
@@ -234,6 +234,14 @@ OCI documents supported predefined cipher suite names in [Predefined Load Balanc
 The controller supports gRPC host, service, method, and exact header matching. `HTTPRoute` and `GRPCRoute` can share the same HTTPS listener and hostname; `GRPCRoute` rules require a native gRPC `content-type` and are ordered before broad `HTTPRoute` matches.
 
 See [deploy/manifests/examples/grpcroute.yaml](./deploy/manifests/examples/grpcroute.yaml) for a minimal route example.
+
+## ListenerSet
+
+`ListenerSet` attaches additional listeners to an existing `Gateway`. ListenerSet listeners are reconciled with the Gateway's listeners on the same OCI Load Balancer or OCI Network Load Balancer, and route `parentRefs` may target the ListenerSet by name and `sectionName`.
+
+Use ListenerSet when separate namespaces need to contribute listeners to a shared Gateway. The parent Gateway must opt in with `spec.allowedListeners`; generated OCI listener names for ListenerSet listeners are stable and may differ from Kubernetes listener names. Cross-namespace certificate references still require a `ReferenceGrant`.
+
+See [deploy/manifests/examples/listenerset-alb.yaml](./deploy/manifests/examples/listenerset-alb.yaml) for OCI Load Balancer HTTP usage, [deploy/manifests/examples/listenerset-nlb.yaml](./deploy/manifests/examples/listenerset-nlb.yaml) for OCI Network Load Balancer TCP/UDP usage, [deploy/manifests/examples/listenerset-https-secret.yaml](./deploy/manifests/examples/listenerset-https-secret.yaml) and [deploy/manifests/examples/listenerset-https-oci-certificate.yaml](./deploy/manifests/examples/listenerset-https-oci-certificate.yaml) for HTTPS certificates, [deploy/manifests/examples/listenerset-tlsroute-alb.yaml](./deploy/manifests/examples/listenerset-tlsroute-alb.yaml) and [deploy/manifests/examples/listenerset-tlsroute-nlb.yaml](./deploy/manifests/examples/listenerset-tlsroute-nlb.yaml) for TLSRoute, and [deploy/manifests/examples/listenerset-cross-namespace-certificate.yaml](./deploy/manifests/examples/listenerset-cross-namespace-certificate.yaml) plus [deploy/manifests/examples/listenerset-namespace-selector.yaml](./deploy/manifests/examples/listenerset-namespace-selector.yaml) for cross-namespace attachment patterns.
 
 ## Backend TLS
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ update their status, or provision OCI resources for them.
 | `UDPRoute` | Supported on OCI Network Load Balancer |
 | `ReferenceGrant` | Supported for cross-namespace references used by supported routes and policies |
 | `BackendTLSPolicy` | Supported for OCI Load Balancer backend TLS; OCI Network Load Balancer uses passthrough routing instead |
-| `ListenerSet` | Supported for adding Gateway listeners across namespaces |
+| `ListenerSet` | Supported on OCI Load Balancer and OCI Network Load Balancer |
 | `XBackend`, `XBackendTrafficPolicy`, `XMesh` | Not supported; ignored if installed |
 
 ## Getting Started

--- a/cmd/controller/start_test.go
+++ b/cmd/controller/start_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/services"
+)
+
+func TestStartServer(t *testing.T) {
+	t.Run("returns shutdown errors in noop mode", func(t *testing.T) {
+		shutdownHooks := services.NewTestShutdownHooks()
+		wantErr := errors.New("shutdown failed")
+		shutdownHooks.Register("failing-hook", func(context.Context) error {
+			return wantErr
+		})
+
+		err := startServer(startServerParams{
+			ShutdownHooks: shutdownHooks,
+			RootLogger:    diag.RootTestLogger(),
+			noop:          true,
+		})
+
+		require.ErrorIs(t, err, wantErr)
+	})
+}

--- a/cmd/server/start_test.go
+++ b/cmd/server/start_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/services"
+)
+
+func TestStartServer(t *testing.T) {
+	t.Run("returns shutdown errors in noop mode", func(t *testing.T) {
+		shutdownHooks := services.NewTestShutdownHooks()
+		wantErr := errors.New("shutdown failed")
+		shutdownHooks.Register("failing-hook", func(context.Context) error {
+			return wantErr
+		})
+
+		err := startServer(startServerParams{
+			ShutdownHooks: shutdownHooks,
+			RootLogger:    diag.RootTestLogger(),
+			noop:          true,
+		})
+
+		require.ErrorIs(t, err, wantErr)
+	})
+}

--- a/deploy/helm/controller/templates/clusterrole.yaml
+++ b/deploy/helm/controller/templates/clusterrole.yaml
@@ -8,10 +8,10 @@ metadata:
 rules:
 # Permissions to watch and update Gateway API resources
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["gatewayclasses", "gateways", "httproutes", "grpcroutes", "tcproutes", "udproutes", "tlsroutes", "backendtlspolicies", "referencegrants"]
+  resources: ["gatewayclasses", "gateways", "httproutes", "grpcroutes", "tcproutes", "udproutes", "tlsroutes", "backendtlspolicies", "listenersets", "referencegrants"]
   verbs: ["get", "list", "watch", "update", "patch"] # Read access + update/patch for finalizers/annotations
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "tcproutes/status", "udproutes/status", "tlsroutes/status", "backendtlspolicies/status"]
+  resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "tcproutes/status", "udproutes/status", "tlsroutes/status", "backendtlspolicies/status", "listenersets/status"]
   verbs: ["update", "patch"] # Update status
 # Permissions to read necessary core resources for OCI LB configuration
 - apiGroups: [""]

--- a/deploy/manifests/examples/listenerset-alb.yaml
+++ b/deploy/manifests/examples/listenerset-alb.yaml
@@ -1,0 +1,48 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: oke-gateway
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: oke-gateway-extra-http
+spec:
+  parentRef:
+    name: oke-gateway
+  listeners:
+    - name: api
+      protocol: HTTP
+      port: 8080
+      hostname: api.example.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: listener-set-api
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: oke-gateway-extra-http
+      sectionName: api
+  hostnames:
+    - api.example.com
+  rules:
+    - backendRefs:
+        - name: oke-gateway-example-server
+          port: 8080

--- a/deploy/manifests/examples/listenerset-cross-namespace-certificate.yaml
+++ b/deploy/manifests/examples/listenerset-cross-namespace-certificate.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-team
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-team
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-tls
+  namespace: cert-team
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    REPLACE_WITH_FRONTEND_CERTIFICATE_PEM
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    REPLACE_WITH_FRONTEND_PRIVATE_KEY_PEM
+    -----END PRIVATE KEY-----
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-listenerset-api-tls
+  namespace: cert-team
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      namespace: app-team
+  to:
+    - group: ""
+      kind: Secret
+      name: api-tls
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: app-https
+  namespace: app-team
+spec:
+  parentRef:
+    namespace: infra
+    name: shared-alb
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: app.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: api-tls
+            namespace: cert-team

--- a/deploy/manifests/examples/listenerset-https-oci-certificate.yaml
+++ b/deploy/manifests/examples/listenerset-https-oci-certificate.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: shared-alb
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: api-https-oci-cert
+spec:
+  parentRef:
+    name: shared-alb
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: api.example.com
+      tls:
+        mode: Terminate
+        options:
+          oci.oraclecloud.com/certificate-ocid: ocid1.certificate.oc1..exampleuniqueID
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: api-https-oci-cert
+      sectionName: https
+  hostnames:
+    - api.example.com
+  rules:
+    - backendRefs:
+        - name: oke-gateway-example-server
+          port: 8080

--- a/deploy/manifests/examples/listenerset-https-secret.yaml
+++ b/deploy/manifests/examples/listenerset-https-secret.yaml
@@ -1,0 +1,67 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: shared-alb
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-tls
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    REPLACE_WITH_FRONTEND_CERTIFICATE_PEM
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    REPLACE_WITH_FRONTEND_PRIVATE_KEY_PEM
+    -----END PRIVATE KEY-----
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: api-https
+spec:
+  parentRef:
+    name: shared-alb
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: api.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: api-tls
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: api-https
+      sectionName: https
+  hostnames:
+    - api.example.com
+  rules:
+    - backendRefs:
+        - name: oke-gateway-example-server
+          port: 8080

--- a/deploy/manifests/examples/listenerset-namespace-selector.yaml
+++ b/deploy/manifests/examples/listenerset-namespace-selector.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-team
+  labels:
+    gateway-listeners: allowed
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: shared-alb
+  namespace: infra
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Selector
+      selector:
+        matchLabels:
+          gateway-listeners: allowed
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: app-http
+  namespace: app-team
+spec:
+  parentRef:
+    namespace: infra
+    name: shared-alb
+  listeners:
+    - name: http-alt
+      protocol: HTTP
+      port: 8080
+      hostname: app.example.com

--- a/deploy/manifests/examples/listenerset-nlb.yaml
+++ b/deploy/manifests/examples/listenerset-nlb.yaml
@@ -1,0 +1,65 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: oke-nlb-gateway
+spec:
+  gatewayClassName: oke-nlb
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-nlb-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: health
+      protocol: TCP
+      port: 10256
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: oke-nlb-extra-listeners
+spec:
+  parentRef:
+    name: oke-nlb-gateway
+  listeners:
+    - name: coap-dtls
+      protocol: UDP
+      port: 5684
+    - name: rtmp
+      protocol: TCP
+      port: 1935
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: listener-set-coap-dtls
+  annotations:
+    oke-gateway-api.gemyago.github.io/nlb-udp-health-check-port: "10256"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: oke-nlb-extra-listeners
+      sectionName: coap-dtls
+  rules:
+    - backendRefs:
+        - name: coap-service
+          port: 5684
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: listener-set-rtmp
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: oke-nlb-extra-listeners
+      sectionName: rtmp
+  rules:
+    - backendRefs:
+        - name: rtmp-service
+          port: 1935

--- a/deploy/manifests/examples/listenerset-tlsroute-alb.yaml
+++ b/deploy/manifests/examples/listenerset-tlsroute-alb.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: shared-alb
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: rtmps-listener
+spec:
+  parentRef:
+    name: shared-alb
+  listeners:
+    - name: rtmps
+      protocol: TLS
+      port: 8443
+      hostname: rtmps.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: rtmps-cert
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: rtmps
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: rtmps-listener
+      sectionName: rtmps
+  hostnames:
+    - rtmps.example.com
+  rules:
+    - backendRefs:
+        - name: rtmp-service
+          port: 1935

--- a/deploy/manifests/examples/listenerset-tlsroute-nlb.yaml
+++ b/deploy/manifests/examples/listenerset-tlsroute-nlb.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: shared-nlb
+spec:
+  gatewayClassName: oke-nlb
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-nlb-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: rtmp
+      protocol: TCP
+      port: 1935
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: tls-passthrough-listener
+spec:
+  parentRef:
+    name: shared-nlb
+  listeners:
+    - name: tls
+      protocol: TLS
+      port: 443
+      hostname: passthrough.example.com
+      tls:
+        mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tls-passthrough
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: tls-passthrough-listener
+      sectionName: tls
+  hostnames:
+    - passthrough.example.com
+  rules:
+    - backendRefs:
+        - name: tls-service
+          port: 443

--- a/internal/api/http/server/server_test.go
+++ b/internal/api/http/server/server_test.go
@@ -79,6 +79,20 @@ func TestHTTPServer(t *testing.T) {
 			require.Error(t, err)
 			assert.ErrorIs(t, err, syscall.ECONNREFUSED)
 		})
+
+		t.Run("should return listen errors", func(t *testing.T) {
+			srv := NewHTTPServer(HTTPServerDeps{
+				RootLogger:    diag.RootTestLogger(),
+				Host:          "localhost",
+				Port:          -1,
+				ShutdownHooks: services.NewTestShutdownHooks(),
+				Handler:       http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+			})
+
+			err := srv.Start(t.Context())
+
+			require.ErrorContains(t, err, "failed to listen")
+		})
 	})
 }
 

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -60,6 +60,10 @@ const (
 	// The value is set by the controller when the http route is programmed.
 	HTTPRouteProgrammedPolicyRulesAnnotation = "oke-gateway-api.gemyago.github.io/http-route-programmed-lb-policy-rules"
 
+	// HTTPRouteProgrammedBackendSetsAnnotation is a comma-separated list of load balancer backend set names.
+	// The value is set by the controller when the http route is programmed.
+	HTTPRouteProgrammedBackendSetsAnnotation = "oke-gateway-api.gemyago.github.io/http-route-programmed-lb-backend-sets"
+
 	// L7RouteProgrammedLoadBalancerIDAnnotation tracks the OCI Load Balancer used by HTTPRoute and GRPCRoute.
 	L7RouteProgrammedLoadBalancerIDAnnotation = "oke-gateway-api.gemyago.github.io/l7-route-programmed-load-balancer-id"
 
@@ -74,6 +78,10 @@ const (
 	// GRPCRouteProgrammedPolicyRulesAnnotation is a comma-separated list of load balancer listener/policy rule names.
 	// The value is set by the controller when the grpc route is programmed.
 	GRPCRouteProgrammedPolicyRulesAnnotation = "oke-gateway-api.gemyago.github.io/grpc-route-programmed-lb-policy-rules"
+
+	// GRPCRouteProgrammedBackendSetsAnnotation is a comma-separated list of load balancer backend set names.
+	// The value is set by the controller when the grpc route is programmed.
+	GRPCRouteProgrammedBackendSetsAnnotation = "oke-gateway-api.gemyago.github.io/grpc-route-programmed-lb-backend-sets"
 
 	// GRPCRouteProgrammedFinalizer is the finalizer that indicates that the grpc route has been programmed.
 	// It is used to clean up resources when the grpc route is deleted.
@@ -140,11 +148,11 @@ const (
 
 	// HTTPRouteProgrammingRevisionValue is the value for the http route programming revision.
 	// Incremented when the controller programming steps are changed.
-	HTTPRouteProgrammingRevisionValue = "5"
+	HTTPRouteProgrammingRevisionValue = "6"
 
 	// GRPCRouteProgrammingRevisionValue is the value for the grpc route programming revision.
 	// Incremented when the controller programming steps are changed.
-	GRPCRouteProgrammingRevisionValue = "2"
+	GRPCRouteProgrammingRevisionValue = "3"
 )
 
 const ConfigRefGroup = "oke-gateway-api.gemyago.github.io"

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -98,6 +98,10 @@ const (
 	// NetworkLoadBalancerGatewayIDAnnotation stores the OCI NLB OCID programmed by the controller.
 	NetworkLoadBalancerGatewayIDAnnotation = "oke-gateway-api.gemyago.github.io/nlb-id"
 
+	// L4RouteProgrammedNetworkLoadBalancerIDAnnotation tracks the OCI Network Load Balancer used by L4 routes.
+	L4RouteProgrammedNetworkLoadBalancerIDAnnotation = "oke-gateway-api.gemyago.github.io/" +
+		"l4-route-programmed-network-load-balancer-id"
+
 	// NetworkLoadBalancerTCPRouteProgrammedFinalizer indicates a TCPRoute has programmed OCI NLB resources.
 	NetworkLoadBalancerTCPRouteProgrammedFinalizer = "oke-gateway-api.gemyago.github.io/nlb-tcproute-programmed"
 

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -60,6 +60,9 @@ const (
 	// The value is set by the controller when the http route is programmed.
 	HTTPRouteProgrammedPolicyRulesAnnotation = "oke-gateway-api.gemyago.github.io/http-route-programmed-lb-policy-rules"
 
+	// L7RouteProgrammedLoadBalancerIDAnnotation tracks the OCI Load Balancer used by HTTPRoute and GRPCRoute.
+	L7RouteProgrammedLoadBalancerIDAnnotation = "oke-gateway-api.gemyago.github.io/l7-route-programmed-load-balancer-id"
+
 	// HTTPRouteProgrammedFinalizer is the finalizer that indicates that the http route has been programmed.
 	// It is used to clean up the resources when the http route is deleted.
 	HTTPRouteProgrammedFinalizer = "oke-gateway-api.gemyago.github.io/http-route-programmed"

--- a/internal/app/gateway_controller.go
+++ b/internal/app/gateway_controller.go
@@ -45,6 +45,12 @@ func NewGatewayController(deps GatewayControllerDeps) *GatewayController {
 	}
 }
 
+func (r *GatewayController) SetListenerSetEnabled(enabled bool) {
+	if model, ok := r.gatewayModel.(interface{ setListenerSetEnabled(bool) }); ok {
+		model.setListenerSetEnabled(enabled)
+	}
+}
+
 func isGatewayAccepted(gateway *gatewayv1.Gateway) bool {
 	condition := meta.FindStatusCondition(
 		gateway.Status.Conditions,

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -45,6 +45,19 @@ func TestGatewayController(t *testing.T) {
 		})
 	}
 
+	t.Run("SetListenerSetEnabled", func(t *testing.T) {
+		model := &gatewayModelImpl{}
+		controller := NewGatewayController(GatewayControllerDeps{
+			RootLogger:     diag.RootTestLogger(),
+			ResourcesModel: NewMockresourcesModel(t),
+			GatewayModel:   model,
+		})
+
+		controller.SetListenerSetEnabled(true)
+
+		assert.True(t, model.listenerSetEnabled)
+	})
+
 	t.Run("Reconcile", func(t *testing.T) {
 		t.Run("acceptAndProgram", func(t *testing.T) {
 			gateway := newRandomGateway()
@@ -183,6 +196,47 @@ func TestGatewayController(t *testing.T) {
 			result, err := controller.Reconcile(t.Context(), req)
 
 			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("returns error when accepted condition update fails", func(t *testing.T) {
+			gateway := newRandomGateway()
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: gateway.Namespace,
+					Name:      gateway.Name,
+				},
+			}
+
+			deps := newMockDeps(t)
+			controller := NewGatewayController(deps)
+			wantErr := errors.New("accepted status failed")
+
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).
+				Once()
+			mockResourcesModel.EXPECT().
+				setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+					gotGateway, ok := params.resource.(*gatewayv1.Gateway)
+					return ok &&
+						gotGateway.Namespace == gateway.Namespace &&
+						gotGateway.Name == gateway.Name &&
+						params.conditionType == string(gatewayv1.GatewayConditionAccepted)
+				})).
+				Return(wantErr).
+				Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to set accepted condition")
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -30,8 +31,12 @@ func listenerOCICertificateOCID(listener gatewayv1.Listener) string {
 }
 
 func gatewayCertificateIDsByListener(gateway gatewayv1.Gateway) map[string]string {
+	return certificateIDsByListener(gateway.Spec.Listeners)
+}
+
+func certificateIDsByListener(listeners []gatewayv1.Listener) map[string]string {
 	result := make(map[string]string)
-	for _, listener := range gateway.Spec.Listeners {
+	for _, listener := range listeners {
 		if certificateID := listenerOCICertificateOCID(listener); certificateID != "" {
 			result[string(listener.Name)] = certificateID
 		}
@@ -85,6 +90,7 @@ func validateGatewayCertificateOptions(gateway gatewayv1.Gateway) error {
 type resolvedGatewayDetails struct {
 	gateway      gatewayv1.Gateway
 	gatewayClass gatewayv1.GatewayClass
+	listenerSets []gatewayv1.ListenerSet
 
 	// Map of secret full name to the secret object
 	// holds all secrets that are used by the gateway (mostly listeners certificates)
@@ -93,6 +99,8 @@ type resolvedGatewayDetails struct {
 	config types.GatewayConfig
 
 	loadBalancer *loadbalancer.LoadBalancer
+
+	effectiveListeners []effectiveListener
 }
 
 type gatewayModel interface {
@@ -120,6 +128,11 @@ type gatewayModelImpl struct {
 	ociClient            ociLoadBalancerClient
 	ociLoadBalancerModel ociLoadBalancerModel
 	resourcesModel       resourcesModel
+	listenerSetEnabled   bool
+}
+
+func (m *gatewayModelImpl) setListenerSetEnabled(enabled bool) {
+	m.listenerSetEnabled = enabled
 }
 
 func (m *gatewayModelImpl) resolveReconcileRequest(
@@ -181,6 +194,11 @@ func (m *gatewayModelImpl) resolveReconcileRequest(
 		return false, err
 	}
 
+	if m.listenerSetEnabled {
+		if err := populateAttachedListenerSets(ctx, m.client, receiver); err != nil {
+			return false, err
+		}
+	}
 	if err := m.populateGatewaySecrets(ctx, receiver); err != nil {
 		return false, err
 	}
@@ -195,11 +213,35 @@ func (m *gatewayModelImpl) populateGatewaySecrets(
 	receiver *resolvedGatewayDetails,
 ) error {
 	receiver.gatewaySecrets = make(map[string]corev1.Secret)
-	for _, listener := range receiver.gateway.Spec.Listeners {
-		if listenerOCICertificateOCID(listener) != "" {
+	if len(receiver.effectiveListeners) == 0 {
+		for _, listener := range receiver.gateway.Spec.Listeners {
+			if listenerOCICertificateOCID(listener) != "" {
+				continue
+			}
+			if populateErr := m.populateGatewayListenerSecrets(
+				ctx,
+				receiver,
+				gatewayv1.Kind("Gateway"),
+				receiver.gateway.Namespace,
+				listener,
+			); populateErr != nil {
+				return populateErr
+			}
+		}
+		return nil
+	}
+
+	for _, listener := range receiver.effectiveListeners {
+		if listener.conflicted || listenerOCICertificateOCID(listener.listener) != "" {
 			continue
 		}
-		if populateErr := m.populateGatewayListenerSecrets(ctx, receiver, listener); populateErr != nil {
+		if populateErr := m.populateGatewayListenerSecrets(
+			ctx,
+			receiver,
+			gatewayv1.Kind(listener.sourceKind),
+			listener.sourceNamespace,
+			listener.listener,
+		); populateErr != nil {
 			return populateErr
 		}
 	}
@@ -207,9 +249,83 @@ func (m *gatewayModelImpl) populateGatewaySecrets(
 	return nil
 }
 
+func populateAttachedListenerSets(ctx context.Context, k8sClient k8sClient, receiver *resolvedGatewayDetails) error {
+	var listenerSetList gatewayv1.ListenerSetList
+	gatewayKey := client.ObjectKeyFromObject(&receiver.gateway)
+	if err := k8sClient.List(ctx, &listenerSetList, client.MatchingFields{
+		listenerSetParentGatewayIndexKey: gatewayKey.String(),
+	}); err != nil {
+		return fmt.Errorf("failed to list ListenerSets for Gateway %s: %w", gatewayKey.String(), err)
+	}
+
+	attached := make([]gatewayv1.ListenerSet, 0, len(listenerSetList.Items))
+	if err := filterAttachedListenerSets(ctx, k8sClient, receiver, listenerSetList.Items, &attached); err != nil {
+		return err
+	}
+
+	receiver.listenerSets = attached
+	receiver.effectiveListeners = effectiveListenersForGateway(receiver.gateway, attached)
+	markUnsupportedListenerSetListeners(receiver.effectiveListeners, receiver.gatewayClass.Spec.ControllerName)
+	return nil
+}
+
+func populateAttachedListenerSetsUnindexed(
+	ctx context.Context,
+	k8sClient k8sClient,
+	receiver *resolvedGatewayDetails,
+) error {
+	var listenerSetList gatewayv1.ListenerSetList
+	if err := k8sClient.List(ctx, &listenerSetList); err != nil {
+		return fmt.Errorf("failed to list ListenerSets for Gateway %s/%s: %w",
+			receiver.gateway.Namespace,
+			receiver.gateway.Name,
+			err,
+		)
+	}
+
+	attached := make([]gatewayv1.ListenerSet, 0, len(listenerSetList.Items))
+	if err := filterAttachedListenerSets(ctx, k8sClient, receiver, listenerSetList.Items, &attached); err != nil {
+		return err
+	}
+
+	receiver.listenerSets = attached
+	receiver.effectiveListeners = effectiveListenersForGateway(receiver.gateway, attached)
+	markUnsupportedListenerSetListeners(receiver.effectiveListeners, receiver.gatewayClass.Spec.ControllerName)
+	return nil
+}
+
+func filterAttachedListenerSets(
+	ctx context.Context,
+	k8sClient k8sClient,
+	receiver *resolvedGatewayDetails,
+	listenerSets []gatewayv1.ListenerSet,
+	attached *[]gatewayv1.ListenerSet,
+) error {
+	gatewayKey := client.ObjectKeyFromObject(&receiver.gateway).String()
+	for _, listenerSet := range listenerSets {
+		parentGatewayName, ok := listenerSetParentGatewayName(listenerSet)
+		if !ok || parentGatewayName != gatewayKey {
+			continue
+		}
+		var namespace corev1.Namespace
+		if err := k8sClient.Get(ctx, apitypes.NamespacedName{Name: listenerSet.Namespace}, &namespace); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to get ListenerSet namespace %s: %w", listenerSet.Namespace, err)
+		}
+		if listenerSetAllowedByGateway(receiver.gateway, listenerSet, namespace) {
+			*attached = append(*attached, listenerSet)
+		}
+	}
+	return nil
+}
+
 func (m *gatewayModelImpl) populateGatewayListenerSecrets(
 	ctx context.Context,
 	receiver *resolvedGatewayDetails,
+	sourceKind gatewayv1.Kind,
+	defaultNamespace string,
 	listener gatewayv1.Listener,
 ) error {
 	if listener.TLS == nil || len(listener.TLS.CertificateRefs) == 0 {
@@ -218,9 +334,26 @@ func (m *gatewayModelImpl) populateGatewayListenerSecrets(
 
 	for _, certRef := range listener.TLS.CertificateRefs {
 		secretName := string(certRef.Name)
-		secretNamespace := receiver.gateway.Namespace
+		secretNamespace := defaultNamespace
 		if certRef.Namespace != nil {
 			secretNamespace = string(*certRef.Namespace)
+		}
+		fullSecretName := apitypes.NamespacedName{Namespace: secretNamespace, Name: secretName}
+		if sourceKind == gatewayv1.Kind(effectiveListenerSourceListenerSet) {
+			allowed, err := referenceGrantAllowsSecretRef(ctx, m.client, sourceKind, defaultNamespace, fullSecretName)
+			if err != nil {
+				return err
+			}
+			if !allowed {
+				return &resourceStatusError{
+					conditionType: string(gatewayv1.GatewayConditionAccepted),
+					reason:        string(gatewayv1.GatewayReasonInvalidParameters),
+					message: fmt.Sprintf(
+						"certificateRef %s is not permitted by a ReferenceGrant",
+						fullSecretName.String(),
+					),
+				}
+			}
 		}
 
 		if err := m.populateGatewaySecret(ctx, receiver, secretNamespace, secretName); err != nil {
@@ -339,22 +472,20 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 		return fmt.Errorf("failed to program default backend set: %w", err)
 	}
 
+	gatewayListeners := effectiveOCIListenersForGateway(data)
+	gatewayManagedListeners := gatewayManagedOCIListenersForLoadBalancer(data)
 	reconcileListenersCertificatesResult, err := m.ociLoadBalancerModel.reconcileListenersCertificates(ctx,
 		reconcileListenersCertificatesParams{
 			loadBalancerID:    loadBalancerID,
 			gateway:           &data.gateway,
+			gatewayListeners:  gatewayListeners,
 			knownCertificates: response.LoadBalancer.Certificates,
 		})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile listeners certificates: %w", err)
 	}
 
-	for _, listener := range data.gateway.Spec.Listeners {
-		// TODO: Support listener with hostname
-		if listener.Protocol == gatewayv1.TLSProtocolType {
-			continue
-		}
-
+	for _, listener := range gatewayManagedListeners {
 		listenerName := string(listener.Name)
 
 		params := reconcileHTTPListenerParams{
@@ -375,7 +506,7 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 	if err = m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
 		loadBalancerID:   loadBalancerID,
 		knownListeners:   response.LoadBalancer.Listeners,
-		gatewayListeners: data.gateway.Spec.Listeners,
+		gatewayListeners: gatewayListeners,
 	}); err != nil {
 		return fmt.Errorf("failed to remove missing listeners: %w", err)
 	}
@@ -453,6 +584,7 @@ func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGate
 	}
 
 	data.gateway.Status.Addresses = gatewayStatusAddressesFromLoadBalancer(data.loadBalancer)
+	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets)
 	if err := m.resourcesModel.setCondition(ctx, setConditionParams{
 		resource:      &data.gateway,
 		conditions:    &data.gateway.Status.Conditions,
@@ -463,6 +595,38 @@ func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGate
 		annotations:   annotations,
 	}); err != nil {
 		return fmt.Errorf("failed to set programmed condition for Gateway %s: %w", data.gateway.Name, err)
+	}
+	if err := setListenerSetsProgrammed(
+		ctx,
+		m.client,
+		data,
+		gatewayv1.GatewayController(ControllerClassName),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setListenerSetsProgrammed(
+	ctx context.Context,
+	k8sClient k8sClient,
+	data *resolvedGatewayDetails,
+	controllerName gatewayv1.GatewayController,
+) error {
+	for _, listenerSet := range data.listenerSets {
+		desiredStatus := listenerSetStatusForGateway(data.gateway, listenerSet, data.effectiveListeners, controllerName)
+		if listenerSetStatusSemanticallyEqual(listenerSet.Status, desiredStatus) {
+			continue
+		}
+		listenerSetToUpdate := listenerSet.DeepCopy()
+		listenerSetToUpdate.Status = desiredStatus
+		if err := k8sClient.Status().Update(ctx, listenerSetToUpdate); err != nil {
+			return fmt.Errorf("failed to update ListenerSet %s/%s status: %w",
+				listenerSet.Namespace,
+				listenerSet.Name,
+				err,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"go.uber.org/dig"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -231,8 +233,9 @@ func (m *gatewayModelImpl) populateGatewaySecrets(
 		return nil
 	}
 
-	for _, listener := range receiver.effectiveListeners {
-		if listener.conflicted || listenerOCICertificateOCID(listener.listener) != "" {
+	for i := range receiver.effectiveListeners {
+		listener := receiver.effectiveListeners[i]
+		if listener.conflicted || listener.unsupported || listenerOCICertificateOCID(listener.listener) != "" {
 			continue
 		}
 		if populateErr := m.populateGatewayListenerSecrets(
@@ -242,11 +245,31 @@ func (m *gatewayModelImpl) populateGatewaySecrets(
 			listener.sourceNamespace,
 			listener.listener,
 		); populateErr != nil {
+			if markListenerSetSecretError(&receiver.effectiveListeners[i], populateErr) {
+				continue
+			}
 			return populateErr
 		}
 	}
 
 	return nil
+}
+
+func markListenerSetSecretError(listener *effectiveListener, err error) bool {
+	if listener.sourceKind != effectiveListenerSourceListenerSet {
+		return false
+	}
+	listener.unsupported = true
+	listener.unsupportedReason = gatewayv1.ListenerReasonInvalidCertificateRef
+	listener.unsupportedMessage = err.Error()
+
+	var statusErr *resourceStatusError
+	if errors.As(err, &statusErr) &&
+		statusErr.reason == string(gatewayv1.GatewayReasonInvalidParameters) &&
+		strings.Contains(statusErr.message, "not permitted") {
+		listener.unsupportedReason = gatewayv1.ListenerReasonRefNotPermitted
+	}
+	return true
 }
 
 func populateAttachedListenerSets(ctx context.Context, k8sClient k8sClient, receiver *resolvedGatewayDetails) error {
@@ -584,7 +607,7 @@ func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGate
 	}
 
 	data.gateway.Status.Addresses = gatewayStatusAddressesFromLoadBalancer(data.loadBalancer)
-	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets)
+	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets, data.effectiveListeners)
 	if err := m.resourcesModel.setCondition(ctx, setConditionParams{
 		resource:      &data.gateway,
 		conditions:    &data.gateway.Status.Conditions,
@@ -614,21 +637,250 @@ func setListenerSetsProgrammed(
 	controllerName gatewayv1.GatewayController,
 ) error {
 	for _, listenerSet := range data.listenerSets {
-		desiredStatus := listenerSetStatusForGateway(data.gateway, listenerSet, data.effectiveListeners, controllerName)
+		attachedRoutes, err := listenerSetAttachedRouteCounts(ctx, k8sClient, data, listenerSet)
+		if err != nil {
+			return err
+		}
+		desiredStatus := listenerSetStatusForGateway(
+			data.gateway,
+			listenerSet,
+			data.effectiveListeners,
+			controllerName,
+			attachedRoutes,
+		)
 		if listenerSetStatusSemanticallyEqual(listenerSet.Status, desiredStatus) {
 			continue
 		}
 		listenerSetToUpdate := listenerSet.DeepCopy()
 		listenerSetToUpdate.Status = desiredStatus
-		if err := k8sClient.Status().Update(ctx, listenerSetToUpdate); err != nil {
+		if updateErr := k8sClient.Status().Update(ctx, listenerSetToUpdate); updateErr != nil {
 			return fmt.Errorf("failed to update ListenerSet %s/%s status: %w",
 				listenerSet.Namespace,
 				listenerSet.Name,
-				err,
+				updateErr,
 			)
 		}
 	}
 	return nil
+}
+
+func listenerSetAttachedRouteCounts(
+	ctx context.Context,
+	k8sClient k8sClient,
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+) (map[gatewayv1.SectionName]int32, error) {
+	counts := map[gatewayv1.SectionName]int32{}
+	if err := addListenerSetHTTPRouteCounts(ctx, k8sClient, data, listenerSet, counts); err != nil {
+		return nil, err
+	}
+	if err := addListenerSetGRPCRouteCounts(ctx, k8sClient, data, listenerSet, counts); err != nil {
+		return nil, err
+	}
+	if err := addListenerSetTCPRouteCounts(ctx, k8sClient, data, listenerSet, counts); err != nil {
+		return nil, err
+	}
+	if err := addListenerSetUDPRouteCounts(ctx, k8sClient, data, listenerSet, counts); err != nil {
+		return nil, err
+	}
+	if err := addListenerSetTLSRouteCounts(ctx, k8sClient, data, listenerSet, counts); err != nil {
+		return nil, err
+	}
+	return counts, nil
+}
+
+func addListenerSetHTTPRouteCounts(
+	ctx context.Context,
+	k8sClient k8sClient,
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	counts map[gatewayv1.SectionName]int32,
+) error {
+	var routeList gatewayv1.HTTPRouteList
+	if err := k8sClient.List(ctx, &routeList); err != nil {
+		return fmt.Errorf("failed to list HTTPRoutes for ListenerSet attached route counts: %w", err)
+	}
+	for _, route := range routeList.Items {
+		addListenerSetRouteCounts(
+			data,
+			listenerSet,
+			counts,
+			route.Namespace,
+			route.Status.Parents,
+			route.Spec.ParentRefs,
+			func(ref gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+				if ref.SectionName != nil && listener.Name != *ref.SectionName {
+					return false
+				}
+				return listener.Protocol == gatewayv1.HTTPProtocolType ||
+					listener.Protocol == gatewayv1.HTTPSProtocolType
+			},
+		)
+	}
+	return nil
+}
+
+func addListenerSetGRPCRouteCounts(
+	ctx context.Context,
+	k8sClient k8sClient,
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	counts map[gatewayv1.SectionName]int32,
+) error {
+	var routeList gatewayv1.GRPCRouteList
+	if err := k8sClient.List(ctx, &routeList); err != nil {
+		return fmt.Errorf("failed to list GRPCRoutes for ListenerSet attached route counts: %w", err)
+	}
+	for _, route := range routeList.Items {
+		addListenerSetRouteCounts(
+			data,
+			listenerSet,
+			counts,
+			route.Namespace,
+			route.Status.Parents,
+			route.Spec.ParentRefs,
+			func(ref gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+				if ref.SectionName != nil && listener.Name != *ref.SectionName {
+					return false
+				}
+				return grpcRouteListenerProtocolSupported(listener.Protocol)
+			},
+		)
+	}
+	return nil
+}
+
+func addListenerSetTCPRouteCounts(
+	ctx context.Context,
+	k8sClient k8sClient,
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	counts map[gatewayv1.SectionName]int32,
+) error {
+	var routeList gatewayv1.TCPRouteList
+	if err := k8sClient.List(ctx, &routeList); err != nil {
+		return fmt.Errorf("failed to list TCPRoutes for ListenerSet attached route counts: %w", err)
+	}
+	for _, route := range routeList.Items {
+		addListenerSetRouteCounts(data, listenerSet, counts, route.Namespace,
+			route.Status.Parents, route.Spec.ParentRefs, tcpRouteMatchesListener)
+	}
+	return nil
+}
+
+func addListenerSetUDPRouteCounts(
+	ctx context.Context,
+	k8sClient k8sClient,
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	counts map[gatewayv1.SectionName]int32,
+) error {
+	var routeList gatewayv1.UDPRouteList
+	if err := k8sClient.List(ctx, &routeList); err != nil {
+		return fmt.Errorf("failed to list UDPRoutes for ListenerSet attached route counts: %w", err)
+	}
+	for _, route := range routeList.Items {
+		addListenerSetRouteCounts(data, listenerSet, counts, route.Namespace,
+			route.Status.Parents, route.Spec.ParentRefs, udpRouteMatchesListener)
+	}
+	return nil
+}
+
+func addListenerSetTLSRouteCounts(
+	ctx context.Context,
+	k8sClient k8sClient,
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	counts map[gatewayv1.SectionName]int32,
+) error {
+	var routeList gatewayv1.TLSRouteList
+	if err := k8sClient.List(ctx, &routeList); err != nil {
+		return fmt.Errorf("failed to list TLSRoutes for ListenerSet attached route counts: %w", err)
+	}
+	for _, route := range routeList.Items {
+		addListenerSetRouteCounts(data, listenerSet, counts, route.Namespace,
+			route.Status.Parents, route.Spec.ParentRefs, tlsRouteMatchesListener)
+	}
+	return nil
+}
+
+func addListenerSetRouteCounts(
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	counts map[gatewayv1.SectionName]int32,
+	routeNamespace string,
+	parentStatuses []gatewayv1.RouteParentStatus,
+	parentRefs []gatewayv1.ParentReference,
+	matchesListener func(gatewayv1.ParentReference, gatewayv1.Listener) bool,
+) {
+	for _, parentStatus := range parentStatuses {
+		if !listenerSetRouteParentStatusAccepted(data, listenerSet, routeNamespace, parentStatus) {
+			continue
+		}
+		for _, parentRef := range parentRefs {
+			addListenerSetRouteCountForParentRef(
+				data,
+				listenerSet,
+				counts,
+				routeNamespace,
+				parentStatus.ParentRef,
+				parentRef,
+				matchesListener,
+			)
+		}
+	}
+}
+
+func listenerSetRouteParentStatusAccepted(
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	routeNamespace string,
+	parentStatus gatewayv1.RouteParentStatus,
+) bool {
+	return parentStatus.ControllerName == data.gatewayClass.Spec.ControllerName &&
+		meta.IsStatusConditionTrue(parentStatus.Conditions, string(gatewayv1.RouteConditionAccepted)) &&
+		parentRefTargetsListenerSet(parentStatus.ParentRef) &&
+		parentRefTargetName(parentStatus.ParentRef, routeNamespace) == client.ObjectKeyFromObject(&listenerSet)
+}
+
+func addListenerSetRouteCountForParentRef(
+	data *resolvedGatewayDetails,
+	listenerSet gatewayv1.ListenerSet,
+	counts map[gatewayv1.SectionName]int32,
+	routeNamespace string,
+	statusParentRef gatewayv1.ParentReference,
+	parentRef gatewayv1.ParentReference,
+	matchesListener func(gatewayv1.ParentReference, gatewayv1.Listener) bool,
+) {
+	if !parentRefSameTarget(parentRef, statusParentRef) {
+		return
+	}
+	for _, listener := range effectiveListenersForParentRef(*data, parentRef, routeNamespace, matchesListener) {
+		if entry, found := listenerSetEntryForEffectiveListener(data.gateway, listenerSet, listener.Name); found {
+			counts[entry.Name]++
+		}
+	}
+}
+
+func listenerSetEntryForEffectiveListener(
+	gateway gatewayv1.Gateway,
+	listenerSet gatewayv1.ListenerSet,
+	effectiveName gatewayv1.SectionName,
+) (gatewayv1.ListenerEntry, bool) {
+	for _, entry := range listenerSet.Spec.Listeners {
+		listener := listenerFromListenerSetEntry(entry)
+		ociListener := effectiveListenerOCIListener(effectiveListener{
+			listener:        listener,
+			sourceKind:      effectiveListenerSourceListenerSet,
+			sourceNamespace: listenerSet.Namespace,
+			sourceName:      listenerSet.Name,
+			ociName:         listenerSetOCIListenerName(gateway, listenerSet, listener),
+		})
+		if ociListener.Name == effectiveName {
+			return entry, true
+		}
+	}
+	return gatewayv1.ListenerEntry{}, false
 }
 
 type gatewayModelDeps struct {

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -15,14 +15,17 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
+	k8sapi "github.com/gemyago/oke-gateway-api/internal/services/k8sapi"
 	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
 	"github.com/gemyago/oke-gateway-api/internal/types"
 )
@@ -123,6 +126,179 @@ func TestGatewayModelImpl(t *testing.T) {
 			assert.Equal(t, gatewayConfig, receiver.config)
 			assert.Equal(t, *gateway, receiver.gateway)
 			assert.Equal(t, *gatewayClass, receiver.gatewayClass)
+		})
+
+		t.Run("valid gateway with ListenerSet listeners", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			model.setListenerSetEnabled(true)
+
+			gatewayClass := newRandomGatewayClass(
+				randomGatewayClassWithControllerNameOpt(ControllerClassName),
+			)
+			gateway := newRandomGateway()
+			gateway.Namespace = "infra-" + fake.Lorem().Word()
+			gateway.Name = "edge-" + fake.Lorem().Word()
+			fromAll := gatewayv1.NamespacesFromAll
+			gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+			}
+			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{
+					Group: ConfigRefGroup,
+					Kind:  ConfigRefKind,
+					Name:  "config-" + fake.Lorem().Word(),
+				},
+			}
+			gatewayConfig := types.GatewayConfig{
+				Spec: types.GatewayConfigSpec{LoadBalancerID: fake.UUID().V4()},
+			}
+			parentNamespace := gatewayv1.Namespace(gateway.Namespace)
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps-" + fake.Lorem().Word(),
+					Name:      "extra-" + fake.Lorem().Word(),
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Namespace: &parentNamespace,
+						Name:      gatewayv1.ObjectName(gateway.Name),
+					},
+					Listeners: []gatewayv1.ListenerEntry{{
+						Name:     "https",
+						Port:     443,
+						Protocol: gatewayv1.HTTPSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-cert"}},
+						},
+					}},
+				},
+			}
+			secret := makeRandomSecret(
+				randomSecretWithNameOpt("tls-cert"),
+				randomSecretWithTLSDataOpt(),
+			)
+			secret.Namespace = listenerSet.Namespace
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(gateway)}
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			setupClientGet(t, mockClient, req.NamespacedName, *gateway)
+			setupClientGet(t, mockClient, apitypes.NamespacedName{
+				Name: string(gateway.Spec.GatewayClassName),
+			}, *gatewayClass)
+			setupClientGet(t, mockClient, apitypes.NamespacedName{
+				Namespace: gateway.Namespace,
+				Name:      gateway.Spec.Infrastructure.ParametersRef.Name,
+			}, gatewayConfig)
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{},
+					client.MatchingFields{listenerSetParentGatewayIndexKey: req.NamespacedName.String()}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.ListenerSet{
+						listenerSet,
+						{
+							ObjectMeta: metav1.ObjectMeta{Namespace: "other", Name: "ignored"},
+							Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+								Name: "other",
+							}},
+						},
+					}))
+					return nil
+				})
+			setupClientGet(t, mockClient, apitypes.NamespacedName{Name: listenerSet.Namespace}, corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: listenerSet.Namespace},
+			})
+			setupClientGet(t, mockClient, apitypes.NamespacedName{
+				Namespace: secret.Namespace,
+				Name:      secret.Name,
+			}, secret)
+
+			var receiver resolvedGatewayDetails
+			relevant, err := model.resolveReconcileRequest(t.Context(), req, &receiver)
+
+			require.NoError(t, err)
+			assert.True(t, relevant)
+			require.Len(t, receiver.listenerSets, 1)
+			require.Len(t, receiver.effectiveListeners, 1+len(gateway.Spec.Listeners))
+			assert.Contains(t, receiver.gatewaySecrets, secret.Namespace+"/"+secret.Name)
+		})
+
+		t.Run("returns invalid certificate option errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			gatewayClass := newRandomGatewayClass(randomGatewayClassWithControllerNameOpt(ControllerClassName))
+			gateway := newRandomGateway()
+			gateway.Spec.Listeners = []gatewayv1.Listener{{
+				Name:     "https",
+				Protocol: gatewayv1.HTTPSProtocolType,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-cert"}},
+					Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+						ListenerTLSOptionOCICertificateOCID: "ocid1.certificate.oc1..test",
+					},
+				},
+			}}
+			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{Name: "alb-config"},
+			}
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(gateway)}
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			setupClientGet(t, mockClient, req.NamespacedName, *gateway)
+			setupClientGet(
+				t,
+				mockClient,
+				apitypes.NamespacedName{Name: string(gateway.Spec.GatewayClassName)},
+				*gatewayClass,
+			)
+			setupClientGet(t, mockClient, apitypes.NamespacedName{
+				Namespace: gateway.Namespace,
+				Name:      "alb-config",
+			}, makeRandomGatewayConfig())
+
+			var receiver resolvedGatewayDetails
+			relevant, err := model.resolveReconcileRequest(t.Context(), req, &receiver)
+
+			assert.False(t, relevant)
+			require.ErrorContains(t, err, "cannot be used together with listener.tls.certificateRefs")
+		})
+
+		t.Run("returns ListenerSet population errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			model.setListenerSetEnabled(true)
+			gatewayClass := newRandomGatewayClass(randomGatewayClassWithControllerNameOpt(ControllerClassName))
+			gateway := newRandomGateway()
+			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{Name: "alb-config"},
+			}
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(gateway)}
+			wantErr := errors.New("listenerset list failed")
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			setupClientGet(t, mockClient, req.NamespacedName, *gateway)
+			setupClientGet(
+				t,
+				mockClient,
+				apitypes.NamespacedName{Name: string(gateway.Spec.GatewayClassName)},
+				*gatewayClass,
+			)
+			setupClientGet(t, mockClient, apitypes.NamespacedName{
+				Namespace: gateway.Namespace,
+				Name:      "alb-config",
+			}, makeRandomGatewayConfig())
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{},
+					client.MatchingFields{listenerSetParentGatewayIndexKey: req.NamespacedName.String()}).
+				Return(wantErr)
+
+			var receiver resolvedGatewayDetails
+			relevant, err := model.resolveReconcileRequest(t.Context(), req, &receiver)
+
+			assert.False(t, relevant)
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to list ListenerSets")
 		})
 
 		t.Run("missingGateway", func(t *testing.T) {
@@ -899,6 +1075,7 @@ func TestGatewayModelImpl(t *testing.T) {
 				reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
 					loadBalancerID:    config.Spec.LoadBalancerID,
 					gateway:           gateway,
+					gatewayListeners:  gateway.Spec.Listeners,
 					knownCertificates: loadBalancer.Certificates,
 				}).
 				Return(reconcileListenersCertificatesResult{
@@ -945,6 +1122,102 @@ func TestGatewayModelImpl(t *testing.T) {
 			})
 
 			require.NoError(t, err)
+		})
+		t.Run("programs ListenerSet listeners with derived OCI listener names", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			config := makeRandomGatewayConfig()
+			directListener := makeRandomListener(randomListenerWithHTTPProtocolOpt())
+			listenerSetListener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway()
+			gateway.Spec.Listeners = []gatewayv1.Listener{directListener}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         gateway.Namespace,
+					Name:              "team-" + faker.New().Internet().Slug(),
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(gateway.Name)},
+					Listeners: []gatewayv1.ListenerEntry{{
+						Name:     listenerSetListener.Name,
+						Protocol: listenerSetListener.Protocol,
+						Port:     listenerSetListener.Port,
+						Hostname: listenerSetListener.Hostname,
+						TLS:      listenerSetListener.TLS,
+					}},
+				},
+			}
+			data := &resolvedGatewayDetails{
+				gateway:            *gateway,
+				config:             config,
+				listenerSets:       []gatewayv1.ListenerSet{listenerSet},
+				effectiveListeners: effectiveListenersForGateway(*gateway, []gatewayv1.ListenerSet{listenerSet}),
+			}
+			gatewayListeners := effectiveOCIListenersForGateway(data)
+			loadBalancer := makeRandomOCILoadBalancer(
+				randomOCILoadBalancerWithRandomBackendSetsOpt(),
+				randomOCILoadBalancerWithRandomPoliciesOpt(),
+				randomOCILoadBalancerWithRandomCertificatesOpt(),
+			)
+			defaultBackendSet := makeRandomOCIBackendSet()
+			certificatesByListener := map[string][]loadbalancer.Certificate{}
+			for _, listener := range gatewayListeners {
+				certificatesByListener[string(listener.Name)] = []loadbalancer.Certificate{makeRandomOCICertificate()}
+			}
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadBalancer}, nil)
+			loadBalancerModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			loadBalancerModel.EXPECT().
+				reconcileDefaultBackendSet(t.Context(), mock.Anything).
+				Return(defaultBackendSet, nil)
+			reconcileCertificatesCall := loadBalancerModel.EXPECT().
+				reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+					loadBalancerID:    config.Spec.LoadBalancerID,
+					gateway:           gateway,
+					gatewayListeners:  gatewayListeners,
+					knownCertificates: loadBalancer.Certificates,
+				}).
+				Return(reconcileListenersCertificatesResult{
+					certificatesByListener: certificatesByListener,
+				}, nil)
+			for _, listener := range gatewayListeners {
+				loadBalancerModel.EXPECT().
+					reconcileHTTPListener(t.Context(), mock.MatchedBy(func(params reconcileHTTPListenerParams) bool {
+						return params.listenerSpec != nil &&
+							params.listenerSpec.Name == listener.Name &&
+							reflect.DeepEqual(
+								params.listenerCertificates,
+								certificatesByListener[string(listener.Name)],
+							)
+					})).
+					Return(nil).
+					Once().
+					NotBefore(reconcileCertificatesCall.Call)
+			}
+			removeCall := loadBalancerModel.EXPECT().
+				removeMissingListeners(t.Context(), removeMissingListenersParams{
+					loadBalancerID:   config.Spec.LoadBalancerID,
+					knownListeners:   loadBalancer.Listeners,
+					gatewayListeners: gatewayListeners,
+				}).
+				Return(nil)
+			loadBalancerModel.EXPECT().
+				removeUnusedCertificates(t.Context(), mock.Anything).
+				Return(nil).
+				NotBefore(removeCall.Call)
+
+			err := model.programGateway(t.Context(), data)
+
+			require.NoError(t, err)
+			assert.NotEqual(t, listenerSetListener.Name, gatewayListeners[1].Name)
+			assert.Contains(t, string(gatewayListeners[1].Name), "ls_")
 		})
 		t.Run("skips TLS listeners because TLSRoute owns ALB TLS listener reconciliation", func(t *testing.T) {
 			deps := newMockDeps(t)
@@ -1148,6 +1421,7 @@ func TestGatewayModelImpl(t *testing.T) {
 				reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
 					loadBalancerID:    config.Spec.LoadBalancerID,
 					gateway:           gateway,
+					gatewayListeners:  gateway.Spec.Listeners,
 					knownCertificates: loadBalancer.Certificates,
 				}).
 				Return(reconcileListenersCertificatesResult{
@@ -1486,9 +1760,396 @@ func TestGatewayModelImpl(t *testing.T) {
 			mockResourcesModel.AssertExpectations(t)
 		})
 	})
+
+	t.Run("populateAttachedListenerSets", func(t *testing.T) {
+		t.Run("returns indexed list errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			data := makeRandomAcceptedGatewayDetails()
+			wantErr := errors.New("list failed")
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{},
+					client.MatchingFields{
+						listenerSetParentGatewayIndexKey: client.ObjectKeyFromObject(&data.gateway).String(),
+					}).
+				Return(wantErr)
+
+			err := populateAttachedListenerSets(t.Context(), model.client, data)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to list ListenerSets")
+		})
+
+		t.Run("returns namespace lookup errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			data := makeRandomAcceptedGatewayDetails()
+			fromAll := gatewayv1.NamespacesFromAll
+			data.gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+			}
+			parentNamespace := gatewayv1.Namespace(data.gateway.Namespace)
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Namespace: &parentNamespace,
+						Name:      gatewayv1.ObjectName(data.gateway.Name),
+					},
+				},
+			}
+			wantErr := errors.New("namespace failed")
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{},
+					client.MatchingFields{
+						listenerSetParentGatewayIndexKey: client.ObjectKeyFromObject(&data.gateway).String(),
+					}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).
+						Elem().
+						FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.ListenerSet{listenerSet}))
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), apitypes.NamespacedName{Name: listenerSet.Namespace}, mock.AnythingOfType("*v1.Namespace")).
+				Return(wantErr)
+
+			err := populateAttachedListenerSets(t.Context(), model.client, data)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to get ListenerSet namespace")
+		})
+
+		t.Run("unindexed list skips missing namespaces and attaches selected namespaces", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			data := makeRandomAcceptedGatewayDetails()
+			fromSelector := gatewayv1.NamespacesFromSelector
+			data.gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{
+					From: &fromSelector,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"team": "edge",
+					}},
+				},
+			}
+			parentNamespace := gatewayv1.Namespace(data.gateway.Namespace)
+			attachedListenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Namespace: &parentNamespace,
+						Name:      gatewayv1.ObjectName(data.gateway.Name),
+					},
+					Listeners: []gatewayv1.ListenerEntry{
+						{Name: "tcp", Port: 1935, Protocol: gatewayv1.TCPProtocolType},
+					},
+				},
+			}
+			missingNamespaceListenerSet := attachedListenerSet
+			missingNamespaceListenerSet.Namespace = "missing"
+			missingNamespaceListenerSet.Name = "missing"
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.ListenerSet{
+						missingNamespaceListenerSet,
+						attachedListenerSet,
+					}))
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), apitypes.NamespacedName{Name: missingNamespaceListenerSet.Namespace}, mock.Anything).
+				Return(apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, missingNamespaceListenerSet.Namespace))
+			setupClientGet(
+				t,
+				mockClient,
+				apitypes.NamespacedName{Name: attachedListenerSet.Namespace},
+				corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   attachedListenerSet.Namespace,
+						Labels: map[string]string{"team": "edge"},
+					},
+				},
+			)
+
+			err := populateAttachedListenerSetsUnindexed(t.Context(), model.client, data)
+
+			require.NoError(t, err)
+			require.Len(t, data.listenerSets, 1)
+			assert.Equal(t, attachedListenerSet.Name, data.listenerSets[0].Name)
+			require.Len(t, data.effectiveListeners, len(data.gateway.Spec.Listeners)+1)
+		})
+	})
+
+	t.Run("setListenerSetsProgrammed", func(t *testing.T) {
+		t.Run("updates only semantically changed ListenerSet status", func(t *testing.T) {
+			deps := newMockDeps(t)
+			gateway := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "apps",
+					Name:       "extra",
+					Generation: 3,
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(gateway.Name)},
+					Listeners: []gatewayv1.ListenerEntry{
+						{Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+					},
+				},
+			}
+			upToDate := listenerSet
+			upToDate.Name = "current"
+			upToDate.Spec.Listeners = append([]gatewayv1.ListenerEntry(nil), listenerSet.Spec.Listeners...)
+			upToDate.Spec.Listeners[0].Port = 8443
+			data := &resolvedGatewayDetails{
+				gateway: gateway,
+				listenerSets: []gatewayv1.ListenerSet{
+					upToDate,
+					listenerSet,
+				},
+			}
+			data.effectiveListeners = effectiveListenersForGateway(gateway, data.listenerSets)
+			data.listenerSets[0].Status = listenerSetStatusForGateway(
+				gateway,
+				data.listenerSets[0],
+				data.effectiveListeners,
+				gatewayv1.GatewayController(ControllerClassName),
+			)
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+			mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+			mockStatusWriter.EXPECT().
+				Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+					updated, ok := obj.(*gatewayv1.ListenerSet)
+					return ok &&
+						updated.Namespace == listenerSet.Namespace &&
+						updated.Name == listenerSet.Name &&
+						meta.IsStatusConditionTrue(
+							updated.Status.Conditions,
+							string(gatewayv1.ListenerSetConditionProgrammed),
+						)
+				})).
+				Return(nil).
+				Once()
+
+			err := setListenerSetsProgrammed(
+				t.Context(),
+				mockClient,
+				data,
+				gatewayv1.GatewayController(ControllerClassName),
+			)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("returns status update errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			gateway := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(gateway.Name)},
+					Listeners: []gatewayv1.ListenerEntry{
+						{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+				},
+			}
+			data := &resolvedGatewayDetails{
+				gateway:            gateway,
+				listenerSets:       []gatewayv1.ListenerSet{listenerSet},
+				effectiveListeners: effectiveListenersForGateway(gateway, []gatewayv1.ListenerSet{listenerSet}),
+			}
+			wantErr := errors.New("status failed")
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+			mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+			mockStatusWriter.EXPECT().Update(t.Context(), mock.Anything).Return(wantErr).Once()
+
+			err := setListenerSetsProgrammed(
+				t.Context(),
+				mockClient,
+				data,
+				gatewayv1.GatewayController(ControllerClassName),
+			)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to update ListenerSet apps/extra status")
+		})
+	})
+
+	t.Run("setProgrammed returns ListenerSet status update errors", func(t *testing.T) {
+		deps := newMockDeps(t)
+		model := newGatewayModel(deps)
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+				Listeners: []gatewayv1.ListenerEntry{{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+			},
+		}
+		data := &resolvedGatewayDetails{
+			gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}},
+			listenerSets: []gatewayv1.ListenerSet{
+				listenerSet,
+			},
+			effectiveListeners: effectiveListenersForGateway(
+				gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}},
+				[]gatewayv1.ListenerSet{listenerSet},
+			),
+		}
+		wantErr := errors.New("listenerset status failed")
+
+		mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+		mockResourcesModel.EXPECT().
+			setCondition(t.Context(), mock.Anything).
+			Return(nil).
+			Once()
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+		mockStatusWriter.EXPECT().Update(t.Context(), mock.Anything).Return(wantErr).Once()
+
+		err := model.setProgrammed(t.Context(), data)
+
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("populateGatewaySecrets with effective listeners", func(t *testing.T) {
+		deps := newMockDeps(t)
+		model := newGatewayModel(deps)
+		gateway := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}}
+		certNamespace := gatewayv1.Namespace("apps")
+		certName := gatewayv1.ObjectName("tls-cert")
+		data := &resolvedGatewayDetails{
+			gateway: gateway,
+			effectiveListeners: []effectiveListener{
+				{
+					listener: gatewayv1.Listener{
+						Name:     "conflicted",
+						Protocol: gatewayv1.HTTPSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "ignored-conflict"}},
+						},
+					},
+					conflicted: true,
+				},
+				{
+					listener: gatewayv1.Listener{
+						Name:     "oci-cert",
+						Protocol: gatewayv1.HTTPSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+								ListenerTLSOptionOCICertificateOCID: "ocid1.certificate.oc1..test",
+							},
+						},
+					},
+				},
+				{
+					sourceNamespace: string(certNamespace),
+					listener: gatewayv1.Listener{
+						Name:     "https",
+						Protocol: gatewayv1.HTTPSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayv1.SecretObjectReference{{
+								Namespace: &certNamespace,
+								Name:      certName,
+							}},
+						},
+					},
+				},
+			},
+		}
+		secret := makeRandomSecret(
+			randomSecretWithNameOpt(string(certName)),
+			randomSecretWithTLSDataOpt(),
+		)
+		secret.Namespace = string(certNamespace)
+
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		setupClientGet(t, mockClient, apitypes.NamespacedName{
+			Namespace: secret.Namespace,
+			Name:      secret.Name,
+		}, secret).Once()
+
+		err := model.populateGatewaySecrets(t.Context(), data)
+
+		require.NoError(t, err)
+		assert.Len(t, data.gatewaySecrets, 1)
+		assert.Contains(t, data.gatewaySecrets, secret.Namespace+"/"+secret.Name)
+	})
+
+	t.Run(
+		"populateGatewaySecrets rejects cross namespace ListenerSet certificate without ReferenceGrant",
+		func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			certNamespace := gatewayv1.Namespace("certs")
+			certName := gatewayv1.ObjectName("tls-cert")
+			data := &resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}},
+				effectiveListeners: []effectiveListener{{
+					sourceKind:      effectiveListenerSourceListenerSet,
+					sourceNamespace: "apps",
+					listener: gatewayv1.Listener{
+						Name:     "https",
+						Protocol: gatewayv1.HTTPSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayv1.SecretObjectReference{{
+								Namespace: &certNamespace,
+								Name:      certName,
+							}},
+						},
+					},
+				}},
+			}
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				List(t.Context(), mock.AnythingOfType("*v1beta1.ReferenceGrantList"), mock.Anything).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().Set(reflect.ValueOf(gatewayv1beta1.ReferenceGrantList{}))
+					return nil
+				})
+
+			err := model.populateGatewaySecrets(t.Context(), data)
+
+			var statusErr *resourceStatusError
+			require.ErrorAs(t, err, &statusErr)
+			assert.Equal(t, string(gatewayv1.GatewayReasonInvalidParameters), statusErr.reason)
+			assert.Contains(t, statusErr.message, "certificateRef certs/tls-cert is not permitted by a ReferenceGrant")
+		},
+	)
 }
 
 func TestProgrammedGatewayCertificatesAnnotation(t *testing.T) {
+	t.Run("collects OCI certificate IDs by listener", func(t *testing.T) {
+		assert.Equal(t, map[string]string{
+			"https": "ocid1.certificate.oc1..test",
+		}, gatewayCertificateIDsByListener(gatewayv1.Gateway{
+			Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{
+				{Name: "http"},
+				{
+					Name: "https",
+					TLS: &gatewayv1.ListenerTLSConfig{
+						Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+							ListenerTLSOptionOCICertificateOCID: "ocid1.certificate.oc1..test",
+						},
+					},
+				},
+			}},
+		}))
+	})
+
 	t.Run("normalizes annotation values", func(t *testing.T) {
 		got := programmedGatewayCertificatesAnnotation([]string{
 			"kora-cert-rev-2",

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -39,6 +40,16 @@ func TestGatewayModelImpl(t *testing.T) {
 			OciClient:            NewMockociLoadBalancerClient(t),
 			OciLoadBalancerModel: NewMockociLoadBalancerModel(t),
 		}
+	}
+	expectEmptyListenerSetRouteCountLists := func(t *testing.T, mockClient *Mockk8sClient, listenerSetCount int) {
+		t.Helper()
+		mockClient.EXPECT().
+			List(t.Context(), mock.Anything).
+			RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().Set(reflect.Zero(reflect.ValueOf(list).Elem().Type()))
+				return nil
+			}).
+			Times(5 * listenerSetCount)
 	}
 
 	t.Run("resolveReconcileRequest", func(t *testing.T) {
@@ -1887,6 +1898,46 @@ func TestGatewayModelImpl(t *testing.T) {
 			assert.Equal(t, attachedListenerSet.Name, data.listenerSets[0].Name)
 			require.Len(t, data.effectiveListeners, len(data.gateway.Spec.Listeners)+1)
 		})
+
+		t.Run("unindexed list returns namespace lookup errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			data := makeRandomAcceptedGatewayDetails()
+			fromAll := gatewayv1.NamespacesFromAll
+			data.gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+			}
+			parentNamespace := gatewayv1.Namespace(data.gateway.Namespace)
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Namespace: &parentNamespace,
+						Name:      gatewayv1.ObjectName(data.gateway.Name),
+					},
+				},
+			}
+			wantErr := errors.New("namespace failed")
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).
+						Elem().
+						FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.ListenerSet{listenerSet}))
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), apitypes.NamespacedName{Name: listenerSet.Namespace}, mock.AnythingOfType("*v1.Namespace")).
+				Return(wantErr)
+
+			err := populateAttachedListenerSetsUnindexed(t.Context(), model.client, data)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to get ListenerSet namespace")
+		})
 	})
 
 	t.Run("setListenerSetsProgrammed", func(t *testing.T) {
@@ -1923,9 +1974,11 @@ func TestGatewayModelImpl(t *testing.T) {
 				data.listenerSets[0],
 				data.effectiveListeners,
 				gatewayv1.GatewayController(ControllerClassName),
+				nil,
 			)
 
 			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			expectEmptyListenerSetRouteCountLists(t, mockClient, len(data.listenerSets))
 			mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
 			mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
 			mockStatusWriter.EXPECT().
@@ -1972,6 +2025,7 @@ func TestGatewayModelImpl(t *testing.T) {
 			wantErr := errors.New("status failed")
 
 			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			expectEmptyListenerSetRouteCountLists(t, mockClient, len(data.listenerSets))
 			mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
 			mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
 			mockStatusWriter.EXPECT().Update(t.Context(), mock.Anything).Return(wantErr).Once()
@@ -1985,6 +2039,311 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			require.ErrorIs(t, err, wantErr)
 			require.ErrorContains(t, err, "failed to update ListenerSet apps/extra status")
+		})
+
+		t.Run("returns attached route count errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			wantErr := errors.New("list failed")
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+					Listeners: []gatewayv1.ListenerEntry{{
+						Name:     "http",
+						Port:     80,
+						Protocol: gatewayv1.HTTPProtocolType,
+					}},
+				},
+			}
+			gateway := gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"},
+			}
+			effectiveListeners := effectiveListenersForGateway(gateway, []gatewayv1.ListenerSet{listenerSet})
+			data := &resolvedGatewayDetails{
+				gateway:            gateway,
+				listenerSets:       []gatewayv1.ListenerSet{listenerSet},
+				effectiveListeners: effectiveListeners,
+			}
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().List(t.Context(), mock.Anything).Return(wantErr)
+
+			err := setListenerSetsProgrammed(
+				t.Context(),
+				mockClient,
+				data,
+				gatewayv1.GatewayController(ControllerClassName),
+			)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("counts accepted direct ListenerSet route parents", func(t *testing.T) {
+			httpListener := gatewayv1.SectionName("http")
+			grpcListener := gatewayv1.SectionName("grpc")
+			tcpListener := gatewayv1.SectionName("tcp")
+			udpListener := gatewayv1.SectionName("udp")
+			tlsListener := gatewayv1.SectionName("tls")
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			httpParentRef := gatewayv1.ParentReference{
+				Kind:        &listenerSetKind,
+				Name:        "extra",
+				SectionName: &httpListener,
+			}
+			grpcParentRef := httpParentRef
+			grpcParentRef.SectionName = &grpcListener
+			tcpParentRef := httpParentRef
+			tcpParentRef.SectionName = &tcpListener
+			udpParentRef := httpParentRef
+			udpParentRef.SectionName = &udpListener
+			tlsParentRef := httpParentRef
+			tlsParentRef.SectionName = &tlsListener
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: string(httpParentRef.Name)},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+					Listeners: []gatewayv1.ListenerEntry{
+						{Name: httpListener, Port: 8080, Protocol: gatewayv1.HTTPProtocolType},
+						{Name: grpcListener, Port: 8081, Protocol: gatewayv1.HTTPSProtocolType},
+						{Name: tcpListener, Port: 8082, Protocol: gatewayv1.TCPProtocolType},
+						{Name: udpListener, Port: 8083, Protocol: gatewayv1.UDPProtocolType},
+						{Name: tlsListener, Port: 8084, Protocol: gatewayv1.TLSProtocolType},
+					},
+				},
+			}
+			acceptedParentStatus := func(parentRef gatewayv1.ParentReference) []gatewayv1.RouteParentStatus {
+				return []gatewayv1.RouteParentStatus{{
+					ParentRef:      parentRef,
+					ControllerName: gatewayv1.GatewayController(ControllerClassName),
+					Conditions: []metav1.Condition{{
+						Type:               string(gatewayv1.RouteConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(gatewayv1.RouteReasonAccepted),
+						ObservedGeneration: 4,
+					}},
+				}}
+			}
+			route := gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "api", Generation: 4},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{httpParentRef}},
+				},
+				Status: gatewayv1.HTTPRouteStatus{
+					RouteStatus: gatewayv1.RouteStatus{Parents: acceptedParentStatus(httpParentRef)},
+				},
+			}
+			grpcRoute := gatewayv1.GRPCRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "grpc", Generation: 4},
+				Spec: gatewayv1.GRPCRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{grpcParentRef}},
+				},
+				Status: gatewayv1.GRPCRouteStatus{
+					RouteStatus: gatewayv1.RouteStatus{Parents: acceptedParentStatus(grpcParentRef)},
+				},
+			}
+			tcpRoute := gatewayv1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "tcp", Generation: 4},
+				Spec: gatewayv1.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{tcpParentRef}},
+				},
+				Status: gatewayv1.TCPRouteStatus{
+					RouteStatus: gatewayv1.RouteStatus{Parents: acceptedParentStatus(tcpParentRef)},
+				},
+			}
+			udpRoute := gatewayv1.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "udp", Generation: 4},
+				Spec: gatewayv1.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{udpParentRef}},
+				},
+				Status: gatewayv1.UDPRouteStatus{
+					RouteStatus: gatewayv1.RouteStatus{Parents: acceptedParentStatus(udpParentRef)},
+				},
+			}
+			tlsRoute := gatewayv1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "tls", Generation: 4},
+				Spec: gatewayv1.TLSRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{tlsParentRef}},
+				},
+				Status: gatewayv1.TLSRouteStatus{
+					RouteStatus: gatewayv1.RouteStatus{Parents: acceptedParentStatus(tlsParentRef)},
+				},
+			}
+			data := &resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}},
+				gatewayClass: gatewayv1.GatewayClass{
+					Spec: gatewayv1.GatewayClassSpec{ControllerName: gatewayv1.GatewayController(ControllerClassName)},
+				},
+				listenerSets: []gatewayv1.ListenerSet{listenerSet},
+			}
+			data.effectiveListeners = effectiveListenersForGateway(data.gateway, data.listenerSets)
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(&route, &grpcRoute, &tcpRoute, &udpRoute, &tlsRoute).
+				Build()
+
+			counts, err := listenerSetAttachedRouteCounts(t.Context(), k8sClient, data, listenerSet)
+
+			require.NoError(t, err)
+			assert.Equal(t, int32(1), counts[httpListener])
+			assert.Equal(t, int32(1), counts[grpcListener])
+			assert.Equal(t, int32(1), counts[tcpListener])
+			assert.Equal(t, int32(1), counts[udpListener])
+			assert.Equal(t, int32(1), counts[tlsListener])
+		})
+
+		t.Run("returns attached route count list errors", func(t *testing.T) {
+			wantErr := errors.New("list failed")
+			data := &resolvedGatewayDetails{}
+			listenerSet := gatewayv1.ListenerSet{}
+			testCases := []struct {
+				name string
+				run  func(context.Context, k8sClient, *resolvedGatewayDetails, gatewayv1.ListenerSet) error
+			}{
+				{
+					name: "HTTPRoute",
+					run: func(ctx context.Context,
+						k8sClient k8sClient,
+						data *resolvedGatewayDetails,
+						listenerSet gatewayv1.ListenerSet,
+					) error {
+						counts := map[gatewayv1.SectionName]int32{}
+						return addListenerSetHTTPRouteCounts(ctx, k8sClient, data, listenerSet, counts)
+					},
+				},
+				{
+					name: "GRPCRoute",
+					run: func(ctx context.Context,
+						k8sClient k8sClient,
+						data *resolvedGatewayDetails,
+						listenerSet gatewayv1.ListenerSet,
+					) error {
+						counts := map[gatewayv1.SectionName]int32{}
+						return addListenerSetGRPCRouteCounts(ctx, k8sClient, data, listenerSet, counts)
+					},
+				},
+				{
+					name: "TCPRoute",
+					run: func(ctx context.Context,
+						k8sClient k8sClient,
+						data *resolvedGatewayDetails,
+						listenerSet gatewayv1.ListenerSet,
+					) error {
+						counts := map[gatewayv1.SectionName]int32{}
+						return addListenerSetTCPRouteCounts(ctx, k8sClient, data, listenerSet, counts)
+					},
+				},
+				{
+					name: "UDPRoute",
+					run: func(ctx context.Context,
+						k8sClient k8sClient,
+						data *resolvedGatewayDetails,
+						listenerSet gatewayv1.ListenerSet,
+					) error {
+						counts := map[gatewayv1.SectionName]int32{}
+						return addListenerSetUDPRouteCounts(ctx, k8sClient, data, listenerSet, counts)
+					},
+				},
+				{
+					name: "TLSRoute",
+					run: func(ctx context.Context,
+						k8sClient k8sClient,
+						data *resolvedGatewayDetails,
+						listenerSet gatewayv1.ListenerSet,
+					) error {
+						counts := map[gatewayv1.SectionName]int32{}
+						return addListenerSetTLSRouteCounts(ctx, k8sClient, data, listenerSet, counts)
+					},
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					mockClient := NewMockk8sClient(t)
+					mockClient.EXPECT().List(t.Context(), mock.Anything).Return(wantErr)
+
+					err := tc.run(t.Context(), mockClient, data, listenerSet)
+
+					require.ErrorIs(t, err, wantErr)
+				})
+			}
+		})
+
+		t.Run("listenerSetAttachedRouteCounts returns staged list errors", func(t *testing.T) {
+			wantErr := errors.New("list failed")
+			data := &resolvedGatewayDetails{}
+			listenerSet := gatewayv1.ListenerSet{}
+			for _, failAtCall := range []int{1, 2, 3, 4, 5} {
+				t.Run(fmt.Sprintf("call %d", failAtCall), func(t *testing.T) {
+					mockClient := NewMockk8sClient(t)
+					call := 0
+					mockClient.EXPECT().
+						List(t.Context(), mock.Anything).
+						RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+							call++
+							if call == failAtCall {
+								return wantErr
+							}
+							reflect.ValueOf(list).Elem().Set(reflect.Zero(reflect.ValueOf(list).Elem().Type()))
+							return nil
+						}).
+						Times(failAtCall)
+
+					counts, err := listenerSetAttachedRouteCounts(t.Context(), mockClient, data, listenerSet)
+
+					require.ErrorIs(t, err, wantErr)
+					assert.Nil(t, counts)
+				})
+			}
+		})
+
+		t.Run("ignores attached route counts for nonmatching parent refs", func(t *testing.T) {
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			listenerName := gatewayv1.SectionName("http")
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					Listeners: []gatewayv1.ListenerEntry{{
+						Name:     listenerName,
+						Port:     80,
+						Protocol: gatewayv1.HTTPProtocolType,
+					}},
+				},
+			}
+			data := &resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}},
+				effectiveListeners: effectiveListenersForGateway(
+					gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}},
+					[]gatewayv1.ListenerSet{listenerSet},
+				),
+			}
+			counts := map[gatewayv1.SectionName]int32{}
+			statusParentRef := gatewayv1.ParentReference{Kind: &listenerSetKind, Name: "extra"}
+			otherParentRef := gatewayv1.ParentReference{Kind: &listenerSetKind, Name: "other"}
+
+			addListenerSetRouteCountForParentRef(
+				data,
+				listenerSet,
+				counts,
+				"apps",
+				statusParentRef,
+				otherParentRef,
+				func(gatewayv1.ParentReference, gatewayv1.Listener) bool { return true },
+			)
+
+			assert.Zero(t, counts[listenerName])
+			_, found := listenerSetEntryForEffectiveListener(data.gateway, listenerSet, "missing")
+			assert.False(t, found)
+
+			addListenerSetRouteCounts(
+				data,
+				listenerSet,
+				counts,
+				"apps",
+				[]gatewayv1.RouteParentStatus{{ParentRef: statusParentRef}},
+				[]gatewayv1.ParentReference{statusParentRef},
+				func(gatewayv1.ParentReference, gatewayv1.Listener) bool { return true },
+			)
+			assert.Zero(t, counts[listenerName])
 		})
 	})
 
@@ -2016,6 +2375,7 @@ func TestGatewayModelImpl(t *testing.T) {
 			Return(nil).
 			Once()
 		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		expectEmptyListenerSetRouteCountLists(t, mockClient, len(data.listenerSets))
 		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
 		mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
 		mockStatusWriter.EXPECT().Update(t.Context(), mock.Anything).Return(wantErr).Once()
@@ -2090,7 +2450,7 @@ func TestGatewayModelImpl(t *testing.T) {
 	})
 
 	t.Run(
-		"populateGatewaySecrets rejects cross namespace ListenerSet certificate without ReferenceGrant",
+		"populateGatewaySecrets isolates cross namespace ListenerSet certificate without ReferenceGrant",
 		func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newGatewayModel(deps)
@@ -2123,12 +2483,92 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			err := model.populateGatewaySecrets(t.Context(), data)
 
-			var statusErr *resourceStatusError
-			require.ErrorAs(t, err, &statusErr)
-			assert.Equal(t, string(gatewayv1.GatewayReasonInvalidParameters), statusErr.reason)
-			assert.Contains(t, statusErr.message, "certificateRef certs/tls-cert is not permitted by a ReferenceGrant")
+			require.NoError(t, err)
+			require.Len(t, data.effectiveListeners, 1)
+			assert.True(t, data.effectiveListeners[0].unsupported)
+			assert.Equal(t, gatewayv1.ListenerReasonRefNotPermitted, data.effectiveListeners[0].unsupportedReason)
+			assert.Contains(
+				t,
+				data.effectiveListeners[0].unsupportedMessage,
+				"certificateRef certs/tls-cert is not permitted by a ReferenceGrant",
+			)
 		},
 	)
+
+	t.Run("populateGatewaySecrets returns Gateway effective listener secret errors", func(t *testing.T) {
+		deps := newMockDeps(t)
+		model := newGatewayModel(deps)
+		data := &resolvedGatewayDetails{
+			gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}},
+			effectiveListeners: []effectiveListener{{
+				sourceKind:      effectiveListenerSourceGateway,
+				sourceNamespace: "infra",
+				listener: gatewayv1.Listener{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "tls-cert"}},
+					},
+				},
+			}},
+		}
+		wantErr := errors.New("secret lookup failed")
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: "infra", Name: "tls-cert"}, mock.Anything).
+			Return(wantErr)
+
+		err := model.populateGatewaySecrets(t.Context(), data)
+
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("populateGatewayListenerSecrets returns ReferenceGrant lookup errors", func(t *testing.T) {
+		deps := newMockDeps(t)
+		model := newGatewayModel(deps)
+		certNamespace := gatewayv1.Namespace("certs")
+		wantErr := errors.New("referencegrant list failed")
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockClient.EXPECT().
+			List(t.Context(), mock.AnythingOfType("*v1beta1.ReferenceGrantList"), mock.Anything).
+			Return(wantErr)
+
+		err := model.populateGatewayListenerSecrets(
+			t.Context(),
+			&resolvedGatewayDetails{},
+			gatewayv1.Kind(effectiveListenerSourceListenerSet),
+			"apps",
+			gatewayv1.Listener{
+				Name:     "https",
+				Protocol: gatewayv1.HTTPSProtocolType,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{{
+						Namespace: &certNamespace,
+						Name:      "tls-cert",
+					}},
+				},
+			},
+		)
+
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("markListenerSetSecretError only isolates ListenerSet listener errors", func(t *testing.T) {
+		gatewayListener := effectiveListener{sourceKind: effectiveListenerSourceGateway}
+		assert.False(t, markListenerSetSecretError(&gatewayListener, errors.New("gateway failed")))
+		assert.False(t, gatewayListener.unsupported)
+
+		listenerSetListener := effectiveListener{sourceKind: effectiveListenerSourceListenerSet}
+		handled := markListenerSetSecretError(&listenerSetListener, &resourceStatusError{
+			reason:  string(gatewayv1.GatewayReasonInvalidParameters),
+			message: "certificateRef certs/tls-cert is not permitted by a ReferenceGrant",
+		})
+
+		assert.True(t, handled)
+		assert.True(t, listenerSetListener.unsupported)
+		assert.Equal(t, gatewayv1.ListenerReasonRefNotPermitted, listenerSetListener.unsupportedReason)
+		assert.Contains(t, listenerSetListener.unsupportedMessage, "not permitted")
+	})
 }
 
 func TestProgrammedGatewayCertificatesAnnotation(t *testing.T) {

--- a/internal/app/grpcroute_controller.go
+++ b/internal/app/grpcroute_controller.go
@@ -113,6 +113,7 @@ func (r *GRPCRouteController) reconcileResolvedRoute(
 	if err = r.grpcRouteModel.setProgrammed(ctx, setGRPCRouteProgrammedParams{
 		gatewayClass:          resolvedData.gatewayDetails.gatewayClass,
 		gateway:               resolvedData.gatewayDetails.gateway,
+		config:                resolvedData.gatewayDetails.config,
 		grpcRoute:             *acceptedRoute,
 		matchedRef:            resolvedData.matchedRef,
 		programmedPolicyRules: programResult.programmedPolicyRules,

--- a/internal/app/grpcroute_controller.go
+++ b/internal/app/grpcroute_controller.go
@@ -117,6 +117,7 @@ func (r *GRPCRouteController) reconcileResolvedRoute(
 		grpcRoute:             *acceptedRoute,
 		matchedRef:            resolvedData.matchedRef,
 		programmedPolicyRules: programResult.programmedPolicyRules,
+		programmedBackendSets: programResult.programmedBackendSets,
 	}); err != nil {
 		return false, fmt.Errorf("failed to set programmed status: %w", err)
 	}

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -439,6 +439,36 @@ func TestGRPCRouteController(t *testing.T) {
 		assertDriftRequeue(t, got, 2*time.Minute)
 	})
 
+	t.Run("wraps rejected status update errors", func(t *testing.T) {
+		route := makeRoute()
+		resolved := makeResolved(route)
+		statusErr := newGRPCRouteRefNotPermittedStatusError("cross namespace backend is not permitted")
+		wantErr := errors.New("reject failed")
+		routeModel := fakeGRPCRouteModel{
+			resolveRequestFunc: func(
+				_ context.Context,
+				_ reconcile.Request,
+			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+				return resolvedMap(route, resolved), nil
+			},
+			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
+			acceptRouteFunc: func(_ context.Context, details resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
+				return &details.grpcRoute, nil
+			},
+			resolveBackendRefsFunc: func(context.Context, resolveGRPCBackendRefsParams) (map[string]corev1.Service, error) {
+				return nil, statusErr
+			},
+			setRejectedFunc: func(context.Context, resolvedGRPCRouteDetails, grpcRouteStatusError) error {
+				return wantErr
+			},
+		}
+
+		_, err := newController(routeModel, NewMockhttpBackendModel(t)).Reconcile(t.Context(), reconcile.Request{})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to reject route")
+	})
+
 	t.Run("deprovisions deleted routes", func(t *testing.T) {
 		route := makeRoute()
 		now := metav1.Now()

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 type fakeGRPCRouteModel struct {
-	resolveRequestFunc      func(context.Context, reconcile.Request) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error)
+	resolveRequestFunc      func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedGRPCRouteDetails, error)
 	acceptRouteFunc         func(context.Context, resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error)
 	resolveBackendRefsFunc  func(context.Context, resolveGRPCBackendRefsParams) (map[string]corev1.Service, error)
 	isProgrammingRequiredFn func(resolvedGRPCRouteDetails) bool
@@ -34,7 +34,7 @@ type fakeGRPCRouteModel struct {
 func (m fakeGRPCRouteModel) resolveRequest(
 	ctx context.Context,
 	req reconcile.Request,
-) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 	return m.resolveRequestFunc(ctx, req)
 }
 
@@ -145,9 +145,9 @@ func TestGRPCRouteController(t *testing.T) {
 	newController := func(routeModel grpcRouteModel, backendModel httpBackendModel) *GRPCRouteController {
 		return newControllerWithDriftInterval(routeModel, backendModel, 2*time.Minute)
 	}
-	resolvedMap := func(route gatewayv1.GRPCRoute, resolved resolvedGRPCRouteDetails) map[apitypes.NamespacedName]resolvedGRPCRouteDetails {
-		return map[apitypes.NamespacedName]resolvedGRPCRouteDetails{
-			{Namespace: route.Namespace, Name: "gw"}: resolved,
+	resolvedMap := func(route gatewayv1.GRPCRoute, resolved resolvedGRPCRouteDetails) map[routeParentResultKey]resolvedGRPCRouteDetails {
+		return map[routeParentResultKey]resolvedGRPCRouteDetails{
+			gatewayParentResultKey(apitypes.NamespacedName{Namespace: route.Namespace, Name: "gw"}): resolved,
 		}
 	}
 
@@ -175,7 +175,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
@@ -218,7 +218,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return false },
@@ -250,7 +250,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return false },
@@ -295,7 +295,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			acceptRouteFunc: func(_ context.Context, details resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
@@ -319,7 +319,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
@@ -347,7 +347,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			acceptRouteFunc: func(context.Context, resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
@@ -367,7 +367,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			acceptRouteFunc: func(context.Context, resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
@@ -391,7 +391,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
@@ -416,7 +416,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
@@ -448,7 +448,7 @@ func TestGRPCRouteController(t *testing.T) {
 			resolveRequestFunc: func(
 				_ context.Context,
 				_ reconcile.Request,
-			) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
@@ -475,7 +475,7 @@ func TestGRPCRouteController(t *testing.T) {
 		route.DeletionTimestamp = &now
 		resolved := makeResolved(route)
 		routeModel := fakeGRPCRouteModel{
-			resolveRequestFunc: func(context.Context, reconcile.Request) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			resolveRequestFunc: func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			deprovisionRouteFunc: func(_ context.Context, params deprovisionGRPCRouteParams) error {
@@ -497,7 +497,7 @@ func TestGRPCRouteController(t *testing.T) {
 		resolved := makeResolved(route)
 		wantErr := errors.New(faker.New().Lorem().Sentence(10))
 		routeModel := fakeGRPCRouteModel{
-			resolveRequestFunc: func(context.Context, reconcile.Request) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			resolveRequestFunc: func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			deprovisionRouteFunc: func(context.Context, deprovisionGRPCRouteParams) error {
@@ -513,7 +513,7 @@ func TestGRPCRouteController(t *testing.T) {
 	t.Run("returns resolve request errors", func(t *testing.T) {
 		wantErr := errors.New(faker.New().Lorem().Sentence(10))
 		routeModel := fakeGRPCRouteModel{
-			resolveRequestFunc: func(context.Context, reconcile.Request) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			resolveRequestFunc: func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return nil, wantErr
 			},
 		}
@@ -525,8 +525,8 @@ func TestGRPCRouteController(t *testing.T) {
 
 	t.Run("returns no requeue when no routes resolve", func(t *testing.T) {
 		routeModel := fakeGRPCRouteModel{
-			resolveRequestFunc: func(context.Context, reconcile.Request) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
-				return map[apitypes.NamespacedName]resolvedGRPCRouteDetails{}, nil
+			resolveRequestFunc: func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
+				return map[routeParentResultKey]resolvedGRPCRouteDetails{}, nil
 			},
 		}
 
@@ -542,7 +542,7 @@ func TestGRPCRouteController(t *testing.T) {
 		wantErr := errors.New(faker.New().Lorem().Sentence(10))
 		backendModel := NewMockhttpBackendModel(t)
 		routeModel := fakeGRPCRouteModel{
-			resolveRequestFunc: func(context.Context, reconcile.Request) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			resolveRequestFunc: func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return false },
@@ -565,7 +565,7 @@ func TestGRPCRouteController(t *testing.T) {
 		resolved := makeResolved(route)
 		wantErr := errors.New(faker.New().Lorem().Sentence(10))
 		routeModel := fakeGRPCRouteModel{
-			resolveRequestFunc: func(context.Context, reconcile.Request) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+			resolveRequestFunc: func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 				return resolvedMap(route, resolved), nil
 			},
 			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -59,6 +59,7 @@ type setGRPCRouteProgrammedParams struct {
 	grpcRoute    gatewayv1.GRPCRoute
 	gatewayClass gatewayv1.GatewayClass
 	gateway      gatewayv1.Gateway
+	config       types.GatewayConfig
 	matchedRef   gatewayv1.ParentReference
 
 	programmedPolicyRules []string
@@ -269,6 +270,13 @@ func (m *grpcRouteModelImpl) resolveRequest(
 				makeTargetOnlyParentRef(parentRef),
 				matchedListeners,
 			)
+		}
+	}
+
+	if len(results) == 0 && grpcRoute.DeletionTimestamp != nil &&
+		controllerutil.ContainsFinalizer(&grpcRoute, GRPCRouteProgrammedFinalizer) {
+		if err := m.deprovisionDetachedRoute(ctx, grpcRoute); err != nil {
+			return nil, fmt.Errorf("failed to deprovision detached GRPCRoute %s: %w", req.NamespacedName, err)
 		}
 	}
 
@@ -562,6 +570,39 @@ func (m *grpcRouteModelImpl) deprovisionRoute(
 	return nil
 }
 
+func (m *grpcRouteModelImpl) deprovisionDetachedRoute(
+	ctx context.Context,
+	grpcRoute gatewayv1.GRPCRoute,
+) error {
+	return deprovisionDetachedL7Route(ctx, m.ociLoadBalancerModel, deprovisionDetachedL7RouteParams{
+		route:                 &grpcRoute,
+		routeKind:             "GRPCRoute",
+		policyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
+		loadBalancerID:        grpcRoute.Annotations[L7RouteProgrammedLoadBalancerIDAnnotation],
+		backendRefs:           grpcRouteBackendRefs(grpcRoute),
+		removeFinalizer: func(ctx context.Context) error {
+			return m.removeDetachedGRPCRouteFinalizer(ctx, grpcRoute)
+		},
+	})
+}
+
+func (m *grpcRouteModelImpl) removeDetachedGRPCRouteFinalizer(
+	ctx context.Context,
+	grpcRoute gatewayv1.GRPCRoute,
+) error {
+	routeToUpdate := grpcRoute.DeepCopy()
+	controllerutil.RemoveFinalizer(routeToUpdate, GRPCRouteProgrammedFinalizer)
+	if routeToUpdate.Annotations != nil {
+		delete(routeToUpdate.Annotations, GRPCRouteProgrammedPolicyRulesAnnotation)
+		delete(routeToUpdate.Annotations, L7RouteProgrammedLoadBalancerIDAnnotation)
+	}
+	if err := m.client.Update(ctx, routeToUpdate); err != nil {
+		return fmt.Errorf("failed to update detached GRPCRoute %s/%s after cleanup: %w",
+			routeToUpdate.Namespace, routeToUpdate.Name, err)
+	}
+	return nil
+}
+
 func (m *grpcRouteModelImpl) setRejected(
 	ctx context.Context,
 	routeDetails resolvedGRPCRouteDetails,
@@ -606,7 +647,8 @@ func (m *grpcRouteModelImpl) isProgrammingRequired(details resolvedGRPCRouteDeta
 		conditions:    parentStatus.Conditions,
 		conditionType: string(gatewayv1.RouteConditionResolvedRefs),
 		annotations: map[string]string{
-			GRPCRouteProgrammingRevisionAnnotation: GRPCRouteProgrammingRevisionValue,
+			GRPCRouteProgrammingRevisionAnnotation:    GRPCRouteProgrammingRevisionValue,
+			L7RouteProgrammedLoadBalancerIDAnnotation: details.gatewayDetails.config.Spec.LoadBalancerID,
 		},
 	})
 }
@@ -622,6 +664,7 @@ func (m *grpcRouteModelImpl) setProgrammed(
 		parentStatuses:        grpcRoute.Status.Parents,
 		gatewayClass:          params.gatewayClass,
 		gateway:               params.gateway,
+		loadBalancerID:        params.config.Spec.LoadBalancerID,
 		matchedRef:            params.matchedRef,
 		programmedPolicyRules: params.programmedPolicyRules,
 		programmingAnnotation: GRPCRouteProgrammingRevisionAnnotation,

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -40,9 +40,7 @@ type programGRPCRouteParams struct {
 	matchedListeners []gatewayv1.Listener
 }
 
-type programGRPCRouteResult struct {
-	programmedPolicyRules []string
-}
+type programGRPCRouteResult = programRouteResult
 
 type ensureGRPCListenersProtocolParams struct {
 	config           types.GatewayConfig
@@ -63,6 +61,7 @@ type setGRPCRouteProgrammedParams struct {
 	matchedRef   gatewayv1.ParentReference
 
 	programmedPolicyRules []string
+	programmedBackendSets []string
 }
 
 type grpcRouteModel interface {
@@ -447,40 +446,26 @@ func (m *grpcRouteModelImpl) programRoute(
 	ctx context.Context,
 	params programGRPCRouteParams,
 ) (programGRPCRouteResult, error) {
-	var previousRules []programmedHTTPRoutePolicyRule
-	if prevPolicyRulesStr, ok := params.grpcRoute.Annotations[GRPCRouteProgrammedPolicyRulesAnnotation]; ok {
-		previousRules = parseProgrammedHTTPRoutePolicyRules(prevPolicyRulesStr)
-	}
-
-	routePolicyParams := programL7RoutePolicyParams{
-		loadBalancerID:      params.config.Spec.LoadBalancerID,
-		gateway:             params.gateway,
-		config:              params.config,
-		routeName:           params.grpcRoute.Name,
-		routeNamespace:      params.grpcRoute.Namespace,
-		backendRefs:         grpcRouteBackendRefs(params.grpcRoute),
-		knownBackends:       params.knownBackends,
-		matchedListeners:    params.matchedListeners,
-		previousPolicyRules: previousRules,
-		backendTLSPolicy:    m.backendTLSPolicy,
-		backendTLSDisabled:  m.backendTLSDisabled,
-		ruleCount:           len(params.grpcRoute.Spec.Rules),
+	return programL7RouteResult(ctx, m.ociLoadBalancerModel, programL7RouteParams{
+		route:                 &params.grpcRoute,
+		loadBalancerID:        params.config.Spec.LoadBalancerID,
+		gateway:               params.gateway,
+		config:                params.config,
+		backendRefs:           grpcRouteBackendRefs(params.grpcRoute),
+		knownBackends:         params.knownBackends,
+		matchedListeners:      params.matchedListeners,
+		backendTLSPolicy:      m.backendTLSPolicy,
+		backendTLSDisabled:    m.backendTLSDisabled,
+		ruleCount:             len(params.grpcRoute.Spec.Rules),
+		policyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
+		backendSetsAnnotation: GRPCRouteProgrammedBackendSetsAnnotation,
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeGRPCRoutingRule(ctx, makeGRPCRoutingRuleParams{
 				grpcRoute:          params.grpcRoute,
 				grpcRouteRuleIndex: ruleIndex,
 			})
 		},
-	}
-
-	programmedPolicyRules, err := programL7RoutePolicy(ctx, m.ociLoadBalancerModel, routePolicyParams)
-	if err != nil {
-		return programGRPCRouteResult{}, err
-	}
-
-	return programGRPCRouteResult{
-		programmedPolicyRules: programmedPolicyRules,
-	}, nil
+	})
 }
 
 func (m *grpcRouteModelImpl) ensureGRPCListenersProtocol(
@@ -667,9 +652,11 @@ func (m *grpcRouteModelImpl) setProgrammed(
 		loadBalancerID:        params.config.Spec.LoadBalancerID,
 		matchedRef:            params.matchedRef,
 		programmedPolicyRules: params.programmedPolicyRules,
+		programmedBackendSets: params.programmedBackendSets,
 		programmingAnnotation: GRPCRouteProgrammingRevisionAnnotation,
 		programmingRevision:   GRPCRouteProgrammingRevisionValue,
 		policyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
+		backendSetsAnnotation: GRPCRouteProgrammedBackendSetsAnnotation,
 		finalizer:             GRPCRouteProgrammedFinalizer,
 	})
 	if err != nil {

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -143,15 +143,7 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 	parentRef gatewayv1.ParentReference,
 	defaultNamespace string,
 ) (*resolvedGatewayDetails, []gatewayv1.Listener, error) {
-	var resolvedGatewayData resolvedGatewayDetails
-	gatewayNamespace := defaultNamespace
-	if parentRef.Namespace != nil {
-		gatewayNamespace = string(lo.FromPtr(parentRef.Namespace))
-	}
-	parentName := apitypes.NamespacedName{
-		Namespace: gatewayNamespace,
-		Name:      string(parentRef.Name),
-	}
+	parentName := parentRefTargetName(parentRef, defaultNamespace)
 	m.logger.DebugContext(ctx, "Resolving parent for GRPCRoute",
 		slog.String("parentName", parentName.String()),
 		slog.Any("parentRef", parentRef),
@@ -161,9 +153,13 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 		}.String()),
 	)
 
-	gatewayResolved, err := m.gatewayModel.resolveReconcileRequest(ctx, reconcile.Request{
-		NamespacedName: parentName,
-	}, &resolvedGatewayData)
+	resolvedGatewayData, gatewayResolved, err := resolveL7ParentGateway(
+		ctx,
+		m.client,
+		m.gatewayModel,
+		parentRef,
+		defaultNamespace,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve gateway %s for route %s/%s: %w",
 			parentName.String(), grpcRoute.Namespace, grpcRoute.Name, err)
@@ -174,10 +170,14 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 
 	if parentRef.SectionName != nil {
 		sectionName := *parentRef.SectionName
-		matchingListeners := lo.Filter(
-			resolvedGatewayData.gateway.Spec.Listeners,
-			func(listener gatewayv1.Listener, _ int) bool {
-				return listener.Name == sectionName && grpcRouteListenerProtocolSupported(listener.Protocol)
+		matchingListeners := effectiveListenersForParentRef(
+			resolvedGatewayData,
+			parentRef,
+			defaultNamespace,
+			func(ref gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+				return ref.SectionName != nil &&
+					listener.Name == sectionName &&
+					grpcRouteListenerProtocolSupported(listener.Protocol)
 			},
 		)
 		if len(matchingListeners) == 0 {
@@ -186,9 +186,11 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 		return &resolvedGatewayData, matchingListeners, nil
 	}
 
-	matchingListeners := lo.Filter(
-		resolvedGatewayData.gateway.Spec.Listeners,
-		func(listener gatewayv1.Listener, _ int) bool {
+	matchingListeners := effectiveListenersForParentRef(
+		resolvedGatewayData,
+		parentRef,
+		defaultNamespace,
+		func(_ gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
 			return grpcRouteListenerProtocolSupported(listener.Protocol)
 		},
 	)
@@ -278,8 +280,9 @@ func (m *grpcRouteModelImpl) acceptRoute(
 	routeDetails resolvedGRPCRouteDetails,
 ) (*gatewayv1.GRPCRoute, error) {
 	winner, conflicted, err := checkL7RouteConflict(ctx, checkL7RouteConflictParams{
-		gateway:          routeDetails.gatewayDetails.gateway,
-		matchedListeners: routeDetails.matchedListeners,
+		gateway:            routeDetails.gatewayDetails.gateway,
+		effectiveListeners: routeDetails.gatewayDetails.effectiveListeners,
+		matchedListeners:   routeDetails.matchedListeners,
 		current: l7RouteCandidate{
 			identity: l7RouteIdentity{
 				kind:              l7GRPCRouteKind,

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -26,6 +26,7 @@ type resolvedGRPCRouteDetails struct {
 	grpcRoute        gatewayv1.GRPCRoute
 	matchedRef       gatewayv1.ParentReference
 	matchedListeners []gatewayv1.Listener
+	attachmentDenied bool
 }
 
 type resolveGRPCBackendRefsParams struct {
@@ -68,7 +69,7 @@ type grpcRouteModel interface {
 	resolveRequest(
 		ctx context.Context,
 		req reconcile.Request,
-	) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error)
+	) (map[routeParentResultKey]resolvedGRPCRouteDetails, error)
 
 	acceptRoute(
 		ctx context.Context,
@@ -142,7 +143,7 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 	grpcRoute gatewayv1.GRPCRoute,
 	parentRef gatewayv1.ParentReference,
 	defaultNamespace string,
-) (*resolvedGatewayDetails, []gatewayv1.Listener, error) {
+) (*resolvedGatewayDetails, []gatewayv1.Listener, bool, error) {
 	parentName := parentRefTargetName(parentRef, defaultNamespace)
 	m.logger.DebugContext(ctx, "Resolving parent for GRPCRoute",
 		slog.String("parentName", parentName.String()),
@@ -161,11 +162,11 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 		defaultNamespace,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to resolve gateway %s for route %s/%s: %w",
+		return nil, nil, false, fmt.Errorf("failed to resolve gateway %s for route %s/%s: %w",
 			parentName.String(), grpcRoute.Namespace, grpcRoute.Name, err)
 	}
 	if !gatewayResolved {
-		return nil, nil, nil
+		return nil, nil, false, nil
 	}
 
 	if parentRef.SectionName != nil {
@@ -181,9 +182,20 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 			},
 		)
 		if len(matchingListeners) == 0 {
-			return nil, nil, nil
+			return nil, nil, false, nil
 		}
-		return &resolvedGatewayData, matchingListeners, nil
+		allowedListeners, allowErr := allowedRouteListeners(
+			ctx,
+			m.client,
+			resolvedGatewayData,
+			grpcRoute.Namespace,
+			matchingListeners,
+			"GRPCRoute",
+		)
+		if allowErr != nil {
+			return nil, nil, false, allowErr
+		}
+		return &resolvedGatewayData, allowedListeners, len(allowedListeners) == 0, nil
 	}
 
 	matchingListeners := effectiveListenersForParentRef(
@@ -194,7 +206,21 @@ func (m *grpcRouteModelImpl) resolveRouteParentRefData(
 			return grpcRouteListenerProtocolSupported(listener.Protocol)
 		},
 	)
-	return &resolvedGatewayData, matchingListeners, nil
+	if len(matchingListeners) == 0 {
+		return nil, nil, false, nil
+	}
+	allowedListeners, allowErr := allowedRouteListeners(
+		ctx,
+		m.client,
+		resolvedGatewayData,
+		grpcRoute.Namespace,
+		matchingListeners,
+		"GRPCRoute",
+	)
+	if allowErr != nil {
+		return nil, nil, false, allowErr
+	}
+	return &resolvedGatewayData, allowedListeners, len(allowedListeners) == 0, nil
 }
 
 func grpcRouteListenerProtocolSupported(protocol gatewayv1.ProtocolType) bool {
@@ -203,16 +229,14 @@ func grpcRouteListenerProtocolSupported(protocol gatewayv1.ProtocolType) bool {
 
 func (m *grpcRouteModelImpl) aggregateRouteParentRefData(
 	ctx context.Context,
-	results map[apitypes.NamespacedName]resolvedGRPCRouteDetails,
+	results map[routeParentResultKey]resolvedGRPCRouteDetails,
 	grpcRoute gatewayv1.GRPCRoute,
 	gatewayDetails resolvedGatewayDetails,
 	matchedRef gatewayv1.ParentReference,
 	matchedListeners []gatewayv1.Listener,
+	attachmentDenied bool,
 ) {
-	parentName := apitypes.NamespacedName{
-		Namespace: gatewayDetails.gateway.Namespace,
-		Name:      gatewayDetails.gateway.Name,
-	}
+	parentName := directParentResultKey(matchedRef, grpcRoute.Namespace)
 
 	if existingResult, found := results[parentName]; found {
 		existingResult.matchedListeners = lo.UniqBy(
@@ -221,6 +245,7 @@ func (m *grpcRouteModelImpl) aggregateRouteParentRefData(
 				return listener.Name
 			},
 		)
+		existingResult.attachmentDenied = existingResult.attachmentDenied && attachmentDenied
 		results[parentName] = existingResult
 		m.logger.DebugContext(ctx, "Appended/merged listeners for existing GRPCRoute gateway result",
 			slog.String("parentName", parentName.String()),
@@ -234,24 +259,25 @@ func (m *grpcRouteModelImpl) aggregateRouteParentRefData(
 		gatewayDetails:   gatewayDetails,
 		matchedRef:       matchedRef,
 		matchedListeners: matchedListeners,
+		attachmentDenied: attachmentDenied,
 	}
 }
 
 func (m *grpcRouteModelImpl) resolveRequest(
 	ctx context.Context,
 	req reconcile.Request,
-) (map[apitypes.NamespacedName]resolvedGRPCRouteDetails, error) {
+) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
 	var grpcRoute gatewayv1.GRPCRoute
 	if err := m.client.Get(ctx, req.NamespacedName, &grpcRoute); err != nil {
 		if apierrors.IsNotFound(err) {
-			return map[apitypes.NamespacedName]resolvedGRPCRouteDetails{}, nil
+			return map[routeParentResultKey]resolvedGRPCRouteDetails{}, nil
 		}
 		return nil, fmt.Errorf("failed to get GRPCRoute %s: %w", req.NamespacedName.String(), err)
 	}
 
-	results := make(map[apitypes.NamespacedName]resolvedGRPCRouteDetails)
+	results := make(map[routeParentResultKey]resolvedGRPCRouteDetails)
 	for _, parentRef := range grpcRoute.Spec.ParentRefs {
-		resolvedGatewayData, matchedListeners, err := m.resolveRouteParentRefData(
+		resolvedGatewayData, matchedListeners, attachmentDenied, err := m.resolveRouteParentRefData(
 			ctx,
 			grpcRoute,
 			parentRef,
@@ -268,6 +294,7 @@ func (m *grpcRouteModelImpl) resolveRequest(
 				*resolvedGatewayData,
 				makeTargetOnlyParentRef(parentRef),
 				matchedListeners,
+				attachmentDenied,
 			)
 		}
 	}
@@ -286,6 +313,14 @@ func (m *grpcRouteModelImpl) acceptRoute(
 	ctx context.Context,
 	routeDetails resolvedGRPCRouteDetails,
 ) (*gatewayv1.GRPCRoute, error) {
+	if routeDetails.attachmentDenied {
+		return nil, m.rejectRoute(ctx, routeDetails, fmt.Sprintf(
+			"matched listeners do not allow GRPCRoute %s/%s",
+			routeDetails.grpcRoute.Namespace,
+			routeDetails.grpcRoute.Name,
+		))
+	}
+
 	winner, conflicted, err := checkL7RouteConflict(ctx, checkL7RouteConflictParams{
 		gateway:            routeDetails.gatewayDetails.gateway,
 		effectiveListeners: routeDetails.gatewayDetails.effectiveListeners,

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1263,6 +1263,11 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			[]string{fmt.Sprintf("%s/%s", listener.Name, lo.FromPtr(routingRule.Name))},
 			got.programmedPolicyRules,
 		)
+		assert.Equal(
+			t,
+			[]string{ociBackendSetNameFromBackendObjectRef(route.Namespace, backendRef.BackendObjectReference)},
+			got.programmedBackendSets,
+		)
 	})
 
 	t.Run("programRoute clears backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
@@ -1411,12 +1416,15 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			}}
 		})
 		programmedRules := []string{"grpc/rule-" + fake.Lorem().Word()}
+		programmedBackendSets := []string{"backend-set-" + fake.Lorem().Word()}
 
 		resourcesModel.EXPECT().setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
 			return params.conditionType == string(gatewayv1.RouteConditionResolvedRefs) &&
 				params.finalizer == GRPCRouteProgrammedFinalizer &&
 				params.annotations[GRPCRouteProgrammingRevisionAnnotation] == GRPCRouteProgrammingRevisionValue &&
 				params.annotations[GRPCRouteProgrammedPolicyRulesAnnotation] == strings.Join(programmedRules, ",") &&
+				params.annotations[GRPCRouteProgrammedBackendSetsAnnotation] ==
+					strings.Join(programmedBackendSets, ",") &&
 				params.annotations[L7RouteProgrammedLoadBalancerIDAnnotation] == config.Spec.LoadBalancerID
 		})).Return(nil).Once()
 
@@ -1427,6 +1435,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			config:                config,
 			matchedRef:            parentRef,
 			programmedPolicyRules: programmedRules,
+			programmedBackendSets: programmedBackendSets,
 		})
 
 		require.NoError(t, err)

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -105,6 +106,8 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			route := makeGRPCRoute()
 			parentRef := gatewayv1.ParentReference{Name: "gw"}
 			gatewayData := makeResolvedGateway()
+			gatewayData.gateway.Namespace = route.Namespace
+			gatewayData.gateway.Name = string(parentRef.Name)
 
 			gatewayModel.EXPECT().
 				resolveReconcileRequest(t.Context(), mock.Anything, mock.Anything).
@@ -135,6 +138,8 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			parentRef := gatewayv1.ParentReference{Name: "gw", SectionName: &sectionName}
 			grpcListener := gatewayv1.Listener{Name: sectionName, Port: 50051, Protocol: gatewayv1.HTTPSProtocolType}
 			gatewayData := makeResolvedGateway(grpcListener, gatewayv1.Listener{Name: "web", Port: 443})
+			gatewayData.gateway.Namespace = route.Namespace
+			gatewayData.gateway.Name = string(parentRef.Name)
 
 			gatewayModel.EXPECT().
 				resolveReconcileRequest(t.Context(), mock.Anything, mock.Anything).
@@ -149,6 +154,83 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			assert.Equal(t, []gatewayv1.Listener{grpcListener}, gotListeners)
 		})
 
+		t.Run("resolves ListenerSet parent refs by logical section name", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGRPCRouteModel(deps)
+			gatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			route := makeGRPCRoute()
+			route.Namespace = "apps"
+			sectionName := gatewayv1.SectionName("grpc")
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			parentNamespace := gatewayv1.Namespace("infra")
+			parentRef := gatewayv1.ParentReference{
+				Kind:        &listenerSetKind,
+				Name:        "extra",
+				SectionName: &sectionName,
+			}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(parentRef.Name)},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Namespace: &parentNamespace,
+						Name:      "edge",
+					},
+					Listeners: []gatewayv1.ListenerEntry{{
+						Name:     sectionName,
+						Port:     443,
+						Protocol: gatewayv1.HTTPSProtocolType,
+					}},
+				},
+			}
+			fromAll := gatewayv1.NamespacesFromAll
+			gatewayData := makeResolvedGateway()
+			gatewayData.gateway.Namespace = string(parentNamespace)
+			gatewayData.gateway.Name = "edge"
+			gatewayData.gateway.Spec.Listeners = nil
+			gatewayData.gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+			}
+
+			setupClientGet(t, deps.K8sClient, apitypes.NamespacedName{
+				Namespace: listenerSet.Namespace,
+				Name:      listenerSet.Name,
+			}, listenerSet)
+			gatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), reconcile.Request{
+					NamespacedName: apitypes.NamespacedName{Namespace: "infra", Name: "edge"},
+				}, mock.Anything).
+				RunAndReturn(func(_ context.Context, _ reconcile.Request, receiver *resolvedGatewayDetails) (bool, error) {
+					*receiver = gatewayData
+					return true, nil
+				})
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).
+						Elem().
+						FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.ListenerSet{listenerSet}))
+					return nil
+				})
+			setupClientGet(t, mockClient, apitypes.NamespacedName{Name: listenerSet.Namespace}, corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: listenerSet.Namespace},
+			})
+
+			gotGatewayData, gotListeners, err := model.resolveRouteParentRefData(
+				t.Context(),
+				route,
+				parentRef,
+				route.Namespace,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, gotGatewayData)
+			require.Len(t, gotListeners, 1)
+			assert.NotEqual(t, sectionName, gotListeners[0].Name)
+			assert.Equal(t, gatewayv1.HTTPSProtocolType, gotListeners[0].Protocol)
+		})
+
 		t.Run("returns nil when section listener protocol is unsupported", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newGRPCRouteModel(deps)
@@ -161,6 +243,8 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				Port:     50051,
 				Protocol: gatewayv1.TCPProtocolType,
 			})
+			gatewayData.gateway.Namespace = route.Namespace
+			gatewayData.gateway.Name = string(parentRef.Name)
 
 			gatewayModel.EXPECT().
 				resolveReconcileRequest(t.Context(), mock.Anything, mock.Anything).
@@ -300,6 +384,8 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				gatewayv1.Listener{Name: grpcSection, Port: 50051},
 				gatewayv1.Listener{Name: httpsSection, Port: 443},
 			)
+			gatewayData.gateway.Namespace = route.Namespace
+			gatewayData.gateway.Name = "gw"
 
 			k8sClient.EXPECT().Get(t.Context(), req.NamespacedName, mock.Anything).
 				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -335,6 +335,91 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 	})
 
 	t.Run("resolveRequest", func(t *testing.T) {
+		t.Run("cleans deleting programmed route with no resolved parent", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newGRPCRouteModel(deps)
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			loadBalancerID := "lb-" + fake.UUID().V4()
+			listenerName := "listener-" + fake.Lorem().Word()
+			ruleName := "rule-" + fake.Lorem().Word()
+			deleteTime := metav1.Now()
+			backendRef := makeGRPCBackendRef()
+			route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+				route.Spec.Rules = []gatewayv1.GRPCRouteRule{{BackendRefs: []gatewayv1.GRPCBackendRef{backendRef}}}
+				route.DeletionTimestamp = &deleteTime
+				route.Finalizers = []string{GRPCRouteProgrammedFinalizer}
+				route.Annotations = map[string]string{
+					GRPCRouteProgrammedPolicyRulesAnnotation:  listenerName + "/" + ruleName,
+					L7RouteProgrammedLoadBalancerIDAnnotation: loadBalancerID,
+				}
+			})
+			req := reconcile.Request{
+				NamespacedName: apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name},
+			}
+
+			k8sClient.EXPECT().Get(t.Context(), req.NamespacedName, mock.AnythingOfType("*v1.GRPCRoute")).
+				Run(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) {
+					*obj.(*gatewayv1.GRPCRoute) = route
+				}).
+				Return(nil).
+				Once()
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    listenerName,
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{ruleName},
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().deprovisionBackendSet(t.Context(), deprovisionBackendSetParams{
+				loadBalancerID: loadBalancerID,
+				routeNamespace: route.Namespace,
+				backendRef:     backendRef.BackendRef,
+			}).Return(nil).Once()
+			k8sClient.EXPECT().Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updated, ok := obj.(*gatewayv1.GRPCRoute)
+				return ok &&
+					!controllerutil.ContainsFinalizer(updated, GRPCRouteProgrammedFinalizer) &&
+					updated.Annotations[GRPCRouteProgrammedPolicyRulesAnnotation] == "" &&
+					updated.Annotations[L7RouteProgrammedLoadBalancerIDAnnotation] == ""
+			})).Return(nil).Once()
+
+			got, err := model.resolveRequest(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Empty(t, got)
+		})
+
+		t.Run("wraps detached finalizer update errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGRPCRouteModel(deps)
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			deleteTime := metav1.Now()
+			route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+				route.DeletionTimestamp = &deleteTime
+				route.Finalizers = []string{GRPCRouteProgrammedFinalizer}
+			})
+			req := reconcile.Request{
+				NamespacedName: apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name},
+			}
+			wantErr := errors.New("update failed")
+
+			k8sClient.EXPECT().Get(t.Context(), req.NamespacedName, mock.AnythingOfType("*v1.GRPCRoute")).
+				Run(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) {
+					*obj.(*gatewayv1.GRPCRoute) = route
+				}).
+				Return(nil).
+				Once()
+			k8sClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.GRPCRoute")).
+				Return(wantErr).
+				Once()
+
+			_, err := model.resolveRequest(t.Context(), req)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to deprovision detached GRPCRoute")
+		})
+
 		t.Run("returns empty result when route is not found", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newGRPCRouteModel(deps)
@@ -1106,7 +1191,8 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			})
 			resourcesModel.EXPECT().isConditionSet(mock.MatchedBy(func(params isConditionSetParams) bool {
 				return params.conditionType == string(gatewayv1.RouteConditionResolvedRefs) &&
-					params.annotations[GRPCRouteProgrammingRevisionAnnotation] == GRPCRouteProgrammingRevisionValue
+					params.annotations[GRPCRouteProgrammingRevisionAnnotation] == GRPCRouteProgrammingRevisionValue &&
+					params.annotations[L7RouteProgrammedLoadBalancerIDAnnotation] == gatewayData.config.Spec.LoadBalancerID
 			})).Return(true).Once()
 
 			got := model.isProgrammingRequired(resolvedGRPCRouteDetails{
@@ -1316,6 +1402,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			Spec: gatewayv1.GatewayClassSpec{ControllerName: ControllerClassName},
 		}
 		gateway := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw-" + fake.Lorem().Word()}}
+		config := makeRandomGatewayConfig()
 		parentRef := gatewayv1.ParentReference{Name: gatewayv1.ObjectName(gateway.Name)}
 		route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
 			route.Status.Parents = []gatewayv1.RouteParentStatus{{
@@ -1329,13 +1416,15 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			return params.conditionType == string(gatewayv1.RouteConditionResolvedRefs) &&
 				params.finalizer == GRPCRouteProgrammedFinalizer &&
 				params.annotations[GRPCRouteProgrammingRevisionAnnotation] == GRPCRouteProgrammingRevisionValue &&
-				params.annotations[GRPCRouteProgrammedPolicyRulesAnnotation] == strings.Join(programmedRules, ",")
+				params.annotations[GRPCRouteProgrammedPolicyRulesAnnotation] == strings.Join(programmedRules, ",") &&
+				params.annotations[L7RouteProgrammedLoadBalancerIDAnnotation] == config.Spec.LoadBalancerID
 		})).Return(nil).Once()
 
 		err := model.setProgrammed(t.Context(), setGRPCRouteProgrammedParams{
 			grpcRoute:             route,
 			gatewayClass:          gatewayClass,
 			gateway:               gateway,
+			config:                config,
 			matchedRef:            parentRef,
 			programmedPolicyRules: programmedRules,
 		})

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -116,7 +116,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 					return true, nil
 				})
 
-			gotGatewayData, gotListeners, err := model.resolveRouteParentRefData(
+			gotGatewayData, gotListeners, _, err := model.resolveRouteParentRefData(
 				t.Context(),
 				route,
 				parentRef,
@@ -148,7 +148,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 					return true, nil
 				})
 
-			_, gotListeners, err := model.resolveRouteParentRefData(t.Context(), route, parentRef, route.Namespace)
+			_, gotListeners, _, err := model.resolveRouteParentRefData(t.Context(), route, parentRef, route.Namespace)
 
 			require.NoError(t, err)
 			assert.Equal(t, []gatewayv1.Listener{grpcListener}, gotListeners)
@@ -217,7 +217,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: listenerSet.Namespace},
 			})
 
-			gotGatewayData, gotListeners, err := model.resolveRouteParentRefData(
+			gotGatewayData, gotListeners, _, err := model.resolveRouteParentRefData(
 				t.Context(),
 				route,
 				parentRef,
@@ -253,7 +253,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 					return true, nil
 				})
 
-			gotGatewayData, gotListeners, err := model.resolveRouteParentRefData(
+			gotGatewayData, gotListeners, _, err := model.resolveRouteParentRefData(
 				t.Context(),
 				route,
 				parentRef,
@@ -280,7 +280,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 					return false, nil
 				})
 
-			gotGatewayData, gotListeners, err := model.resolveRouteParentRefData(
+			gotGatewayData, gotListeners, _, err := model.resolveRouteParentRefData(
 				t.Context(),
 				route,
 				parentRef,
@@ -301,7 +301,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				resolveReconcileRequest(t.Context(), mock.Anything, mock.Anything).
 				Return(false, nil)
 
-			gotGatewayData, gotListeners, err := model.resolveRouteParentRefData(
+			gotGatewayData, gotListeners, _, err := model.resolveRouteParentRefData(
 				t.Context(),
 				makeGRPCRoute(),
 				gatewayv1.ParentReference{Name: "gw"},
@@ -323,7 +323,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				resolveReconcileRequest(t.Context(), mock.Anything, mock.Anything).
 				Return(false, wantErr)
 
-			_, _, err := model.resolveRouteParentRefData(
+			_, _, _, err := model.resolveRouteParentRefData(
 				t.Context(),
 				makeGRPCRoute(),
 				gatewayv1.ParentReference{Name: "gw"},
@@ -491,7 +491,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			got, err := model.resolveRequest(t.Context(), req)
 
 			require.NoError(t, err)
-			result := got[client.ObjectKeyFromObject(&gatewayData.gateway)]
+			result := got[gatewayParentResultKey(client.ObjectKeyFromObject(&gatewayData.gateway))]
 			assert.Len(t, result.matchedListeners, 2)
 		})
 

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -127,6 +127,7 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 		httpRoute:             *acceptedRoute,
 		matchedRef:            resolvedData.matchedRef,
 		programmedPolicyRules: programResult.programmedPolicyRules,
+		programmedBackendSets: programResult.programmedBackendSets,
 	}); err != nil {
 		return false, fmt.Errorf("failed to set programmed status: %w", err)
 	}

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -123,6 +123,7 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 	if err = r.httpRouteModel.setProgrammed(ctx, setProgrammedParams{
 		gatewayClass:          resolvedData.gatewayDetails.gatewayClass,
 		gateway:               resolvedData.gatewayDetails.gateway,
+		config:                resolvedData.gatewayDetails.config,
 		httpRoute:             *acceptedRoute,
 		matchedRef:            resolvedData.matchedRef,
 		programmedPolicyRules: programResult.programmedPolicyRules,

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -165,6 +165,41 @@ func TestHTTPRouteController(t *testing.T) {
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 
+		t.Run("skips programming when accept returns nil", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			controller := NewHTTPRouteController(deps)
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: fake.Internet().Domain(),
+					Name:      fake.Lorem().Word(),
+				},
+			}
+			resolvedData := resolvedRouteDetails{
+				httpRoute: makeRandomHTTPRoute(),
+				gatewayDetails: resolvedGatewayDetails{
+					gateway: *newRandomGateway(),
+					config:  makeRandomGatewayConfig(),
+				},
+			}
+
+			mockModel, _ := deps.HTTPRouteModel.(*MockhttpRouteModel)
+			mockModel.EXPECT().resolveRequest(
+				t.Context(),
+				req,
+			).Return(map[types.NamespacedName]resolvedRouteDetails{
+				req.NamespacedName: resolvedData,
+			}, (error)(nil))
+			mockModel.EXPECT().acceptRoute(t.Context(), resolvedData).Return(nil, nil)
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+			mockModel.AssertNotCalled(t, "isProgrammingRequired", mock.Anything)
+			mockModel.AssertNotCalled(t, "programRoute", mock.Anything, mock.Anything)
+		})
+
 		t.Run("RelevantRouteDeleted", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -120,6 +120,7 @@ func TestHTTPRouteController(t *testing.T) {
 				setProgrammedParams{
 					gatewayClass:          wantResolvedData.gatewayDetails.gatewayClass,
 					gateway:               wantResolvedData.gatewayDetails.gateway,
+					config:                wantResolvedData.gatewayDetails.config,
 					httpRoute:             wantAcceptedRoute,
 					matchedRef:            wantResolvedData.matchedRef,
 					programmedPolicyRules: programmedPolicyRules,
@@ -569,6 +570,7 @@ func TestHTTPRouteController(t *testing.T) {
 				setProgrammedParams{
 					gatewayClass:          wantResolvedData.gatewayDetails.gatewayClass,
 					gateway:               wantResolvedData.gatewayDetails.gateway,
+					config:                wantResolvedData.gatewayDetails.config,
 					httpRoute:             wantAcceptedRoute,
 					matchedRef:            wantResolvedData.matchedRef,
 					programmedPolicyRules: programmedPolicyRules,
@@ -660,6 +662,7 @@ func TestHTTPRouteController(t *testing.T) {
 				setProgrammedParams{
 					gatewayClass: wantResolvedData.gatewayDetails.gatewayClass,
 					gateway:      wantResolvedData.gatewayDetails.gateway,
+					config:       wantResolvedData.gatewayDetails.config,
 					httpRoute:    wantAcceptedRoute,
 					matchedRef:   wantResolvedData.matchedRef,
 				},

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -77,8 +77,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
@@ -158,7 +158,7 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{}, (error)(nil))
+			).Return(map[routeParentResultKey]resolvedRouteDetails{}, (error)(nil))
 
 			result, err := controller.Reconcile(t.Context(), req)
 
@@ -188,8 +188,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: resolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): resolvedData,
 			}, (error)(nil))
 			mockModel.EXPECT().acceptRoute(t.Context(), resolvedData).Return(nil, nil)
 
@@ -229,8 +229,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			mockModel.EXPECT().deprovisionRoute(
@@ -273,7 +273,7 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return((map[types.NamespacedName]resolvedRouteDetails)(nil), wantErr)
+			).Return((map[routeParentResultKey]resolvedRouteDetails)(nil), wantErr)
 
 			result, err := controller.Reconcile(t.Context(), req)
 
@@ -305,8 +305,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			wantErr := fmt.Errorf("accept error: %s", fake.Lorem().Sentence(10))
@@ -345,8 +345,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
@@ -405,8 +405,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
@@ -465,8 +465,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			wantAcceptedRoute := makeRandomHTTPRoute()
@@ -521,8 +521,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			wantAcceptedRoute := makeRandomHTTPRoute()
@@ -626,8 +626,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
@@ -698,8 +698,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			wantErr := fmt.Errorf("is programming required error: %s", fake.Lorem().Sentence(10))
@@ -735,8 +735,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			// Assume programming is not required to isolate the sync error
@@ -786,8 +786,8 @@ func TestHTTPRouteController(t *testing.T) {
 			mockModel.EXPECT().resolveRequest(
 				t.Context(),
 				req,
-			).Return(map[types.NamespacedName]resolvedRouteDetails{
-				req.NamespacedName: wantResolvedData,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
 			}, (error)(nil))
 
 			wantErr := fmt.Errorf("deprovision error: %s", fake.Lorem().Sentence(10))

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -46,6 +46,7 @@ type programRouteParams struct {
 type programRouteResult struct {
 	// Names of the policy rules that were programmed for this particular route
 	programmedPolicyRules []string
+	programmedBackendSets []string
 }
 
 type deprovisionRouteParams struct {
@@ -64,6 +65,7 @@ type setProgrammedParams struct {
 
 	// List of load balancer policy rules that were programmed for this route
 	programmedPolicyRules []string
+	programmedBackendSets []string
 }
 
 type programmedHTTPRoutePolicyRule struct {
@@ -129,10 +131,27 @@ type programL7RoutePolicyParams struct {
 	knownBackends       map[string]v1.Service
 	matchedListeners    []gatewayv1.Listener
 	previousPolicyRules []programmedHTTPRoutePolicyRule
+	previousBackendSets map[string]struct{}
 	ruleCount           int
 	makeRoutingRule     func(ruleIndex int) (loadbalancer.RoutingRule, error)
 	backendTLSPolicy    backendTLSPolicyModel
 	backendTLSDisabled  bool
+}
+
+type programL7RouteParams struct {
+	route                 client.Object
+	loadBalancerID        string
+	gateway               gatewayv1.Gateway
+	config                types.GatewayConfig
+	backendRefs           []gatewayv1.BackendRef
+	knownBackends         map[string]v1.Service
+	matchedListeners      []gatewayv1.Listener
+	backendTLSPolicy      backendTLSPolicyModel
+	backendTLSDisabled    bool
+	ruleCount             int
+	policyRulesAnnotation string
+	backendSetsAnnotation string
+	makeRoutingRule       func(ruleIndex int) (loadbalancer.RoutingRule, error)
 }
 
 type setL7RouteProgrammedParams struct {
@@ -143,9 +162,11 @@ type setL7RouteProgrammedParams struct {
 	loadBalancerID        string
 	matchedRef            gatewayv1.ParentReference
 	programmedPolicyRules []string
+	programmedBackendSets []string
 	programmingAnnotation string
 	programmingRevision   string
 	policyRulesAnnotation string
+	backendSetsAnnotation string
 	finalizer             string
 }
 
@@ -979,34 +1000,10 @@ func programL7RoutePolicy(
 	ctx context.Context,
 	ociLoadBalancerModel ociLoadBalancerModel,
 	params programL7RoutePolicyParams,
-) ([]string, error) {
-	processedBackendRefs := make(map[string]struct{})
-	for _, backendRef := range params.backendRefs {
-		key := l7BackendRefKey(backendRef, params.routeNamespace)
-		if _, ok := processedBackendRefs[key]; ok {
-			continue
-		}
-		serviceName := backendObjectRefName(backendRef.BackendObjectReference, params.routeNamespace).String()
-		service, ok := params.knownBackends[serviceName]
-		if !ok {
-			return nil, fmt.Errorf("resolved backend service %s not found", serviceName)
-		}
-		backendSSLConfig, manageSSLConfig, err := resolveL7BackendSSLConfig(ctx, params, service, backendRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve BackendTLSPolicy for service %s: %w", key, err)
-		}
-		err = ociLoadBalancerModel.reconcileBackendSet(ctx, reconcileBackendSetParams{
-			loadBalancerID:  params.loadBalancerID,
-			service:         service,
-			routeNS:         params.routeNamespace,
-			backendRef:      backendRef,
-			sslConfig:       backendSSLConfig,
-			manageSSLConfig: manageSSLConfig,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to reconcile backend set for service %s: %w", key, err)
-		}
-		processedBackendRefs[key] = struct{}{}
+) ([]string, []string, error) {
+	desiredBackendSets, reconcileErr := reconcileL7BackendSets(ctx, ociLoadBalancerModel, params)
+	if reconcileErr != nil {
+		return nil, nil, reconcileErr
 	}
 
 	policyRules := make([]loadbalancer.RoutingRule, 0, params.ruleCount)
@@ -1014,7 +1011,12 @@ func programL7RoutePolicy(
 	for ruleIndex := range params.ruleCount {
 		rule, err := params.makeRoutingRule(ruleIndex)
 		if err != nil {
-			return nil, fmt.Errorf("failed to make routing rule %d for route %s: %w", ruleIndex, params.routeName, err)
+			return nil, nil, fmt.Errorf(
+				"failed to make routing rule %d for route %s: %w",
+				ruleIndex,
+				params.routeName,
+				err,
+			)
 		}
 		policyRules = append(policyRules, rule)
 		policyRuleNames = append(policyRuleNames, *rule.Name)
@@ -1037,10 +1039,132 @@ func programL7RoutePolicy(
 			prevPolicyRules: prevRulesByListener[listenerName],
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to commit routing policy for listener %s: %w", listener.Name, err)
+			return nil, nil, fmt.Errorf("failed to commit routing policy for listener %s: %w", listener.Name, err)
 		}
 	}
 
+	if err := removeStaleL7PolicyRules(
+		ctx,
+		ociLoadBalancerModel,
+		params.loadBalancerID,
+		prevRulesByListener,
+		currentListenerNames,
+	); err != nil {
+		return nil, nil, err
+	}
+
+	if err := deprovisionStaleL7BackendSets(
+		ctx,
+		ociLoadBalancerModel,
+		params.loadBalancerID,
+		desiredBackendSets,
+		params.previousBackendSets,
+	); err != nil {
+		return nil, nil, err
+	}
+
+	programmedBackendSets := lo.Keys(desiredBackendSets)
+	sort.Strings(programmedBackendSets)
+
+	return programmedHTTPRoutePolicyRulesAnnotation(params.matchedListeners, policyRuleNames),
+		programmedBackendSets,
+		nil
+}
+
+func programL7Route(
+	ctx context.Context,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	params programL7RouteParams,
+) ([]string, []string, error) {
+	var previousRules []programmedHTTPRoutePolicyRule
+	if prevPolicyRulesStr, ok := params.route.GetAnnotations()[params.policyRulesAnnotation]; ok {
+		previousRules = parseProgrammedHTTPRoutePolicyRules(prevPolicyRulesStr)
+	}
+	previousBackendSets := annotatedBackendSetNames(params.route, params.backendSetsAnnotation)
+
+	return programL7RoutePolicy(ctx, ociLoadBalancerModel, programL7RoutePolicyParams{
+		loadBalancerID:      params.loadBalancerID,
+		gateway:             params.gateway,
+		config:              params.config,
+		routeName:           params.route.GetName(),
+		routeNamespace:      params.route.GetNamespace(),
+		backendRefs:         params.backendRefs,
+		knownBackends:       params.knownBackends,
+		matchedListeners:    params.matchedListeners,
+		previousPolicyRules: previousRules,
+		previousBackendSets: previousBackendSets,
+		backendTLSPolicy:    params.backendTLSPolicy,
+		backendTLSDisabled:  params.backendTLSDisabled,
+		ruleCount:           params.ruleCount,
+		makeRoutingRule:     params.makeRoutingRule,
+	})
+}
+
+func programL7RouteResult(
+	ctx context.Context,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	params programL7RouteParams,
+) (programRouteResult, error) {
+	programmedPolicyRules, programmedBackendSets, err := programL7Route(ctx, ociLoadBalancerModel, params)
+	if err != nil {
+		return programRouteResult{}, err
+	}
+
+	return programRouteResult{
+		programmedPolicyRules: programmedPolicyRules,
+		programmedBackendSets: programmedBackendSets,
+	}, nil
+}
+
+func reconcileL7BackendSets(
+	ctx context.Context,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	params programL7RoutePolicyParams,
+) (map[string]struct{}, error) {
+	processedBackendRefs := make(map[string]struct{})
+	desiredBackendSets := make(map[string]struct{})
+	for _, backendRef := range params.backendRefs {
+		key := l7BackendRefKey(backendRef, params.routeNamespace)
+		if _, ok := processedBackendRefs[key]; ok {
+			continue
+		}
+		backendSetName := ociBackendSetNameFromBackendObjectRef(
+			params.routeNamespace,
+			backendRef.BackendObjectReference,
+		)
+		serviceName := backendObjectRefName(backendRef.BackendObjectReference, params.routeNamespace).String()
+		service, ok := params.knownBackends[serviceName]
+		if !ok {
+			return nil, fmt.Errorf("resolved backend service %s not found", serviceName)
+		}
+		backendSSLConfig, manageSSLConfig, err := resolveL7BackendSSLConfig(ctx, params, service, backendRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve BackendTLSPolicy for service %s: %w", key, err)
+		}
+		err = ociLoadBalancerModel.reconcileBackendSet(ctx, reconcileBackendSetParams{
+			loadBalancerID:  params.loadBalancerID,
+			service:         service,
+			routeNS:         params.routeNamespace,
+			backendRef:      backendRef,
+			sslConfig:       backendSSLConfig,
+			manageSSLConfig: manageSSLConfig,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to reconcile backend set for service %s: %w", key, err)
+		}
+		processedBackendRefs[key] = struct{}{}
+		desiredBackendSets[backendSetName] = struct{}{}
+	}
+	return desiredBackendSets, nil
+}
+
+func removeStaleL7PolicyRules(
+	ctx context.Context,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	loadBalancerID string,
+	prevRulesByListener map[string][]string,
+	currentListenerNames map[string]struct{},
+) error {
 	staleListenerNames := lo.Keys(prevRulesByListener)
 	sort.Strings(staleListenerNames)
 	for _, listenerName := range staleListenerNames {
@@ -1048,17 +1172,40 @@ func programL7RoutePolicy(
 			continue
 		}
 		err := ociLoadBalancerModel.commitRoutingPolicy(ctx, commitRoutingPolicyParams{
-			loadBalancerID:  params.loadBalancerID,
+			loadBalancerID:  loadBalancerID,
 			listenerName:    listenerName,
 			policyRules:     []loadbalancer.RoutingRule{},
 			prevPolicyRules: prevRulesByListener[listenerName],
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to remove stale routing policy rules for listener %s: %w", listenerName, err)
+			return fmt.Errorf(
+				"failed to remove stale routing policy rules for listener %s: %w",
+				listenerName,
+				err,
+			)
 		}
 	}
+	return nil
+}
 
-	return programmedHTTPRoutePolicyRulesAnnotation(params.matchedListeners, policyRuleNames), nil
+func deprovisionStaleL7BackendSets(
+	ctx context.Context,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	loadBalancerID string,
+	desiredBackendSets map[string]struct{},
+	previousBackendSets map[string]struct{},
+) error {
+	staleBackendSetNames := lo.Keys(previousBackendSets)
+	sort.Strings(staleBackendSetNames)
+	for _, backendSetName := range staleBackendSetNames {
+		if _, ok := desiredBackendSets[backendSetName]; ok {
+			continue
+		}
+		if err := ociLoadBalancerModel.deprovisionBackendSetByName(ctx, loadBalancerID, backendSetName); err != nil {
+			return fmt.Errorf("failed to deprovision stale backend set %s: %w", backendSetName, err)
+		}
+	}
+	return nil
 }
 
 func resolveL7BackendSSLConfig(
@@ -1090,24 +1237,19 @@ func (m *httpRouteModelImpl) programRoute(
 	ctx context.Context,
 	params programRouteParams,
 ) (programRouteResult, error) {
-	var previousRules []programmedHTTPRoutePolicyRule
-	if prevPolicyRulesStr, ok := params.httpRoute.Annotations[HTTPRouteProgrammedPolicyRulesAnnotation]; ok {
-		previousRules = parseProgrammedHTTPRoutePolicyRules(prevPolicyRulesStr)
-	}
-
-	programmedPolicyRules, err := programL7RoutePolicy(ctx, m.ociLoadBalancerModel, programL7RoutePolicyParams{
-		loadBalancerID:      params.config.Spec.LoadBalancerID,
-		gateway:             params.gateway,
-		config:              params.config,
-		routeName:           params.httpRoute.Name,
-		routeNamespace:      params.httpRoute.Namespace,
-		backendRefs:         httpRouteBackendRefs(params.httpRoute),
-		knownBackends:       params.knownBackends,
-		matchedListeners:    params.matchedListeners,
-		previousPolicyRules: previousRules,
-		backendTLSPolicy:    m.backendTLSPolicy,
-		backendTLSDisabled:  m.backendTLSDisabled,
-		ruleCount:           len(params.httpRoute.Spec.Rules),
+	return programL7RouteResult(ctx, m.ociLoadBalancerModel, programL7RouteParams{
+		route:                 &params.httpRoute,
+		loadBalancerID:        params.config.Spec.LoadBalancerID,
+		gateway:               params.gateway,
+		config:                params.config,
+		backendRefs:           httpRouteBackendRefs(params.httpRoute),
+		knownBackends:         params.knownBackends,
+		matchedListeners:      params.matchedListeners,
+		backendTLSPolicy:      m.backendTLSPolicy,
+		backendTLSDisabled:    m.backendTLSDisabled,
+		ruleCount:             len(params.httpRoute.Spec.Rules),
+		policyRulesAnnotation: HTTPRouteProgrammedPolicyRulesAnnotation,
+		backendSetsAnnotation: HTTPRouteProgrammedBackendSetsAnnotation,
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeRoutingRule(ctx, makeRoutingRuleParams{
 				httpRoute:          params.httpRoute,
@@ -1115,13 +1257,6 @@ func (m *httpRouteModelImpl) programRoute(
 			})
 		},
 	})
-	if err != nil {
-		return programRouteResult{}, err
-	}
-
-	return programRouteResult{
-		programmedPolicyRules: programmedPolicyRules,
-	}, nil
 }
 
 func httpRouteBackendRefs(route gatewayv1.HTTPRoute) []gatewayv1.BackendRef {
@@ -1341,6 +1476,7 @@ func setL7RouteProgrammed(
 		annotations: map[string]string{
 			params.programmingAnnotation:              params.programmingRevision,
 			params.policyRulesAnnotation:              strings.Join(params.programmedPolicyRules, ","),
+			params.backendSetsAnnotation:              strings.Join(params.programmedBackendSets, ","),
 			L7RouteProgrammedLoadBalancerIDAnnotation: params.loadBalancerID,
 		},
 		finalizer: params.finalizer,
@@ -1361,9 +1497,11 @@ func (m *httpRouteModelImpl) setProgrammed(
 		loadBalancerID:        params.config.Spec.LoadBalancerID,
 		matchedRef:            params.matchedRef,
 		programmedPolicyRules: params.programmedPolicyRules,
+		programmedBackendSets: params.programmedBackendSets,
 		programmingAnnotation: HTTPRouteProgrammingRevisionAnnotation,
 		programmingRevision:   HTTPRouteProgrammingRevisionValue,
 		policyRulesAnnotation: HTTPRouteProgrammedPolicyRulesAnnotation,
+		backendSetsAnnotation: HTTPRouteProgrammedBackendSetsAnnotation,
 		finalizer:             HTTPRouteProgrammedFinalizer,
 	})
 	if err != nil {

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -93,14 +93,16 @@ type l7RouteCandidate struct {
 }
 
 type l7RouteConflictParams struct {
-	gateway          gatewayv1.Gateway
-	matchedListeners []gatewayv1.Listener
-	current          l7RouteCandidate
-	oppositeRoutes   []l7RouteCandidate
+	gateway            gatewayv1.Gateway
+	effectiveListeners []effectiveListener
+	matchedListeners   []gatewayv1.Listener
+	current            l7RouteCandidate
+	oppositeRoutes     []l7RouteCandidate
 }
 
 type checkL7RouteConflictParams struct {
 	gateway               gatewayv1.Gateway
+	effectiveListeners    []effectiveListener
 	matchedListeners      []gatewayv1.Listener
 	current               l7RouteCandidate
 	oppositeRouteListName string
@@ -219,7 +221,13 @@ func l7RouteConflictingWinner(params l7RouteConflictParams) (l7RouteCandidate, b
 		if params.current.identity.kind != oppositeRoute.identity.kind {
 			continue
 		}
-		if !l7RoutesShareListenerHostname(params.gateway, params.matchedListeners, params.current, oppositeRoute) {
+		if !l7RoutesShareListenerHostname(
+			params.gateway,
+			params.effectiveListeners,
+			params.matchedListeners,
+			params.current,
+			oppositeRoute,
+		) {
 			continue
 		}
 		if l7RouteWins(oppositeRoute.identity, params.current.identity) {
@@ -242,10 +250,11 @@ func checkL7RouteConflict(ctx context.Context, params checkL7RouteConflictParams
 		)
 	}
 	winner, conflicted := l7RouteConflictingWinner(l7RouteConflictParams{
-		gateway:          params.gateway,
-		matchedListeners: params.matchedListeners,
-		current:          params.current,
-		oppositeRoutes:   oppositeRoutes,
+		gateway:            params.gateway,
+		effectiveListeners: params.effectiveListeners,
+		matchedListeners:   params.matchedListeners,
+		current:            params.current,
+		oppositeRoutes:     oppositeRoutes,
 	})
 	return winner, conflicted, nil
 }
@@ -320,12 +329,13 @@ func removeL7RoutePolicyRules(
 
 func l7RoutesShareListenerHostname(
 	gateway gatewayv1.Gateway,
+	effectiveListeners []effectiveListener,
 	matchedListeners []gatewayv1.Listener,
 	a l7RouteCandidate,
 	b l7RouteCandidate,
 ) bool {
 	listenerByName := lo.SliceToMap(
-		gateway.Spec.Listeners,
+		effectiveOCIListeners(gateway, effectiveListeners),
 		func(listener gatewayv1.Listener) (gatewayv1.SectionName, gatewayv1.Listener) {
 			return listener.Name, listener
 		},
@@ -336,7 +346,7 @@ func l7RoutesShareListenerHostname(
 			return listener.Name, struct{}{}
 		},
 	)
-	for _, listenerName := range l7RouteAttachedListenerNames(gateway, b.parentRefs, b.identity.namespace) {
+	for _, listenerName := range l7RouteAttachedListenerNames(gateway, effectiveListeners, b.parentRefs, b.identity.namespace) {
 		if _, matched := matchedListenerNames[listenerName]; !matched {
 			continue
 		}
@@ -356,35 +366,39 @@ func l7RoutesShareListenerHostname(
 
 func l7RouteAttachedListenerNames(
 	gateway gatewayv1.Gateway,
+	effectiveListeners []effectiveListener,
 	parentRefs []gatewayv1.ParentReference,
 	routeNamespace string,
 ) []gatewayv1.SectionName {
 	listenerNames := lo.SliceToMap(
-		gateway.Spec.Listeners,
+		effectiveOCIListeners(gateway, effectiveListeners),
 		func(listener gatewayv1.Listener) (gatewayv1.SectionName, struct{}) {
 			return listener.Name, struct{}{}
 		},
 	)
-	result := make([]gatewayv1.SectionName, 0, len(gateway.Spec.Listeners))
+	result := make([]gatewayv1.SectionName, 0, len(listenerNames))
 	for _, parentRef := range parentRefs {
-		parentNamespace := routeNamespace
-		if parentRef.Namespace != nil {
-			parentNamespace = string(*parentRef.Namespace)
-		}
-		if parentNamespace != gateway.Namespace || string(parentRef.Name) != gateway.Name {
-			continue
-		}
-		if parentRef.SectionName != nil {
-			if _, found := listenerNames[*parentRef.SectionName]; found {
-				result = append(result, *parentRef.SectionName)
+		for _, listener := range effectiveListenersForParentRef(
+			resolvedGatewayDetails{gateway: gateway, effectiveListeners: effectiveListeners},
+			parentRef,
+			routeNamespace,
+			func(ref gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+				return ref.SectionName == nil || listener.Name == *ref.SectionName
+			},
+		) {
+			if _, found := listenerNames[listener.Name]; found {
+				result = append(result, listener.Name)
 			}
-			continue
-		}
-		for _, listener := range gateway.Spec.Listeners {
-			result = append(result, listener.Name)
 		}
 	}
 	return lo.Uniq(result)
+}
+
+func effectiveOCIListeners(gateway gatewayv1.Gateway, listeners []effectiveListener) []gatewayv1.Listener {
+	return effectiveOCIListenersForGateway(&resolvedGatewayDetails{
+		gateway:            gateway,
+		effectiveListeners: listeners,
+	})
 }
 
 func l7RouteHostnamesForListener(
@@ -580,15 +594,7 @@ func (m *httpRouteModelImpl) resolveRouteParentRefData(
 	parentRef gatewayv1.ParentReference,
 	defaultNamespace string,
 ) (*resolvedGatewayDetails, []gatewayv1.Listener, error) {
-	var resolvedGatewayData resolvedGatewayDetails
-	gatewayNamespace := defaultNamespace
-	if parentRef.Namespace != nil {
-		gatewayNamespace = string(lo.FromPtr(parentRef.Namespace))
-	}
-	parentName := apitypes.NamespacedName{
-		Namespace: gatewayNamespace,
-		Name:      string(parentRef.Name),
-	}
+	parentName := parentRefTargetName(parentRef, defaultNamespace)
 	m.logger.DebugContext(ctx, "Resolving parent for HTTProute",
 		slog.String("parentName", parentName.String()),
 		slog.Any("parentRef", parentRef),
@@ -598,9 +604,13 @@ func (m *httpRouteModelImpl) resolveRouteParentRefData(
 		}.String()),
 	)
 
-	gatewayResolved, err := m.gatewayModel.resolveReconcileRequest(ctx, reconcile.Request{
-		NamespacedName: parentName,
-	}, &resolvedGatewayData)
+	resolvedGatewayData, gatewayResolved, err := resolveL7ParentGateway(
+		ctx,
+		m.client,
+		m.gatewayModel,
+		parentRef,
+		defaultNamespace,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve gateway %s for route %s/%s: %w",
 			parentName.String(), httpRoute.Namespace, httpRoute.Name, err)
@@ -614,10 +624,12 @@ func (m *httpRouteModelImpl) resolveRouteParentRefData(
 
 	if parentRef.SectionName != nil {
 		sectionName := *parentRef.SectionName
-		matchingListeners := lo.Filter(
-			resolvedGatewayData.gateway.Spec.Listeners,
-			func(l gatewayv1.Listener, _ int) bool {
-				return l.Name == sectionName
+		matchingListeners := effectiveListenersForParentRef(
+			resolvedGatewayData,
+			parentRef,
+			defaultNamespace,
+			func(ref gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+				return ref.SectionName != nil && listener.Name == sectionName
 			},
 		)
 
@@ -641,7 +653,45 @@ func (m *httpRouteModelImpl) resolveRouteParentRefData(
 	m.logger.DebugContext(ctx, "Gateway resolved without section name, all listeners match",
 		slog.String("parentName", parentName.String()),
 	)
-	return &resolvedGatewayData, resolvedGatewayData.gateway.Spec.Listeners, nil
+	return &resolvedGatewayData, effectiveListenersForParentRef(
+		resolvedGatewayData,
+		parentRef,
+		defaultNamespace,
+		func(gatewayv1.ParentReference, gatewayv1.Listener) bool { return true },
+	), nil
+}
+
+func resolveL7ParentGateway(
+	ctx context.Context,
+	k8sClient k8sClient,
+	gatewayModel gatewayModel,
+	parentRef gatewayv1.ParentReference,
+	routeNamespace string,
+) (resolvedGatewayDetails, bool, error) {
+	parentName := parentRefTargetName(parentRef, routeNamespace)
+	if parentRefTargetsListenerSet(parentRef) {
+		resolvedName, resolved, err := listenerSetParentGatewayTarget(ctx, k8sClient, routeNamespace, parentRef)
+		if err != nil || !resolved {
+			return resolvedGatewayDetails{}, resolved, err
+		}
+		parentName = resolvedName
+	} else if !parentRefTargetsGateway(parentRef) {
+		return resolvedGatewayDetails{}, false, nil
+	}
+
+	var resolvedGatewayData resolvedGatewayDetails
+	gatewayResolved, err := gatewayModel.resolveReconcileRequest(ctx, reconcile.Request{
+		NamespacedName: parentName,
+	}, &resolvedGatewayData)
+	if err != nil || !gatewayResolved {
+		return resolvedGatewayData, gatewayResolved, err
+	}
+	if parentRefTargetsListenerSet(parentRef) && len(resolvedGatewayData.effectiveListeners) == 0 {
+		if err = populateAttachedListenerSetsUnindexed(ctx, k8sClient, &resolvedGatewayData); err != nil {
+			return resolvedGatewayDetails{}, false, err
+		}
+	}
+	return resolvedGatewayData, true, nil
 }
 
 // aggregateRouteParentRefData adds or updates the results map with the resolved parent details.
@@ -743,8 +793,9 @@ func (m *httpRouteModelImpl) acceptRoute(
 	routeDetails resolvedRouteDetails,
 ) (*gatewayv1.HTTPRoute, error) {
 	winner, conflicted, err := checkL7RouteConflict(ctx, checkL7RouteConflictParams{
-		gateway:          routeDetails.gatewayDetails.gateway,
-		matchedListeners: routeDetails.matchedListeners,
+		gateway:            routeDetails.gatewayDetails.gateway,
+		effectiveListeners: routeDetails.gatewayDetails.effectiveListeners,
+		matchedListeners:   routeDetails.matchedListeners,
 		current: l7RouteCandidate{
 			identity: l7RouteIdentity{
 				kind:              l7HTTPRouteKind,

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -59,6 +59,7 @@ type setProgrammedParams struct {
 	httpRoute    gatewayv1.HTTPRoute
 	gatewayClass gatewayv1.GatewayClass
 	gateway      gatewayv1.Gateway
+	config       types.GatewayConfig
 	matchedRef   gatewayv1.ParentReference
 
 	// List of load balancer policy rules that were programmed for this route
@@ -139,6 +140,7 @@ type setL7RouteProgrammedParams struct {
 	parentStatuses        []gatewayv1.RouteParentStatus
 	gatewayClass          gatewayv1.GatewayClass
 	gateway               gatewayv1.Gateway
+	loadBalancerID        string
 	matchedRef            gatewayv1.ParentReference
 	programmedPolicyRules []string
 	programmingAnnotation string
@@ -780,6 +782,13 @@ func (m *httpRouteModelImpl) resolveRequest(
 			slog.String("route", req.NamespacedName.String()),
 			slog.Int("triedParentRefs", len(httpRoute.Spec.ParentRefs)),
 		)
+		deletingProgrammedRoute := httpRoute.DeletionTimestamp != nil &&
+			controllerutil.ContainsFinalizer(&httpRoute, HTTPRouteProgrammedFinalizer)
+		if deletingProgrammedRoute {
+			if err := m.deprovisionDetachedRoute(ctx, httpRoute); err != nil {
+				return nil, fmt.Errorf("failed to deprovision detached HTTPRoute %s: %w", req.NamespacedName, err)
+			}
+		}
 	}
 
 	return results, nil
@@ -1194,6 +1203,85 @@ func (m *httpRouteModelImpl) deprovisionRoute(
 	return nil
 }
 
+type deprovisionDetachedL7RouteParams struct {
+	route                 client.Object
+	routeKind             string
+	policyRulesAnnotation string
+	loadBalancerID        string
+	backendRefs           []gatewayv1.BackendRef
+	removeFinalizer       func(context.Context) error
+}
+
+func deprovisionDetachedL7Route(
+	ctx context.Context,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	params deprovisionDetachedL7RouteParams,
+) error {
+	if params.loadBalancerID == "" {
+		return params.removeFinalizer(ctx)
+	}
+
+	if policyRules := params.route.GetAnnotations()[params.policyRulesAnnotation]; policyRules != "" {
+		err := removeL7RoutePolicyRules(ctx, ociLoadBalancerModel, params.loadBalancerID, nil, policyRules)
+		if err != nil {
+			return fmt.Errorf("failed to remove detached %s policy rules: %w", params.routeKind, err)
+		}
+	}
+
+	processedBackendRefs := make(map[string]struct{})
+	for _, backendRef := range params.backendRefs {
+		key := l7BackendRefKey(backendRef, params.route.GetNamespace())
+		if _, ok := processedBackendRefs[key]; ok {
+			continue
+		}
+		err := ociLoadBalancerModel.deprovisionBackendSet(ctx, deprovisionBackendSetParams{
+			loadBalancerID: params.loadBalancerID,
+			routeNamespace: params.route.GetNamespace(),
+			backendRef:     backendRef,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to deprovision detached %s backend set %s: %w",
+				params.routeKind, key, err)
+		}
+		processedBackendRefs[key] = struct{}{}
+	}
+
+	return params.removeFinalizer(ctx)
+}
+
+func (m *httpRouteModelImpl) deprovisionDetachedRoute(
+	ctx context.Context,
+	httpRoute gatewayv1.HTTPRoute,
+) error {
+	return deprovisionDetachedL7Route(ctx, m.ociLoadBalancerModel, deprovisionDetachedL7RouteParams{
+		route:                 &httpRoute,
+		routeKind:             "HTTPRoute",
+		policyRulesAnnotation: HTTPRouteProgrammedPolicyRulesAnnotation,
+		loadBalancerID:        httpRoute.Annotations[L7RouteProgrammedLoadBalancerIDAnnotation],
+		backendRefs:           httpRouteBackendRefs(httpRoute),
+		removeFinalizer: func(ctx context.Context) error {
+			return m.removeDetachedHTTPRouteFinalizer(ctx, httpRoute)
+		},
+	})
+}
+
+func (m *httpRouteModelImpl) removeDetachedHTTPRouteFinalizer(
+	ctx context.Context,
+	httpRoute gatewayv1.HTTPRoute,
+) error {
+	routeToUpdate := httpRoute.DeepCopy()
+	controllerutil.RemoveFinalizer(routeToUpdate, HTTPRouteProgrammedFinalizer)
+	if routeToUpdate.Annotations != nil {
+		delete(routeToUpdate.Annotations, HTTPRouteProgrammedPolicyRulesAnnotation)
+		delete(routeToUpdate.Annotations, L7RouteProgrammedLoadBalancerIDAnnotation)
+	}
+	if err := m.client.Update(ctx, routeToUpdate); err != nil {
+		return fmt.Errorf("failed to update detached HTTPRoute %s/%s after cleanup: %w",
+			routeToUpdate.Namespace, routeToUpdate.Name, err)
+	}
+	return nil
+}
+
 func (m *httpRouteModelImpl) isProgrammingRequired(
 	details resolvedRouteDetails,
 ) (bool, error) {
@@ -1218,7 +1306,8 @@ func (m *httpRouteModelImpl) isProgrammingRequired(
 		conditionType: string(gatewayv1.RouteConditionResolvedRefs),
 
 		annotations: map[string]string{
-			HTTPRouteProgrammingRevisionAnnotation: HTTPRouteProgrammingRevisionValue,
+			HTTPRouteProgrammingRevisionAnnotation:    HTTPRouteProgrammingRevisionValue,
+			L7RouteProgrammedLoadBalancerIDAnnotation: details.gatewayDetails.config.Spec.LoadBalancerID,
 		},
 	}), nil
 }
@@ -1250,8 +1339,9 @@ func setL7RouteProgrammed(
 		reason:        string(gatewayv1.RouteReasonResolvedRefs),
 		message:       fmt.Sprintf("Route programmed by %s", params.gateway.Name),
 		annotations: map[string]string{
-			params.programmingAnnotation: params.programmingRevision,
-			params.policyRulesAnnotation: strings.Join(params.programmedPolicyRules, ","),
+			params.programmingAnnotation:              params.programmingRevision,
+			params.policyRulesAnnotation:              strings.Join(params.programmedPolicyRules, ","),
+			L7RouteProgrammedLoadBalancerIDAnnotation: params.loadBalancerID,
 		},
 		finalizer: params.finalizer,
 	})
@@ -1268,6 +1358,7 @@ func (m *httpRouteModelImpl) setProgrammed(
 		parentStatuses:        httpRoute.Status.Parents,
 		gatewayClass:          params.gatewayClass,
 		gateway:               params.gateway,
+		loadBalancerID:        params.config.Spec.LoadBalancerID,
 		matchedRef:            params.matchedRef,
 		programmedPolicyRules: params.programmedPolicyRules,
 		programmingAnnotation: HTTPRouteProgrammingRevisionAnnotation,

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -29,6 +29,7 @@ type resolvedRouteDetails struct {
 	httpRoute        gatewayv1.HTTPRoute
 	matchedRef       gatewayv1.ParentReference
 	matchedListeners []gatewayv1.Listener
+	attachmentDenied bool
 }
 
 type resolveBackendRefsParams struct {
@@ -170,14 +171,45 @@ type setL7RouteProgrammedParams struct {
 	finalizer             string
 }
 
+type routeParentResultKey struct {
+	kind      gatewayv1.Kind
+	namespace string
+	name      string
+}
+
+func directParentResultKey(parentRef gatewayv1.ParentReference, routeNamespace string) routeParentResultKey {
+	key := parentRefTargetName(parentRef, routeNamespace)
+	kind := gatewayv1.Kind("Gateway")
+	if parentRef.Kind != nil {
+		kind = *parentRef.Kind
+	}
+	return routeParentResultKey{
+		kind:      kind,
+		namespace: key.Namespace,
+		name:      key.Name,
+	}
+}
+
+func gatewayParentResultKey(key apitypes.NamespacedName) routeParentResultKey {
+	return routeParentResultKey{
+		kind:      gatewayv1.Kind("Gateway"),
+		namespace: key.Namespace,
+		name:      key.Name,
+	}
+}
+
+func (k routeParentResultKey) String() string {
+	return fmt.Sprintf("%s/%s/%s", k.kind, k.namespace, k.name)
+}
+
 // httpRouteModel defines the interface for managing HTTPRoute resources.
 type httpRouteModel interface {
 	// resolveRequest resolves the parent details for a given HTTPRoute.
-	// It returns a map of parent names (gateway names) to resolved route details.
+	// It returns resolved route details keyed by the direct parent reference.
 	resolveRequest(
 		ctx context.Context,
 		req reconcile.Request,
-	) (map[apitypes.NamespacedName]resolvedRouteDetails, error)
+	) (map[routeParentResultKey]resolvedRouteDetails, error)
 
 	// acceptRoute accepts a reconcile request for a given HTTPRoute.
 	// It returns updated HTTPRoute with status parents updated.
@@ -616,7 +648,7 @@ func (m *httpRouteModelImpl) resolveRouteParentRefData(
 	httpRoute gatewayv1.HTTPRoute,
 	parentRef gatewayv1.ParentReference,
 	defaultNamespace string,
-) (*resolvedGatewayDetails, []gatewayv1.Listener, error) {
+) (*resolvedGatewayDetails, []gatewayv1.Listener, bool, error) {
 	parentName := parentRefTargetName(parentRef, defaultNamespace)
 	m.logger.DebugContext(ctx, "Resolving parent for HTTProute",
 		slog.String("parentName", parentName.String()),
@@ -635,14 +667,14 @@ func (m *httpRouteModelImpl) resolveRouteParentRefData(
 		defaultNamespace,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to resolve gateway %s for route %s/%s: %w",
+		return nil, nil, false, fmt.Errorf("failed to resolve gateway %s for route %s/%s: %w",
 			parentName.String(), httpRoute.Namespace, httpRoute.Name, err)
 	}
 	if !gatewayResolved {
 		m.logger.DebugContext(ctx, "Gateway not resolved or not relevant",
 			slog.String("parentName", parentName.String()),
 		)
-		return nil, nil, nil
+		return nil, nil, false, nil
 	}
 
 	if parentRef.SectionName != nil {
@@ -661,27 +693,53 @@ func (m *httpRouteModelImpl) resolveRouteParentRefData(
 				slog.String("parentName", parentName.String()),
 				slog.String("sectionName", string(sectionName)),
 			)
-			return nil, nil, nil
+			return nil, nil, false, nil
+		}
+		allowedListeners, allowErr := allowedRouteListeners(
+			ctx,
+			m.client,
+			resolvedGatewayData,
+			httpRoute.Namespace,
+			matchingListeners,
+			"HTTPRoute",
+		)
+		if allowErr != nil {
+			return nil, nil, false, allowErr
 		}
 
 		m.logger.DebugContext(ctx, "Gateway resolved with matching section name listener(s)",
 			slog.String("parentName", parentName.String()),
 			slog.String("sectionName", string(sectionName)),
-			slog.Int("matchedListenersCount", len(matchingListeners)),
+			slog.Int("matchedListenersCount", len(allowedListeners)),
 		)
-		return &resolvedGatewayData, matchingListeners, nil
+		return &resolvedGatewayData, allowedListeners, len(allowedListeners) == 0, nil
 	}
 
 	// If no SectionName, all listeners are considered matched
 	m.logger.DebugContext(ctx, "Gateway resolved without section name, all listeners match",
 		slog.String("parentName", parentName.String()),
 	)
-	return &resolvedGatewayData, effectiveListenersForParentRef(
+	matchingListeners := effectiveListenersForParentRef(
 		resolvedGatewayData,
 		parentRef,
 		defaultNamespace,
 		func(gatewayv1.ParentReference, gatewayv1.Listener) bool { return true },
-	), nil
+	)
+	if len(matchingListeners) == 0 {
+		return nil, nil, false, nil
+	}
+	allowedListeners, allowErr := allowedRouteListeners(
+		ctx,
+		m.client,
+		resolvedGatewayData,
+		httpRoute.Namespace,
+		matchingListeners,
+		"HTTPRoute",
+	)
+	if allowErr != nil {
+		return nil, nil, false, allowErr
+	}
+	return &resolvedGatewayData, allowedListeners, len(allowedListeners) == 0, nil
 }
 
 func resolveL7ParentGateway(
@@ -721,16 +779,14 @@ func resolveL7ParentGateway(
 // It handles merging listeners if the same gateway is referenced multiple times (e.g., by different sections).
 func (m *httpRouteModelImpl) aggregateRouteParentRefData(
 	ctx context.Context,
-	results map[apitypes.NamespacedName]resolvedRouteDetails,
+	results map[routeParentResultKey]resolvedRouteDetails,
 	httpRoute gatewayv1.HTTPRoute,
 	gatewayDetails resolvedGatewayDetails,
 	matchedRef gatewayv1.ParentReference, // Should be target-only ref
 	matchedListeners []gatewayv1.Listener,
+	attachmentDenied bool,
 ) {
-	parentName := apitypes.NamespacedName{
-		Namespace: gatewayDetails.gateway.Namespace,
-		Name:      gatewayDetails.gateway.Name,
-	}
+	parentName := directParentResultKey(matchedRef, httpRoute.Namespace)
 
 	if existingResult, found := results[parentName]; found {
 		newListeners := lo.UniqBy(
@@ -740,6 +796,7 @@ func (m *httpRouteModelImpl) aggregateRouteParentRefData(
 			},
 		)
 		existingResult.matchedListeners = newListeners
+		existingResult.attachmentDenied = existingResult.attachmentDenied && attachmentDenied
 		results[parentName] = existingResult
 		m.logger.DebugContext(ctx, "Appended/merged listeners for existing gateway result",
 			slog.String("parentName", parentName.String()),
@@ -751,6 +808,7 @@ func (m *httpRouteModelImpl) aggregateRouteParentRefData(
 			gatewayDetails:   gatewayDetails,
 			matchedRef:       matchedRef, // Use the target-only ref
 			matchedListeners: matchedListeners,
+			attachmentDenied: attachmentDenied,
 		}
 		m.logger.DebugContext(ctx, "Added new gateway result",
 			slog.String("parentName", parentName.String()),
@@ -762,22 +820,22 @@ func (m *httpRouteModelImpl) aggregateRouteParentRefData(
 func (m *httpRouteModelImpl) resolveRequest(
 	ctx context.Context,
 	req reconcile.Request,
-) (map[apitypes.NamespacedName]resolvedRouteDetails, error) {
+) (map[routeParentResultKey]resolvedRouteDetails, error) {
 	var httpRoute gatewayv1.HTTPRoute
 	if err := m.client.Get(ctx, req.NamespacedName, &httpRoute); err != nil {
 		if apierrors.IsNotFound(err) {
 			m.logger.DebugContext(ctx, "HTTProute not found during resolution",
 				slog.String("route", req.NamespacedName.String()),
 			)
-			return map[apitypes.NamespacedName]resolvedRouteDetails{}, nil
+			return map[routeParentResultKey]resolvedRouteDetails{}, nil
 		}
 		return nil, fmt.Errorf("failed to get HTTPRoute %s: %w", req.NamespacedName.String(), err)
 	}
 
-	results := make(map[apitypes.NamespacedName]resolvedRouteDetails)
+	results := make(map[routeParentResultKey]resolvedRouteDetails)
 
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
-		resolvedGatewayData, matchedListeners, err := m.resolveRouteParentRefData(
+		resolvedGatewayData, matchedListeners, attachmentDenied, err := m.resolveRouteParentRefData(
 			ctx,
 			httpRoute,
 			parentRef,
@@ -794,6 +852,7 @@ func (m *httpRouteModelImpl) resolveRequest(
 				*resolvedGatewayData,
 				makeTargetOnlyParentRef(parentRef),
 				matchedListeners,
+				attachmentDenied,
 			)
 		}
 	}
@@ -822,6 +881,14 @@ func (m *httpRouteModelImpl) acceptRoute(
 	ctx context.Context,
 	routeDetails resolvedRouteDetails,
 ) (*gatewayv1.HTTPRoute, error) {
+	if routeDetails.attachmentDenied {
+		return nil, m.rejectRoute(ctx, routeDetails, fmt.Sprintf(
+			"matched listeners do not allow HTTPRoute %s/%s",
+			routeDetails.httpRoute.Namespace,
+			routeDetails.httpRoute.Name,
+		))
+	}
+
 	winner, conflicted, err := checkL7RouteConflict(ctx, checkL7RouteConflictParams{
 		gateway:            routeDetails.gatewayDetails.gateway,
 		effectiveListeners: routeDetails.gatewayDetails.effectiveListeners,

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -382,6 +382,41 @@ func removeL7RoutePolicyRules(
 	return nil
 }
 
+func mergeL7ProgrammedPolicyRules(
+	existingAnnotation string,
+	programmedPolicyRules []string,
+) []string {
+	if existingAnnotation == "" {
+		return programmedPolicyRules
+	}
+
+	newRules := parseProgrammedHTTPRoutePolicyRules(strings.Join(programmedPolicyRules, ","))
+	newListenerNames := map[string]struct{}{}
+	for _, rule := range newRules {
+		if rule.listenerName == "" {
+			continue
+		}
+		newListenerNames[rule.listenerName] = struct{}{}
+	}
+	if len(newListenerNames) == 0 {
+		return programmedPolicyRules
+	}
+
+	merged := make([]string, 0, len(programmedPolicyRules))
+	for _, rule := range parseProgrammedHTTPRoutePolicyRules(existingAnnotation) {
+		if rule.listenerName == "" {
+			continue
+		}
+		if _, replaced := newListenerNames[rule.listenerName]; replaced {
+			continue
+		}
+		merged = append(merged, fmt.Sprintf("%s/%s", rule.listenerName, rule.ruleName))
+	}
+	merged = append(merged, programmedPolicyRules...)
+
+	return merged
+}
+
 func l7RoutesShareListenerHostname(
 	gateway gatewayv1.Gateway,
 	effectiveListeners []effectiveListener,
@@ -1541,8 +1576,11 @@ func setL7RouteProgrammed(
 		reason:        string(gatewayv1.RouteReasonResolvedRefs),
 		message:       fmt.Sprintf("Route programmed by %s", params.gateway.Name),
 		annotations: map[string]string{
-			params.programmingAnnotation:              params.programmingRevision,
-			params.policyRulesAnnotation:              strings.Join(params.programmedPolicyRules, ","),
+			params.programmingAnnotation: params.programmingRevision,
+			params.policyRulesAnnotation: strings.Join(mergeL7ProgrammedPolicyRules(
+				params.resource.GetAnnotations()[params.policyRulesAnnotation],
+				params.programmedPolicyRules,
+			), ","),
 			params.backendSetsAnnotation:              strings.Join(params.programmedBackendSets, ","),
 			L7RouteProgrammedLoadBalancerIDAnnotation: params.loadBalancerID,
 		},

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -1433,6 +1433,9 @@ func (m *httpRouteModelImpl) deprovisionRoute(
 	controllerutil.RemoveFinalizer(routeToUpdate, HTTPRouteProgrammedFinalizer)
 
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to update HTTPRoute %s/%s after deprovisioning: %w",
 			routeToUpdate.Namespace, routeToUpdate.Name, err)
 	}
@@ -1513,6 +1516,9 @@ func (m *httpRouteModelImpl) removeDetachedHTTPRouteFinalizer(
 		delete(routeToUpdate.Annotations, L7RouteProgrammedLoadBalancerIDAnnotation)
 	}
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to update detached HTTPRoute %s/%s after cleanup: %w",
 			routeToUpdate.Namespace, routeToUpdate.Name, err)
 	}

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1864,6 +1864,78 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes stale backend set when backend ref port changes", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			gateway := newRandomGateway()
+			config := makeRandomGatewayConfig()
+			newPort := gatewayv1.PortNumber(9092)
+			oldPort := gatewayv1.PortNumber(9091)
+			backendRef := makeRandomBackendRef(func(ref *gatewayv1.HTTPBackendRef) {
+				ref.Port = &newPort
+			})
+			oldBackendRef := backendRef
+			oldBackendRef.Port = &oldPort
+			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(
+					makeRandomHTTPRouteRule(randomHTTPRouteRuleWithRandomBackendRefsOpt(backendRef)),
+				),
+			)
+			oldBackendSetName := ociBackendSetNameFromBackendObjectRef(
+				httpRoute.Namespace,
+				oldBackendRef.BackendObjectReference,
+			)
+			newBackendSetName := ociBackendSetNameFromBackendObjectRef(
+				httpRoute.Namespace,
+				backendRef.BackendObjectReference,
+			)
+			require.NotEqual(t, oldBackendSetName, newBackendSetName)
+			httpRoute.Annotations = map[string]string{
+				HTTPRouteProgrammedBackendSetsAnnotation: oldBackendSetName,
+			}
+
+			service := makeRandomService(randomServiceFromBackendRef(backendRef, &httpRoute))
+			knownServicesByName := map[string]corev1.Service{
+				types.NamespacedName{Namespace: service.Namespace, Name: service.Name}.String(): service,
+			}
+			listener := makeRandomListener()
+			rule := makeRandomOCIRoutingRule()
+			rule.Name = new(ociListerPolicyRuleName(httpRoute, 0))
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+
+			ociLBModel.EXPECT().reconcileBackendSet(t.Context(), reconcileBackendSetParams{
+				loadBalancerID: config.Spec.LoadBalancerID,
+				service:        service,
+				routeNS:        httpRoute.Namespace,
+				backendRef:     backendRef.BackendRef,
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
+				httpRoute:          httpRoute,
+				httpRouteRuleIndex: 0,
+			}).Return(rule, nil).Once()
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID: config.Spec.LoadBalancerID,
+				listenerName:   string(listener.Name),
+				policyRules:    []loadbalancer.RoutingRule{rule},
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), config.Spec.LoadBalancerID, oldBackendSetName).
+				Return(nil).
+				Once()
+
+			result, err := model.programRoute(t.Context(), programRouteParams{
+				gateway:          *gateway,
+				config:           config,
+				httpRoute:        httpRoute,
+				knownBackends:    knownServicesByName,
+				matchedListeners: []gatewayv1.Listener{listener},
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, []string{newBackendSetName}, result.programmedBackendSets)
+		})
+
 		t.Run("clears backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
 			fake := faker.New()
 			ociLBModel := NewMockociLoadBalancerModel(t)
@@ -1897,7 +1969,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				Return(nil).
 				Once()
 
-			rules, err := programL7RoutePolicy(t.Context(), ociLBModel, programL7RoutePolicyParams{
+			rules, _, err := programL7RoutePolicy(t.Context(), ociLBModel, programL7RoutePolicyParams{
 				loadBalancerID:   config.Spec.LoadBalancerID,
 				routeName:        "http-" + fake.Lorem().Word(),
 				routeNamespace:   routeNamespace,
@@ -2303,6 +2375,108 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 		})
 	})
 
+	t.Run("removeStaleL7PolicyRules", func(t *testing.T) {
+		t.Run("removes rules for listeners that are no longer matched", func(t *testing.T) {
+			fake := faker.New()
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			loadBalancerID := "lb-" + fake.UUID().V4()
+			currentListenerName := "current-" + fake.Lorem().Word()
+			staleListenerName := "stale-" + fake.Lorem().Word()
+			staleRules := []string{
+				"rule-a-" + fake.Lorem().Word(),
+				"rule-b-" + fake.Lorem().Word(),
+			}
+
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    staleListenerName,
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: staleRules,
+			}).Return(nil).Once()
+
+			err := removeStaleL7PolicyRules(
+				t.Context(),
+				ociLBModel,
+				loadBalancerID,
+				map[string][]string{
+					currentListenerName: {"current-rule-" + fake.Lorem().Word()},
+					staleListenerName:   staleRules,
+				},
+				map[string]struct{}{currentListenerName: {}},
+			)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("returns stale rule cleanup errors", func(t *testing.T) {
+			fake := faker.New()
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			loadBalancerID := "lb-" + fake.UUID().V4()
+			staleListenerName := "stale-" + fake.Lorem().Word()
+			wantErr := errors.New("cleanup-" + fake.Lorem().Sentence(4))
+
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), mock.Anything).Return(wantErr).Once()
+
+			err := removeStaleL7PolicyRules(
+				t.Context(),
+				ociLBModel,
+				loadBalancerID,
+				map[string][]string{staleListenerName: {"rule-" + fake.Lorem().Word()}},
+				map[string]struct{}{},
+			)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+	})
+
+	t.Run("deprovisionStaleL7BackendSets", func(t *testing.T) {
+		t.Run("deprovisions backend sets that are no longer desired", func(t *testing.T) {
+			fake := faker.New()
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			loadBalancerID := "lb-" + fake.UUID().V4()
+			currentBackendSetName := "current-" + fake.Lorem().Word()
+			staleBackendSetName := "stale-" + fake.Lorem().Word()
+
+			ociLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, staleBackendSetName).
+				Return(nil).
+				Once()
+
+			err := deprovisionStaleL7BackendSets(
+				t.Context(),
+				ociLBModel,
+				loadBalancerID,
+				map[string]struct{}{currentBackendSetName: {}},
+				map[string]struct{}{currentBackendSetName: {}, staleBackendSetName: {}},
+			)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("returns stale backend set cleanup errors", func(t *testing.T) {
+			fake := faker.New()
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			loadBalancerID := "lb-" + fake.UUID().V4()
+			staleBackendSetName := "stale-" + fake.Lorem().Word()
+			wantErr := errors.New("backend-set-" + fake.Lorem().Sentence(4))
+
+			ociLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, staleBackendSetName).
+				Return(wantErr).
+				Once()
+
+			err := deprovisionStaleL7BackendSets(
+				t.Context(),
+				ociLBModel,
+				loadBalancerID,
+				map[string]struct{}{},
+				map[string]struct{}{staleBackendSetName: {}},
+			)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+	})
+
 	t.Run("isProgrammingRequired", func(t *testing.T) {
 		// Helper to create base details for isProgrammingRequired tests
 		newIsProgrammingRequiredDetails := func() (gatewayv1.GatewayController, resolvedRouteDetails) {
@@ -2464,6 +2638,10 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 					"rule2-" + fake.Lorem().Word(),
 					"rule3-" + fake.Lorem().Word(),
 				},
+				programmedBackendSets: []string{
+					"backend-set-1-" + fake.Lorem().Word(),
+					"backend-set-2-" + fake.Lorem().Word(),
+				},
 			}
 
 			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
@@ -2477,6 +2655,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				annotations: map[string]string{
 					HTTPRouteProgrammingRevisionAnnotation:    HTTPRouteProgrammingRevisionValue,
 					HTTPRouteProgrammedPolicyRulesAnnotation:  strings.Join(params.programmedPolicyRules, ","),
+					HTTPRouteProgrammedBackendSetsAnnotation:  strings.Join(params.programmedBackendSets, ","),
 					L7RouteProgrammedLoadBalancerIDAnnotation: gatewayData.config.Spec.LoadBalancerID,
 				},
 				finalizer: HTTPRouteProgrammedFinalizer,

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -77,6 +78,58 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				fmt.Sprintf(" %s/%s , %s ,,", listenerName, scopedRule, legacyRule),
 			))
 			assert.Empty(t, parseProgrammedHTTPRoutePolicyRules(" ,, "))
+		})
+	})
+
+	t.Run("removeL7RoutePolicyRules", func(t *testing.T) {
+		t.Run("removes previous policy rules per listener", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			listeners := []gatewayv1.Listener{
+				{Name: "b-listener"},
+				{Name: "a-listener"},
+			}
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    "a-listener",
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{"legacy-rule", "a-rule"},
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    "b-listener",
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{"legacy-rule", "b-rule"},
+			}).Return(nil).Once()
+
+			err := removeL7RoutePolicyRules(
+				t.Context(),
+				ociLBModel,
+				loadBalancerID,
+				listeners,
+				"legacy-rule,b-listener/b-rule,a-listener/a-rule",
+			)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("wraps routing policy removal errors", func(t *testing.T) {
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + faker.New().UUID().V4()
+			listeners := []gatewayv1.Listener{{Name: "https"}}
+			wantErr := errors.New("commit failed")
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    "https",
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{"old-rule"},
+			}).Return(wantErr).Once()
+
+			err := removeL7RoutePolicyRules(t.Context(), ociLBModel, loadBalancerID, listeners, "https/old-rule")
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to remove route policy rules for listener https")
 		})
 	})
 
@@ -153,6 +206,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 		assert.True(t, l7HostnamePatternsIntersect("*.foo.example.com", "*.example.com"))
 		assert.ElementsMatch(t, []gatewayv1.SectionName{grpcListener.Name}, l7RouteAttachedListenerNames(
 			gateway,
+			nil,
 			[]gatewayv1.ParentReference{parentRef, {Name: "other"}},
 			"routes",
 		))
@@ -161,6 +215,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			[]gatewayv1.SectionName{grpcListener.Name, webListener.Name},
 			l7RouteAttachedListenerNames(
 				gateway,
+				nil,
 				[]gatewayv1.ParentReference{{Namespace: &parentNamespace, Name: gatewayv1.ObjectName(gateway.Name)}},
 				"routes",
 			),
@@ -181,16 +236,71 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 		))
 		assert.False(t, l7RoutesShareListenerHostname(
 			gateway,
+			nil,
 			[]gatewayv1.Listener{webListener},
 			current,
 			olderOpposite,
 		))
 		assert.False(t, l7RoutesShareListenerHostname(
 			gateway,
+			nil,
 			[]gatewayv1.Listener{{Name: "missing"}},
 			current,
 			olderOpposite,
 		))
+		listenerSetKind := gatewayv1.Kind("ListenerSet")
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "routes",
+				Name:              "team-a",
+				CreationTimestamp: metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{
+					Namespace: &parentNamespace,
+					Name:      gatewayv1.ObjectName(gateway.Name),
+				},
+				Listeners: []gatewayv1.ListenerEntry{{
+					Name:     "api",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     8443,
+					Hostname: lo.ToPtr(gatewayv1.Hostname("api.example.com")),
+				}},
+			},
+		}
+		listenerSetParentRef := gatewayv1.ParentReference{
+			Kind:        &listenerSetKind,
+			Name:        gatewayv1.ObjectName(listenerSet.Name),
+			SectionName: lo.ToPtr(gatewayv1.SectionName("api")),
+		}
+		effectiveListeners := effectiveListenersForGateway(gateway, []gatewayv1.ListenerSet{listenerSet})
+		matchedListenerSetListeners := effectiveListenersForParentRef(
+			resolvedGatewayDetails{gateway: gateway, effectiveListeners: effectiveListeners},
+			listenerSetParentRef,
+			current.identity.namespace,
+			func(ref gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+				return ref.SectionName != nil && listener.Name == *ref.SectionName
+			},
+		)
+		listenerSetCurrent := current
+		listenerSetCurrent.parentRefs = []gatewayv1.ParentReference{listenerSetParentRef}
+		listenerSetCurrent.hostnames = []gatewayv1.Hostname{"api.example.com"}
+		olderListenerSetRoute := listenerSetCurrent
+		olderListenerSetRoute.identity.name = "aaa"
+		olderListenerSetRoute.identity.creationTimestamp = metav1.NewTime(
+			time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		)
+
+		winner, conflicted = l7RouteConflictingWinner(l7RouteConflictParams{
+			gateway:            gateway,
+			effectiveListeners: effectiveListeners,
+			matchedListeners:   matchedListenerSetListeners,
+			current:            listenerSetCurrent,
+			oppositeRoutes:     []l7RouteCandidate{olderListenerSetRoute},
+		})
+		assert.True(t, conflicted)
+		assert.Equal(t, olderListenerSetRoute.identity, winner.identity)
+
 		newerOpposite := olderOpposite
 		newerOpposite.identity.kind = current.identity.kind
 		newerOpposite.identity.creationTimestamp = metav1.NewTime(time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC))
@@ -448,6 +558,98 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				Kind:      workingRef.Kind,
 			}, receiver.matchedRef)
 			assert.Equal(t, wantListeners, receiver.matchedListeners)
+		})
+
+		t.Run("relevant ListenerSet parent with section name", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			sectionName := gatewayv1.SectionName("https")
+			parentNamespace := gatewayv1.Namespace("infra")
+			fromAll := gatewayv1.NamespacesFromAll
+			parentRef := gatewayv1.ParentReference{
+				Kind:        &listenerSetKind,
+				Name:        "extra",
+				SectionName: &sectionName,
+			}
+			route := makeRandomHTTPRoute(
+				randomHTTPRouteWithRandomParentRefOpt(parentRef),
+			)
+			route.Namespace = "apps"
+			route.Name = "api"
+			req := reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: route.Namespace,
+				Name:      route.Name,
+			}}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(parentRef.Name)},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Namespace: &parentNamespace,
+						Name:      "edge",
+					},
+					Listeners: []gatewayv1.ListenerEntry{
+						{Name: sectionName, Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+					},
+				},
+			}
+			gatewayData := makeRandomAcceptedGatewayDetails()
+			gatewayData.gateway.Namespace = string(parentNamespace)
+			gatewayData.gateway.Name = "edge"
+			gatewayData.gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+			}
+			gatewayData.gateway.Spec.Listeners = nil
+			gatewayData.effectiveListeners = nil
+
+			setupClientGet(t, deps.K8sClient, req.NamespacedName, route)
+			setupClientGet(t, deps.K8sClient, types.NamespacedName{
+				Namespace: listenerSet.Namespace,
+				Name:      listenerSet.Name,
+			}, listenerSet)
+
+			gatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			gatewayModel.EXPECT().resolveReconcileRequest(
+				t.Context(),
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "infra", Name: "edge"}},
+				mock.Anything,
+			).RunAndReturn(func(
+				_ context.Context,
+				_ reconcile.Request,
+				receiver *resolvedGatewayDetails,
+			) (bool, error) {
+				*receiver = *gatewayData
+				return true, nil
+			})
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).
+						Elem().
+						FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.ListenerSet{listenerSet}))
+					return nil
+				})
+			setupClientGet(t, mockClient, types.NamespacedName{Name: listenerSet.Namespace}, corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: listenerSet.Namespace},
+			})
+
+			results, err := model.resolveRequest(t.Context(), req)
+
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			receiver := results[types.NamespacedName{Namespace: "infra", Name: "edge"}]
+			assert.Equal(t, route, receiver.httpRoute)
+			assert.Equal(t, gatewayv1.ParentReference{
+				Kind: &listenerSetKind,
+				Name: parentRef.Name,
+			}, receiver.matchedRef)
+			require.Len(t, receiver.gatewayDetails.listenerSets, 1)
+			require.Len(t, receiver.matchedListeners, 1)
+			assert.NotEqual(t, sectionName, receiver.matchedListeners[0].Name)
+			assert.Equal(t, gatewayv1.HTTPSProtocolType, receiver.matchedListeners[0].Protocol)
 		})
 
 		t.Run("relevant parent with multiple sections", func(t *testing.T) {

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -130,6 +131,78 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			require.ErrorIs(t, err, wantErr)
 			require.ErrorContains(t, err, "failed to remove route policy rules for listener https")
+		})
+	})
+
+	t.Run("deprovisionDetachedL7Route", func(t *testing.T) {
+		t.Run("removes finalizer when load balancer annotation is missing", func(t *testing.T) {
+			called := false
+			err := deprovisionDetachedL7Route(t.Context(), nil, deprovisionDetachedL7RouteParams{
+				route:     &gatewayv1.HTTPRoute{},
+				routeKind: "HTTPRoute",
+				removeFinalizer: func(context.Context) error {
+					called = true
+					return nil
+				},
+			})
+
+			require.NoError(t, err)
+			assert.True(t, called)
+		})
+
+		t.Run("returns policy rule cleanup errors", func(t *testing.T) {
+			wantErr := errors.New("policy cleanup failed")
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps",
+					Name:      "api",
+					Annotations: map[string]string{
+						HTTPRouteProgrammedPolicyRulesAnnotation: "http/rule",
+					},
+				},
+			}
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  "lb-id",
+				listenerName:    "http",
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{"rule"},
+			}).Return(wantErr).Once()
+
+			err := deprovisionDetachedL7Route(t.Context(), ociLBModel, deprovisionDetachedL7RouteParams{
+				route:                 route,
+				routeKind:             "HTTPRoute",
+				policyRulesAnnotation: HTTPRouteProgrammedPolicyRulesAnnotation,
+				loadBalancerID:        "lb-id",
+				removeFinalizer:       func(context.Context) error { return nil },
+			})
+
+			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("deduplicates backend refs and returns backend set cleanup errors", func(t *testing.T) {
+			wantErr := errors.New("backend cleanup failed")
+			route := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "api"}}
+			backendRef := makeRandomBackendRef().BackendRef
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			ociLBModel.EXPECT().deprovisionBackendSet(t.Context(), deprovisionBackendSetParams{
+				loadBalancerID: "lb-id",
+				routeNamespace: "apps",
+				backendRef:     backendRef,
+			}).Return(wantErr).Once()
+
+			err := deprovisionDetachedL7Route(t.Context(), ociLBModel, deprovisionDetachedL7RouteParams{
+				route:          route,
+				routeKind:      "HTTPRoute",
+				loadBalancerID: "lb-id",
+				backendRefs:    []gatewayv1.BackendRef{backendRef, backendRef},
+				removeFinalizer: func(context.Context) error {
+					t.Fatal("finalizer should not be removed when backend cleanup fails")
+					return nil
+				},
+			})
+
+			require.ErrorIs(t, err, wantErr)
 		})
 	})
 
@@ -386,6 +459,81 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 	})
 
 	t.Run("resolveRequest", func(t *testing.T) {
+		t.Run("cleans deleting programmed route with no resolved parent", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			loadBalancerID := "lb-" + fake.UUID().V4()
+			listenerName := "listener-" + fake.Lorem().Word()
+			ruleName := "rule-" + fake.Lorem().Word()
+			deleteTime := metav1.Now()
+			backendRef := makeRandomBackendRef()
+			route := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(
+					makeRandomHTTPRouteRule(randomHTTPRouteRuleWithRandomBackendRefsOpt(backendRef)),
+				),
+			)
+			route.DeletionTimestamp = &deleteTime
+			route.Finalizers = []string{HTTPRouteProgrammedFinalizer}
+			route.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation:  listenerName + "/" + ruleName,
+				L7RouteProgrammedLoadBalancerIDAnnotation: loadBalancerID,
+			}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: route.Namespace, Name: route.Name}}
+
+			setupClientGet(t, deps.K8sClient, req.NamespacedName, route)
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    listenerName,
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{ruleName},
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().deprovisionBackendSet(t.Context(), deprovisionBackendSetParams{
+				loadBalancerID: loadBalancerID,
+				routeNamespace: route.Namespace,
+				backendRef:     backendRef.BackendRef,
+			}).Return(nil).Once()
+			k8sClient.EXPECT().Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updated, ok := obj.(*gatewayv1.HTTPRoute)
+				return ok &&
+					!controllerutil.ContainsFinalizer(updated, HTTPRouteProgrammedFinalizer) &&
+					updated.Annotations[HTTPRouteProgrammedPolicyRulesAnnotation] == "" &&
+					updated.Annotations[L7RouteProgrammedLoadBalancerIDAnnotation] == ""
+			})).Return(nil).Once()
+
+			got, err := model.resolveRequest(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Empty(t, got)
+		})
+
+		t.Run("wraps detached cleanup errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			deleteTime := metav1.Now()
+			route := makeRandomHTTPRoute()
+			route.DeletionTimestamp = &deleteTime
+			route.Finalizers = []string{HTTPRouteProgrammedFinalizer}
+			route.Annotations = map[string]string{
+				L7RouteProgrammedLoadBalancerIDAnnotation: "lb-id",
+			}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: route.Namespace, Name: route.Name}}
+			wantErr := errors.New("update failed")
+
+			setupClientGet(t, deps.K8sClient, req.NamespacedName, route)
+			k8sClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.HTTPRoute")).
+				Return(wantErr).
+				Once()
+
+			_, err := model.resolveRequest(t.Context(), req)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to deprovision detached HTTPRoute")
+		})
+
 		t.Run("relevant parent", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)
@@ -2217,7 +2365,8 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				conditions:    details.httpRoute.Status.Parents[0].Conditions,
 				conditionType: string(gatewayv1.RouteConditionResolvedRefs),
 				annotations: map[string]string{
-					HTTPRouteProgrammingRevisionAnnotation: HTTPRouteProgrammingRevisionValue,
+					HTTPRouteProgrammingRevisionAnnotation:    HTTPRouteProgrammingRevisionValue,
+					L7RouteProgrammedLoadBalancerIDAnnotation: details.gatewayDetails.config.Spec.LoadBalancerID,
 				},
 			}).Return(checkResult)
 
@@ -2308,6 +2457,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				httpRoute:    route,
 				gatewayClass: gatewayData.gatewayClass,
 				gateway:      gatewayData.gateway,
+				config:       gatewayData.config,
 				matchedRef:   matchedRef,
 				programmedPolicyRules: []string{
 					"rule1-" + fake.Lorem().Word(),
@@ -2325,8 +2475,9 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				reason:        string(gatewayv1.RouteReasonResolvedRefs),
 				message:       fmt.Sprintf("Route programmed by %s", params.gateway.Name),
 				annotations: map[string]string{
-					HTTPRouteProgrammingRevisionAnnotation:   HTTPRouteProgrammingRevisionValue,
-					HTTPRouteProgrammedPolicyRulesAnnotation: strings.Join(params.programmedPolicyRules, ","),
+					HTTPRouteProgrammingRevisionAnnotation:    HTTPRouteProgrammingRevisionValue,
+					HTTPRouteProgrammedPolicyRulesAnnotation:  strings.Join(params.programmedPolicyRules, ","),
+					L7RouteProgrammedLoadBalancerIDAnnotation: gatewayData.config.Spec.LoadBalancerID,
 				},
 				finalizer: HTTPRouteProgrammedFinalizer,
 			}).Return(nil)

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -82,6 +82,46 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 		})
 	})
 
+	t.Run("mergeL7ProgrammedPolicyRules", func(t *testing.T) {
+		t.Run("returns current rules when previous annotation is empty", func(t *testing.T) {
+			rules := []string{"listener-" + faker.New().Lorem().Word() + "/rule"}
+
+			assert.Equal(t, rules, mergeL7ProgrammedPolicyRules("", rules))
+		})
+
+		t.Run("returns current rules when current rules are legacy unscoped entries", func(t *testing.T) {
+			fake := faker.New()
+			rules := []string{"rule-" + fake.Lorem().Word()}
+
+			assert.Equal(t, rules, mergeL7ProgrammedPolicyRules(
+				"listener-"+fake.Lorem().Word()+"/old-rule",
+				rules,
+			))
+		})
+
+		t.Run("preserves other listener rules and replaces current listener rules", func(t *testing.T) {
+			fake := faker.New()
+			gatewayListenerName := "gateway-" + fake.Lorem().Word()
+			listenerSetListenerName := "listenerset-" + fake.Lorem().Word()
+			gatewayRule := "gateway-rule-" + fake.Lorem().Word()
+			oldListenerSetRule := "old-listenerset-rule-" + fake.Lorem().Word()
+			newListenerSetRule := "new-listenerset-rule-" + fake.Lorem().Word()
+
+			assert.Equal(t, []string{
+				fmt.Sprintf("%s/%s", gatewayListenerName, gatewayRule),
+				fmt.Sprintf("%s/%s", listenerSetListenerName, newListenerSetRule),
+			}, mergeL7ProgrammedPolicyRules(
+				strings.Join([]string{
+					"legacy-" + fake.Lorem().Word(),
+					"",
+					fmt.Sprintf("%s/%s", gatewayListenerName, gatewayRule),
+					fmt.Sprintf("%s/%s", listenerSetListenerName, oldListenerSetRule),
+				}, ","),
+				[]string{fmt.Sprintf("%s/%s", listenerSetListenerName, newListenerSetRule)},
+			))
+		})
+	})
+
 	t.Run("removeL7RoutePolicyRules", func(t *testing.T) {
 		t.Run("removes previous policy rules per listener", func(t *testing.T) {
 			fake := faker.New()
@@ -2720,6 +2760,67 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			}).Return(nil)
 
 			// The model receives details by value, so it works on a copy of httpRoute.
+			err := model.setProgrammed(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("preserves other listener policy rules when route has multiple parents", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			route := makeRandomHTTPRoute()
+			route.Generation = rand.Int64N(1000) + 1
+			gatewayData := makeRandomAcceptedGatewayDetails()
+			gatewayParentRef := makeRandomParentRef()
+			listenerSetParentRef := makeRandomParentRef()
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			listenerSetParentRef.Kind = &listenerSetKind
+
+			route.Status.Parents = []gatewayv1.RouteParentStatus{
+				{
+					ParentRef:      gatewayParentRef,
+					ControllerName: gatewayData.gatewayClass.Spec.ControllerName,
+					Conditions:     []metav1.Condition{{Type: string(gatewayv1.RouteConditionResolvedRefs)}},
+				},
+				{
+					ParentRef:      listenerSetParentRef,
+					ControllerName: gatewayData.gatewayClass.Spec.ControllerName,
+					Conditions:     []metav1.Condition{{Type: string(gatewayv1.RouteConditionResolvedRefs)}},
+				},
+			}
+
+			gatewayListenerName := "https-" + fake.Lorem().Word()
+			listenerSetListenerName := "ls-" + fake.Lorem().Word()
+			oldGatewayRule := "gateway-rule-" + fake.Lorem().Word()
+			oldListenerSetRule := "old-listenerset-rule-" + fake.Lorem().Word()
+			newListenerSetRule := "new-listenerset-rule-" + fake.Lorem().Word()
+			route.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation: strings.Join([]string{
+					fmt.Sprintf("%s/%s", gatewayListenerName, oldGatewayRule),
+					fmt.Sprintf("%s/%s", listenerSetListenerName, oldListenerSetRule),
+				}, ","),
+			}
+
+			params := setProgrammedParams{
+				httpRoute:             route,
+				gatewayClass:          gatewayData.gatewayClass,
+				gateway:               gatewayData.gateway,
+				config:                gatewayData.config,
+				matchedRef:            listenerSetParentRef,
+				programmedPolicyRules: []string{fmt.Sprintf("%s/%s", listenerSetListenerName, newListenerSetRule)},
+				programmedBackendSets: []string{"backend-set-" + fake.Lorem().Word()},
+			}
+
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			mockResourcesModel.EXPECT().setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+				policyRules := params.annotations[HTTPRouteProgrammedPolicyRulesAnnotation]
+				return assert.Equal(t, strings.Join([]string{
+					fmt.Sprintf("%s/%s", gatewayListenerName, oldGatewayRule),
+					fmt.Sprintf("%s/%s", listenerSetListenerName, newListenerSetRule),
+				}, ","), policyRules)
+			})).Return(nil)
+
 			err := model.setProgrammed(t.Context(), params)
 			require.NoError(t, err)
 		})

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -244,6 +244,23 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			require.ErrorIs(t, err, wantErr)
 		})
+
+		t.Run("detached finalizer removal ignores not found", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			httpRoute := makeRandomHTTPRoute()
+			httpRoute.Finalizers = []string{HTTPRouteProgrammedFinalizer}
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().Update(t.Context(), mock.Anything).
+				Return(apierrors.NewNotFound(schema.GroupResource{
+					Group:    gatewayv1.GroupName,
+					Resource: "httproutes",
+				}, httpRoute.Name))
+
+			err := model.removeDetachedHTTPRouteFinalizer(t.Context(), httpRoute)
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("l7 route conflict helpers", func(t *testing.T) {
@@ -3067,6 +3084,56 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				updatedRoute, ok := obj.(*gatewayv1.HTTPRoute)
 				return ok && assert.NotContains(t, updatedRoute.Finalizers, HTTPRouteProgrammedFinalizer)
 			})).Return(nil)
+
+			err := model.deprovisionRoute(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("ignores not found when removing finalizer after cleanup", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			config := makeRandomGatewayConfig()
+			backendRef := makeRandomBackendRef()
+			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(makeRandomHTTPRouteRule(
+					randomHTTPRouteRuleWithRandomBackendRefsOpt(backendRef),
+				)),
+			)
+			httpRoute.Finalizers = []string{HTTPRouteProgrammedFinalizer}
+			listener := makeRandomListener()
+			previousRule := "rule-" + fake.Lorem().Word()
+			httpRoute.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation: fmt.Sprintf("%s/%s", listener.Name, previousRule),
+			}
+
+			params := deprovisionRouteParams{
+				gateway:          *newRandomGateway(),
+				config:           config,
+				httpRoute:        httpRoute,
+				matchedListeners: []gatewayv1.Listener{listener},
+			}
+
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			commitCall := ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  config.Spec.LoadBalancerID,
+				listenerName:    string(listener.Name),
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{previousRule},
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().deprovisionBackendSet(t.Context(), deprovisionBackendSetParams{
+				loadBalancerID: config.Spec.LoadBalancerID,
+				routeNamespace: httpRoute.Namespace,
+				backendRef:     backendRef.BackendRef,
+			}).Return(nil).Once().NotBefore(commitCall)
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().Update(t.Context(), mock.Anything).
+				Return(apierrors.NewNotFound(schema.GroupResource{
+					Group:    gatewayv1.GroupName,
+					Resource: "httproutes",
+				}, httpRoute.Name))
 
 			err := model.deprovisionRoute(t.Context(), params)
 			require.NoError(t, err)

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -617,8 +617,8 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				Namespace: string(lo.FromPtr(workingRef.Namespace)),
 				Name:      string(workingRef.Name),
 			}
-			require.Contains(t, results, parentKey)
-			receiver := results[parentKey]
+			require.Contains(t, results, gatewayParentResultKey(parentKey))
+			receiver := results[gatewayParentResultKey(parentKey)]
 
 			assert.Equal(t, route, receiver.httpRoute)
 			assert.Equal(t, *gatewayData, receiver.gatewayDetails)
@@ -694,8 +694,8 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				Namespace: string(lo.FromPtr(workingRef.Namespace)),
 				Name:      string(workingRef.Name),
 			}
-			require.Contains(t, results, parentKey)
-			receiver := results[parentKey]
+			require.Contains(t, results, gatewayParentResultKey(parentKey))
+			receiver := results[gatewayParentResultKey(parentKey)]
 
 			assert.Equal(t, route, receiver.httpRoute)
 			assert.Equal(t, *gatewayData, receiver.gatewayDetails)
@@ -788,7 +788,11 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, results, 1)
-			receiver := results[types.NamespacedName{Namespace: "infra", Name: "edge"}]
+			receiver := results[routeParentResultKey{
+				kind:      listenerSetKind,
+				namespace: route.Namespace,
+				name:      "extra",
+			}]
 			assert.Equal(t, route, receiver.httpRoute)
 			assert.Equal(t, gatewayv1.ParentReference{
 				Kind: &listenerSetKind,
@@ -798,6 +802,60 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.Len(t, receiver.matchedListeners, 1)
 			assert.NotEqual(t, sectionName, receiver.matchedListeners[0].Name)
 			assert.Equal(t, gatewayv1.HTTPSProtocolType, receiver.matchedListeners[0].Protocol)
+		})
+
+		t.Run("Gateway and ListenerSet parents keep independent results", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			gatewayNamespace := gatewayv1.Namespace("infra")
+			route := makeRandomHTTPRoute(randomHTTPRouteWithNamespaceOpt("apps"))
+			gatewayParentRef := gatewayv1.ParentReference{
+				Namespace: &gatewayNamespace,
+				Name:      "edge",
+			}
+			listenerSetParentRef := gatewayv1.ParentReference{
+				Kind: &listenerSetKind,
+				Name: "extra",
+			}
+			gatewayDetails := resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{
+					Namespace: string(gatewayNamespace),
+					Name:      string(gatewayParentRef.Name),
+				}},
+			}
+			results := map[routeParentResultKey]resolvedRouteDetails{}
+
+			model.aggregateRouteParentRefData(
+				t.Context(),
+				results,
+				route,
+				gatewayDetails,
+				gatewayParentRef,
+				[]gatewayv1.Listener{{Name: "https"}},
+				false,
+			)
+			model.aggregateRouteParentRefData(
+				t.Context(),
+				results,
+				route,
+				gatewayDetails,
+				listenerSetParentRef,
+				[]gatewayv1.Listener{{Name: "extra-https"}},
+				false,
+			)
+
+			require.Len(t, results, 2)
+			assert.Contains(t, results, routeParentResultKey{
+				kind:      "Gateway",
+				namespace: "infra",
+				name:      "edge",
+			})
+			assert.Contains(t, results, routeParentResultKey{
+				kind:      listenerSetKind,
+				namespace: "apps",
+				name:      "extra",
+			})
 		})
 
 		t.Run("relevant parent with multiple sections", func(t *testing.T) {
@@ -892,8 +950,8 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				Namespace: string(lo.FromPtr(workingRef1.Namespace)),
 				Name:      string(workingRef1.Name),
 			}
-			require.Contains(t, results, parentKey)
-			receiver := results[parentKey]
+			require.Contains(t, results, gatewayParentResultKey(parentKey))
+			receiver := results[gatewayParentResultKey(parentKey)]
 
 			assert.Equal(t, route, receiver.httpRoute)
 			assert.Equal(t, *gatewayData, receiver.gatewayDetails)
@@ -990,8 +1048,8 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				Namespace: string(lo.FromPtr(refWithoutSection.Namespace)),
 				Name:      string(refWithoutSection.Name),
 			}
-			require.Contains(t, results, parentKey)
-			res := results[parentKey]
+			require.Contains(t, results, gatewayParentResultKey(parentKey))
+			res := results[gatewayParentResultKey(parentKey)]
 
 			assert.Equal(t, *gatewayData2, res.gatewayDetails)
 			assert.Equal(t, gatewayv1.ParentReference{

--- a/internal/app/l4_route_model_helpers_test.go
+++ b/internal/app/l4_route_model_helpers_test.go
@@ -128,7 +128,9 @@ func TestL4RouteModelHelpers(t *testing.T) {
 
 		matches := matchingL4RoutesForListener(
 			routes,
-			apitypes.NamespacedName{Namespace: "media", Name: "edge"},
+			resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "media", Name: "edge"}},
+			},
 			listener,
 			"",
 			tlsRouteKey,
@@ -136,7 +138,6 @@ func TestL4RouteModelHelpers(t *testing.T) {
 			func(route gatewayv1.TLSRoute) metav1.Time { return route.CreationTimestamp },
 			func(route gatewayv1.TLSRoute) []gatewayv1.ParentReference { return route.Spec.ParentRefs },
 			func(route gatewayv1.TLSRoute) bool { return route.DeletionTimestamp != nil },
-			tlsRouteParentRefTarget,
 			tlsRouteMatchesListener,
 		)
 

--- a/internal/app/l4route_policy.go
+++ b/internal/app/l4route_policy.go
@@ -107,6 +107,28 @@ func parentRefTargetsGateway(parentRef gatewayv1.ParentReference) bool {
 	return group == gatewayAPIGroup && kind == "Gateway"
 }
 
+func parentRefTargetsListenerSet(parentRef gatewayv1.ParentReference) bool {
+	group := gatewayAPIGroup
+	if parentRef.Group != nil {
+		group = string(*parentRef.Group)
+	}
+	if parentRef.Kind == nil {
+		return false
+	}
+	return group == gatewayAPIGroup && string(*parentRef.Kind) == "ListenerSet"
+}
+
+func parentRefTargetName(parentRef gatewayv1.ParentReference, routeNamespace string) apitypes.NamespacedName {
+	namespace := routeNamespace
+	if parentRef.Namespace != nil {
+		namespace = string(*parentRef.Namespace)
+	}
+	return apitypes.NamespacedName{
+		Namespace: namespace,
+		Name:      string(parentRef.Name),
+	}
+}
+
 func l4ValidateServiceBackendRef(backendRef gatewayv1.BackendRef) error {
 	group := ""
 	if backendRef.BackendObjectReference.Group != nil {

--- a/internal/app/l4route_policy.go
+++ b/internal/app/l4route_policy.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -16,19 +17,12 @@ const gatewayAPIGroup = "gateway.networking.k8s.io"
 const serviceKind = "Service"
 
 func l4RouteKindAllowed(listener gatewayv1.Listener, routeKind gatewayv1.Kind) bool {
+	return routeKindAllowedForListener(listener, routeKind)
+}
+
+func routeKindAllowedForListener(listener gatewayv1.Listener, routeKind gatewayv1.Kind) bool {
 	if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
-		switch listener.Protocol {
-		case gatewayv1.TCPProtocolType:
-			return routeKind == "TCPRoute"
-		case gatewayv1.UDPProtocolType:
-			return routeKind == "UDPRoute"
-		case gatewayv1.TLSProtocolType:
-			return routeKind == "TLSRoute"
-		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
-			return false
-		default:
-			return false
-		}
+		return slices.Contains(supportedRouteKindNamesForProtocol(listener.Protocol), routeKind)
 	}
 
 	for _, allowedKind := range listener.AllowedRoutes.Kinds {
@@ -41,6 +35,38 @@ func l4RouteKindAllowed(listener gatewayv1.Listener, routeKind gatewayv1.Kind) b
 		}
 	}
 	return false
+}
+
+func allowedRouteListeners(
+	ctx context.Context,
+	k8sClient k8sClient,
+	gatewayDetails resolvedGatewayDetails,
+	routeNamespace string,
+	matchedListeners []gatewayv1.Listener,
+	routeKind gatewayv1.Kind,
+) ([]gatewayv1.Listener, error) {
+	allowed := make([]gatewayv1.Listener, 0, len(matchedListeners))
+	for _, listener := range matchedListeners {
+		if listener.AllowedRoutes == nil {
+			allowed = append(allowed, listener)
+			continue
+		}
+		if len(listener.AllowedRoutes.Kinds) > 0 && !routeKindAllowedForListener(listener, routeKind) {
+			continue
+		}
+		if listener.AllowedRoutes.Namespaces != nil {
+			ownerNamespace := effectiveListenerSourceNamespaceForOCIListener(gatewayDetails, listener)
+			namespaceAllowed, err := l4RouteNamespaceAllowed(ctx, k8sClient, ownerNamespace, routeNamespace, listener)
+			if err != nil {
+				return nil, err
+			}
+			if !namespaceAllowed {
+				continue
+			}
+		}
+		allowed = append(allowed, listener)
+	}
+	return allowed, nil
 }
 
 func l4RouteNamespaceAllowed(

--- a/internal/app/l4route_policy_test.go
+++ b/internal/app/l4route_policy_test.go
@@ -150,6 +150,80 @@ func TestL4RoutePolicy(t *testing.T) {
 		assert.False(t, allowed)
 	})
 
+	t.Run("allowedRouteListeners filters by kind and namespace policy", func(t *testing.T) {
+		same := gatewayv1.NamespacesFromSame
+		all := gatewayv1.NamespacesFromAll
+		listeners, err := allowedRouteListeners(
+			t.Context(),
+			NewMockk8sClient(t),
+			resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra"}},
+			},
+			"apps",
+			[]gatewayv1.Listener{
+				{Name: "no-policy", Protocol: gatewayv1.TCPProtocolType},
+				{
+					Name:     "wrong-kind",
+					Protocol: gatewayv1.TCPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Kinds: []gatewayv1.RouteGroupKind{{Kind: "UDPRoute"}},
+					},
+				},
+				{
+					Name:     "same-namespace-only",
+					Protocol: gatewayv1.TCPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: &same},
+					},
+				},
+				{
+					Name:     "all-namespaces",
+					Protocol: gatewayv1.TCPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: &all},
+					},
+				},
+			},
+			"TCPRoute",
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, []gatewayv1.SectionName{"no-policy", "all-namespaces"}, lo.Map(
+			listeners,
+			func(listener gatewayv1.Listener, _ int) gatewayv1.SectionName {
+				return listener.Name
+			},
+		))
+	})
+
+	t.Run("allowedRouteListeners returns namespace selector errors", func(t *testing.T) {
+		selector := gatewayv1.NamespacesFromSelector
+		listeners, err := allowedRouteListeners(
+			t.Context(),
+			NewMockk8sClient(t),
+			resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra"}},
+			},
+			"apps",
+			[]gatewayv1.Listener{{
+				Name:     "bad-selector",
+				Protocol: gatewayv1.TCPProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Namespaces: &gatewayv1.RouteNamespaces{
+						From: &selector,
+						Selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Operator: "bad",
+						}}},
+					},
+				},
+			}},
+			"TCPRoute",
+		)
+
+		require.Error(t, err)
+		assert.Nil(t, listeners)
+	})
+
 	t.Run("validates backend refs and weights", func(t *testing.T) {
 		require.NoError(t, l4ValidateServiceBackendRef(gatewayv1.BackendRef{}))
 		require.Error(t, l4ValidateServiceBackendRef(gatewayv1.BackendRef{

--- a/internal/app/listenerset_controller.go
+++ b/internal/app/listenerset_controller.go
@@ -1,0 +1,320 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"strings"
+
+	"go.uber.org/dig"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type listenerSetStatusClient interface {
+	Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+	Status() client.SubResourceWriter
+	Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
+}
+
+// ListenerSetController reconciles ListenerSet status that cannot be driven by parent Gateway reconciliation.
+type ListenerSetController struct {
+	logger *slog.Logger
+	client listenerSetStatusClient
+}
+
+type ListenerSetControllerDeps struct {
+	dig.In
+
+	RootLogger *slog.Logger
+	K8sClient  k8sClient
+}
+
+func NewListenerSetController(deps ListenerSetControllerDeps) *ListenerSetController {
+	return &ListenerSetController{
+		logger: deps.RootLogger.WithGroup("listenerset-controller"),
+		client: deps.K8sClient,
+	}
+}
+
+func (c *ListenerSetController) Reconcile(
+	ctx context.Context,
+	req reconcile.Request,
+) (reconcile.Result, error) {
+	c.logger.InfoContext(ctx, fmt.Sprintf("Processing reconciliation for ListenerSet %s", req.NamespacedName))
+
+	var listenerSet gatewayv1.ListenerSet
+	if err := c.client.Get(ctx, req.NamespacedName, &listenerSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get ListenerSet %s: %w", req.NamespacedName, err)
+	}
+	if listenerSet.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
+	status, err := c.statusForListenerSet(ctx, listenerSet)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if listenerSetStatusSemanticallyEqual(listenerSet.Status, status) {
+		return reconcile.Result{}, c.updateParentGatewayAnnotation(ctx, req.NamespacedName, listenerSet)
+	}
+	listenerSet.Status = status
+	if err = c.client.Status().Update(ctx, &listenerSet); err != nil {
+		return reconcile.Result{}, fmt.Errorf(
+			"failed to update ListenerSet %s status: %w",
+			req.NamespacedName,
+			err,
+		)
+	}
+	if err = c.updateParentGatewayAnnotation(ctx, req.NamespacedName, listenerSet); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (c *ListenerSetController) updateParentGatewayAnnotation(
+	ctx context.Context,
+	listenerSetKey client.ObjectKey,
+	resolvedListenerSet gatewayv1.ListenerSet,
+) error {
+	desiredParent := ""
+	if parentName, ok := listenerSetParentGatewayName(resolvedListenerSet); ok {
+		desiredParent = parentName
+	}
+
+	var listenerSet gatewayv1.ListenerSet
+	if err := c.client.Get(ctx, listenerSetKey, &listenerSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to refresh ListenerSet %s before annotation update: %w", listenerSetKey, err)
+	}
+
+	annotations := listenerSet.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if annotations[ListenerSetParentGatewayAnnotation] == desiredParent {
+		return nil
+	}
+
+	nextAnnotations := maps.Clone(annotations)
+	if desiredParent == "" {
+		delete(nextAnnotations, ListenerSetParentGatewayAnnotation)
+	} else {
+		nextAnnotations[ListenerSetParentGatewayAnnotation] = desiredParent
+	}
+	listenerSet.Annotations = nextAnnotations
+	if err := c.client.Update(ctx, &listenerSet); err != nil {
+		return fmt.Errorf(
+			"failed to update ListenerSet %s/%s parent Gateway annotation: %w",
+			listenerSet.Namespace,
+			listenerSet.Name,
+			err,
+		)
+	}
+	return nil
+}
+
+func (c *ListenerSetController) statusForListenerSet(
+	ctx context.Context,
+	listenerSet gatewayv1.ListenerSet,
+) (gatewayv1.ListenerSetStatus, error) {
+	parentName, ok := listenerSetParentGatewayName(listenerSet)
+	if !ok {
+		return rejectedListenerSetStatus(
+			listenerSet,
+			gatewayv1.ListenerSetReasonInvalid,
+			"ListenerSet parentRef must target a Gateway",
+		), nil
+	}
+	parentNamespace, parentGatewayName, ok := stringsCutParentName(parentName)
+	if !ok {
+		return rejectedListenerSetStatus(
+			listenerSet,
+			gatewayv1.ListenerSetReasonInvalid,
+			"ListenerSet parentRef is invalid",
+		), nil
+	}
+
+	var gateway gatewayv1.Gateway
+	if err := c.client.Get(ctx, apitypes.NamespacedName{
+		Namespace: parentNamespace,
+		Name:      parentGatewayName,
+	}, &gateway); err != nil {
+		if apierrors.IsNotFound(err) {
+			return rejectedListenerSetStatus(
+				listenerSet,
+				gatewayv1.ListenerSetReasonParentNotAccepted,
+				fmt.Sprintf("parent Gateway %s was not found", parentName),
+			), nil
+		}
+		return gatewayv1.ListenerSetStatus{}, fmt.Errorf("failed to get parent Gateway %s: %w", parentName, err)
+	}
+
+	var gatewayClass gatewayv1.GatewayClass
+	if err := c.client.Get(
+		ctx,
+		apitypes.NamespacedName{Name: string(gateway.Spec.GatewayClassName)},
+		&gatewayClass,
+	); err != nil {
+		if apierrors.IsNotFound(err) {
+			return rejectedListenerSetStatus(
+				listenerSet,
+				gatewayv1.ListenerSetReasonParentNotAccepted,
+				fmt.Sprintf("parent GatewayClass %s was not found", gateway.Spec.GatewayClassName),
+			), nil
+		}
+		return gatewayv1.ListenerSetStatus{}, fmt.Errorf(
+			"failed to get parent GatewayClass %s: %w",
+			gateway.Spec.GatewayClassName,
+			err,
+		)
+	}
+	if !listenerSetGatewayClassSupported(gatewayClass) {
+		return rejectedListenerSetStatus(
+			listenerSet,
+			gatewayv1.ListenerSetReasonParentNotAccepted,
+			fmt.Sprintf("parent GatewayClass %s is not managed by this controller", gateway.Spec.GatewayClassName),
+		), nil
+	}
+
+	var listenerSetNamespace corev1.Namespace
+	if err := c.client.Get(
+		ctx,
+		apitypes.NamespacedName{Name: listenerSet.Namespace},
+		&listenerSetNamespace,
+	); err != nil {
+		if apierrors.IsNotFound(err) {
+			return rejectedListenerSetStatus(
+				listenerSet,
+				gatewayv1.ListenerSetReasonNotAllowed,
+				fmt.Sprintf("ListenerSet namespace %s was not found", listenerSet.Namespace),
+			), nil
+		}
+		return gatewayv1.ListenerSetStatus{}, fmt.Errorf(
+			"failed to get ListenerSet namespace %s: %w",
+			listenerSet.Namespace,
+			err,
+		)
+	}
+	if !listenerSetAllowedByGateway(gateway, listenerSet, listenerSetNamespace) {
+		return rejectedListenerSetStatus(
+			listenerSet,
+			gatewayv1.ListenerSetReasonNotAllowed,
+			fmt.Sprintf(
+				"ListenerSet %s/%s is not allowed by Gateway %s",
+				listenerSet.Namespace,
+				listenerSet.Name,
+				parentName,
+			),
+		), nil
+	}
+
+	return pendingListenerSetStatus(listenerSet, gateway), nil
+}
+
+func listenerSetGatewayClassSupported(gatewayClass gatewayv1.GatewayClass) bool {
+	return gatewayClass.Spec.ControllerName == gatewayv1.GatewayController(ControllerClassName) ||
+		gatewayClass.Spec.ControllerName == gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName)
+}
+
+func stringsCutParentName(parentName string) (string, string, bool) {
+	namespace, name, ok := strings.Cut(parentName, "/")
+	return namespace, name, ok
+}
+
+func pendingListenerSetStatus(
+	listenerSet gatewayv1.ListenerSet,
+	gateway gatewayv1.Gateway,
+) gatewayv1.ListenerSetStatus {
+	status := listenerSetStatusWithConditions(
+		listenerSet,
+		metav1.ConditionTrue,
+		gatewayv1.ListenerSetReasonAccepted,
+		fmt.Sprintf(
+			"ListenerSet %s/%s accepted by Gateway %s/%s",
+			listenerSet.Namespace,
+			listenerSet.Name,
+			gateway.Namespace,
+			gateway.Name,
+		),
+		metav1.ConditionUnknown,
+		gatewayv1.ListenerSetReasonPending,
+		fmt.Sprintf(
+			"ListenerSet %s/%s is waiting for parent Gateway programming",
+			listenerSet.Namespace,
+			listenerSet.Name,
+		),
+	)
+	status.Listeners = listenerSetPendingListenerStatuses(listenerSet)
+	return status
+}
+
+func rejectedListenerSetStatus(
+	listenerSet gatewayv1.ListenerSet,
+	reason gatewayv1.ListenerSetConditionReason,
+	message string,
+) gatewayv1.ListenerSetStatus {
+	status := listenerSetStatusWithConditions(
+		listenerSet,
+		metav1.ConditionFalse,
+		reason,
+		message,
+		metav1.ConditionFalse,
+		reason,
+		message,
+	)
+	status.Listeners = listenerSetPendingListenerStatuses(listenerSet)
+	return status
+}
+
+func listenerSetStatusWithConditions(
+	listenerSet gatewayv1.ListenerSet,
+	acceptedStatus metav1.ConditionStatus,
+	acceptedReason gatewayv1.ListenerSetConditionReason,
+	acceptedMessage string,
+	programmedStatus metav1.ConditionStatus,
+	programmedReason gatewayv1.ListenerSetConditionReason,
+	programmedMessage string,
+) gatewayv1.ListenerSetStatus {
+	status := gatewayv1.ListenerSetStatus{}
+	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+		Type:               string(gatewayv1.ListenerSetConditionAccepted),
+		Status:             acceptedStatus,
+		Reason:             string(acceptedReason),
+		ObservedGeneration: listenerSet.Generation,
+		LastTransitionTime: metav1.Now(),
+		Message:            acceptedMessage,
+	})
+	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+		Type:               string(gatewayv1.ListenerSetConditionProgrammed),
+		Status:             programmedStatus,
+		Reason:             string(programmedReason),
+		ObservedGeneration: listenerSet.Generation,
+		LastTransitionTime: metav1.Now(),
+		Message:            programmedMessage,
+	})
+	return status
+}
+
+func listenerSetPendingListenerStatuses(listenerSet gatewayv1.ListenerSet) []gatewayv1.ListenerEntryStatus {
+	statuses := make([]gatewayv1.ListenerEntryStatus, 0, len(listenerSet.Spec.Listeners))
+	for _, listener := range listenerSet.Spec.Listeners {
+		statuses = append(statuses, gatewayv1.ListenerEntryStatus{
+			Name:           listener.Name,
+			SupportedKinds: supportedRouteKindsForListener(listenerFromListenerSetEntry(listener)),
+		})
+	}
+	return statuses
+}

--- a/internal/app/listenerset_controller.go
+++ b/internal/app/listenerset_controller.go
@@ -257,7 +257,15 @@ func pendingListenerSetStatus(
 			listenerSet.Name,
 		),
 	)
-	status.Listeners = listenerSetPendingListenerStatuses(listenerSet)
+	status.Listeners = listenerSetListenerStatuses(
+		listenerSet,
+		metav1.ConditionTrue,
+		gatewayv1.ListenerReasonAccepted,
+		fmt.Sprintf("listener accepted by Gateway %s/%s", gateway.Namespace, gateway.Name),
+		metav1.ConditionUnknown,
+		gatewayv1.ListenerReasonPending,
+		"listener is waiting for parent Gateway programming",
+	)
 	return status
 }
 
@@ -275,7 +283,15 @@ func rejectedListenerSetStatus(
 		reason,
 		message,
 	)
-	status.Listeners = listenerSetPendingListenerStatuses(listenerSet)
+	status.Listeners = listenerSetListenerStatuses(
+		listenerSet,
+		metav1.ConditionFalse,
+		gatewayv1.ListenerConditionReason(reason),
+		message,
+		metav1.ConditionFalse,
+		gatewayv1.ListenerConditionReason(reason),
+		message,
+	)
 	return status
 }
 
@@ -308,13 +324,38 @@ func listenerSetStatusWithConditions(
 	return status
 }
 
-func listenerSetPendingListenerStatuses(listenerSet gatewayv1.ListenerSet) []gatewayv1.ListenerEntryStatus {
+func listenerSetListenerStatuses(
+	listenerSet gatewayv1.ListenerSet,
+	acceptedStatus metav1.ConditionStatus,
+	acceptedReason gatewayv1.ListenerConditionReason,
+	acceptedMessage string,
+	programmedStatus metav1.ConditionStatus,
+	programmedReason gatewayv1.ListenerConditionReason,
+	programmedMessage string,
+) []gatewayv1.ListenerEntryStatus {
 	statuses := make([]gatewayv1.ListenerEntryStatus, 0, len(listenerSet.Spec.Listeners))
 	for _, listener := range listenerSet.Spec.Listeners {
-		statuses = append(statuses, gatewayv1.ListenerEntryStatus{
+		entryStatus := gatewayv1.ListenerEntryStatus{
 			Name:           listener.Name,
 			SupportedKinds: supportedRouteKindsForListener(listenerFromListenerSetEntry(listener)),
-		})
+		}
+		setListenerEntryCondition(
+			&entryStatus,
+			gatewayv1.ListenerConditionAccepted,
+			acceptedStatus,
+			acceptedReason,
+			listenerSet.Generation,
+			acceptedMessage,
+		)
+		setListenerEntryCondition(
+			&entryStatus,
+			gatewayv1.ListenerConditionProgrammed,
+			programmedStatus,
+			programmedReason,
+			listenerSet.Generation,
+			programmedMessage,
+		)
+		statuses = append(statuses, entryStatus)
 	}
 	return statuses
 }

--- a/internal/app/listenerset_controller_test.go
+++ b/internal/app/listenerset_controller_test.go
@@ -413,6 +413,20 @@ func TestListenerSetController(t *testing.T) {
 		assert.Equal(t, string(gatewayv1.ListenerSetReasonPending), programmed.Reason)
 		require.Len(t, status.Listeners, 1)
 		assert.Equal(t, gatewayv1.SectionName("web"), status.Listeners[0].Name)
+		listenerAccepted := meta.FindStatusCondition(
+			status.Listeners[0].Conditions,
+			string(gatewayv1.ListenerConditionAccepted),
+		)
+		require.NotNil(t, listenerAccepted)
+		assert.Equal(t, metav1.ConditionTrue, listenerAccepted.Status)
+		assert.Equal(t, string(gatewayv1.ListenerReasonAccepted), listenerAccepted.Reason)
+		listenerProgrammed := meta.FindStatusCondition(
+			status.Listeners[0].Conditions,
+			string(gatewayv1.ListenerConditionProgrammed),
+		)
+		require.NotNil(t, listenerProgrammed)
+		assert.Equal(t, metav1.ConditionUnknown, listenerProgrammed.Status)
+		assert.Equal(t, string(gatewayv1.ListenerReasonPending), listenerProgrammed.Reason)
 		assert.ElementsMatch(t, []gatewayv1.RouteGroupKind{{
 			Group: lo.ToPtr(gatewayv1.Group(gatewayv1.GroupName)),
 			Kind:  "HTTPRoute",

--- a/internal/app/listenerset_controller_test.go
+++ b/internal/app/listenerset_controller_test.go
@@ -1,0 +1,674 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/services/k8sapi"
+)
+
+func TestListenerSetController(t *testing.T) {
+	makeController := func(objects ...runtime.Object) (*ListenerSetController, client.Client) {
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithRuntimeObjects(objects...).
+			WithStatusSubresource(&gatewayv1.ListenerSet{}).
+			Build()
+		return NewListenerSetController(ListenerSetControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  k8sClient,
+		}), k8sClient
+	}
+	makeRequest := func(listenerSet *gatewayv1.ListenerSet) reconcile.Request {
+		return reconcile.Request{NamespacedName: client.ObjectKeyFromObject(listenerSet)}
+	}
+	getStatus := func(t *testing.T, k8sClient client.Client, listenerSet *gatewayv1.ListenerSet) gatewayv1.ListenerSetStatus {
+		t.Helper()
+		var updated gatewayv1.ListenerSet
+		require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(listenerSet), &updated))
+		return updated.Status
+	}
+	assertAcceptedReason := func(
+		t *testing.T,
+		status gatewayv1.ListenerSetStatus,
+		conditionStatus metav1.ConditionStatus,
+		reason gatewayv1.ListenerSetConditionReason,
+	) {
+		t.Helper()
+		accepted := meta.FindStatusCondition(status.Conditions, string(gatewayv1.ListenerSetConditionAccepted))
+		require.NotNil(t, accepted)
+		assert.Equal(t, conditionStatus, accepted.Status)
+		assert.Equal(t, string(reason), accepted.Reason)
+	}
+
+	t.Run("ignores missing and deleting ListenerSets", func(t *testing.T) {
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "apps",
+				Name:      "deleting",
+			},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+			},
+		}
+		deletedAt := metav1.Now()
+		listenerSet.DeletionTimestamp = &deletedAt
+		listenerSet.Finalizers = []string{"example.com/finalizer"}
+		controller, _ := makeController(listenerSet)
+
+		missingResult, missingErr := controller.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: "apps", Name: "missing"},
+		})
+		deletingResult, deletingErr := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+		require.NoError(t, missingErr)
+		require.NoError(t, deletingErr)
+		assert.Zero(t, missingResult)
+		assert.Zero(t, deletingResult)
+	})
+
+	t.Run("returns ListenerSet get errors", func(t *testing.T) {
+		wantErr := errors.New("get failed")
+		mockClient := NewMockk8sClient(t)
+		req := reconcile.Request{NamespacedName: client.ObjectKey{Namespace: "apps", Name: "extra"}}
+		mockClient.EXPECT().
+			Get(t.Context(), req.NamespacedName, mock.AnythingOfType("*v1.ListenerSet")).
+			Return(wantErr)
+		controller := NewListenerSetController(ListenerSetControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+		})
+
+		result, err := controller.Reconcile(t.Context(), req)
+
+		require.ErrorIs(t, err, wantErr)
+		assert.Zero(t, result)
+	})
+
+	t.Run("sets invalid status for non Gateway parent refs", func(t *testing.T) {
+		parentKind := gatewayv1.Kind("Service")
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra", Generation: 2},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Kind: &parentKind, Name: "edge"},
+			},
+		}
+		controller, k8sClient := makeController(listenerSet)
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+		require.NoError(t, err)
+		assert.Zero(t, result)
+		status := getStatus(t, k8sClient, listenerSet)
+		assertAcceptedReason(t, status, metav1.ConditionFalse, gatewayv1.ListenerSetReasonInvalid)
+	})
+
+	t.Run("sets parent not accepted status when parent Gateway is missing", func(t *testing.T) {
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra", Generation: 3},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+			},
+		}
+		controller, k8sClient := makeController(listenerSet)
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+		require.NoError(t, err)
+		assert.Zero(t, result)
+		assertAcceptedReason(
+			t,
+			getStatus(t, k8sClient, listenerSet),
+			metav1.ConditionFalse,
+			gatewayv1.ListenerSetReasonParentNotAccepted,
+		)
+	})
+
+	t.Run("returns parent Gateway get errors", func(t *testing.T) {
+		wantErr := errors.New("gateway get failed")
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+			},
+		}
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+			RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.ListenerSet) = listenerSet
+				return nil
+			})
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKey{Namespace: "apps", Name: "edge"}, mock.AnythingOfType("*v1.Gateway")).
+			Return(wantErr)
+		controller := NewListenerSetController(ListenerSetControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+		})
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(&listenerSet))
+
+		require.ErrorIs(t, err, wantErr)
+		assert.Zero(t, result)
+	})
+
+	t.Run("sets not allowed status when Gateway does not opt in", func(t *testing.T) {
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra", Generation: 4},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+			},
+		}
+		gateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "edge"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "oci",
+			},
+		}
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "oci"},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			},
+		}
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}}
+		controller, k8sClient := makeController(listenerSet, gateway, gatewayClass, namespace)
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+		require.NoError(t, err)
+		assert.Zero(t, result)
+		assertAcceptedReason(
+			t,
+			getStatus(t, k8sClient, listenerSet),
+			metav1.ConditionFalse,
+			gatewayv1.ListenerSetReasonNotAllowed,
+		)
+	})
+
+	t.Run("sets parent not accepted status for missing or unmanaged GatewayClass", func(t *testing.T) {
+		for _, tc := range []struct {
+			name         string
+			gatewayClass *gatewayv1.GatewayClass
+		}{
+			{name: "missing GatewayClass"},
+			{
+				name: "unmanaged GatewayClass",
+				gatewayClass: &gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "oci"},
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: gatewayv1.GatewayController("example.com/other"),
+					},
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				listenerSet := &gatewayv1.ListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra", Generation: 4},
+					Spec: gatewayv1.ListenerSetSpec{
+						ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+					},
+				}
+				gateway := &gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "edge"},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "oci",
+					},
+				}
+				objects := []runtime.Object{listenerSet, gateway}
+				if tc.gatewayClass != nil {
+					objects = append(objects, tc.gatewayClass)
+				}
+				controller, k8sClient := makeController(objects...)
+
+				result, err := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+				require.NoError(t, err)
+				assert.Zero(t, result)
+				assertAcceptedReason(
+					t,
+					getStatus(t, k8sClient, listenerSet),
+					metav1.ConditionFalse,
+					gatewayv1.ListenerSetReasonParentNotAccepted,
+				)
+			})
+		}
+	})
+
+	t.Run("returns GatewayClass and namespace get errors", func(t *testing.T) {
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+			},
+		}
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "edge"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "oci",
+			},
+		}
+		gatewayClass := gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "oci"},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			},
+		}
+
+		t.Run("GatewayClass get error", func(t *testing.T) {
+			wantErr := errors.New("gatewayclass get failed")
+			mockClient := NewMockk8sClient(t)
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.ListenerSet) = listenerSet
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKey{Namespace: "apps", Name: "edge"}, mock.AnythingOfType("*v1.Gateway")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.Gateway) = gateway
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKey{Name: "oci"}, mock.AnythingOfType("*v1.GatewayClass")).
+				Return(wantErr)
+			controller := NewListenerSetController(ListenerSetControllerDeps{
+				RootLogger: diag.RootTestLogger(),
+				K8sClient:  mockClient,
+			})
+
+			result, err := controller.Reconcile(t.Context(), makeRequest(&listenerSet))
+
+			require.ErrorIs(t, err, wantErr)
+			assert.Zero(t, result)
+		})
+
+		t.Run("namespace get error", func(t *testing.T) {
+			wantErr := errors.New("namespace get failed")
+			mockClient := NewMockk8sClient(t)
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.ListenerSet) = listenerSet
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKey{Namespace: "apps", Name: "edge"}, mock.AnythingOfType("*v1.Gateway")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.Gateway) = gateway
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKey{Name: "oci"}, mock.AnythingOfType("*v1.GatewayClass")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.GatewayClass) = gatewayClass
+					return nil
+				})
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKey{Name: "apps"}, mock.AnythingOfType("*v1.Namespace")).
+				Return(wantErr)
+			controller := NewListenerSetController(ListenerSetControllerDeps{
+				RootLogger: diag.RootTestLogger(),
+				K8sClient:  mockClient,
+			})
+
+			result, err := controller.Reconcile(t.Context(), makeRequest(&listenerSet))
+
+			require.ErrorIs(t, err, wantErr)
+			assert.Zero(t, result)
+		})
+	})
+
+	t.Run("sets not allowed status when namespace is missing", func(t *testing.T) {
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra", Generation: 4},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+			},
+		}
+		gateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "edge"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "oci",
+			},
+		}
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "oci"},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			},
+		}
+		controller, k8sClient := makeController(listenerSet, gateway, gatewayClass)
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+		require.NoError(t, err)
+		assert.Zero(t, result)
+		assertAcceptedReason(
+			t,
+			getStatus(t, k8sClient, listenerSet),
+			metav1.ConditionFalse,
+			gatewayv1.ListenerSetReasonNotAllowed,
+		)
+	})
+
+	t.Run("sets accepted and pending status for allowed ListenerSet", func(t *testing.T) {
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra", Generation: 5},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+				Listeners: []gatewayv1.ListenerEntry{{
+					Name:     "web",
+					Port:     8080,
+					Protocol: gatewayv1.HTTPProtocolType,
+				}},
+			},
+		}
+		gateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "edge"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "oci",
+				AllowedListeners: &gatewayv1.AllowedListeners{
+					Namespaces: &gatewayv1.ListenerNamespaces{From: lo.ToPtr(gatewayv1.NamespacesFromAll)},
+				},
+			},
+		}
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "oci"},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			},
+		}
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}}
+		controller, k8sClient := makeController(listenerSet, gateway, gatewayClass, namespace)
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+		require.NoError(t, err)
+		assert.Zero(t, result)
+		status := getStatus(t, k8sClient, listenerSet)
+		assert.True(t, meta.IsStatusConditionTrue(status.Conditions, string(gatewayv1.ListenerSetConditionAccepted)))
+		programmed := meta.FindStatusCondition(status.Conditions, string(gatewayv1.ListenerSetConditionProgrammed))
+		require.NotNil(t, programmed)
+		assert.Equal(t, metav1.ConditionUnknown, programmed.Status)
+		assert.Equal(t, string(gatewayv1.ListenerSetReasonPending), programmed.Reason)
+		require.Len(t, status.Listeners, 1)
+		assert.Equal(t, gatewayv1.SectionName("web"), status.Listeners[0].Name)
+		assert.ElementsMatch(t, []gatewayv1.RouteGroupKind{{
+			Group: lo.ToPtr(gatewayv1.Group(gatewayv1.GroupName)),
+			Kind:  "HTTPRoute",
+		}, {
+			Group: lo.ToPtr(gatewayv1.Group(gatewayv1.GroupName)),
+			Kind:  "GRPCRoute",
+		}}, status.Listeners[0].SupportedKinds)
+
+		var updated gatewayv1.ListenerSet
+		require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(listenerSet), &updated))
+		assert.Equal(t, "apps/edge", updated.Annotations[ListenerSetParentGatewayAnnotation])
+	})
+
+	t.Run("does not update semantically current status", func(t *testing.T) {
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra", Generation: 5},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+			},
+		}
+		gateway := gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "edge"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "oci",
+				AllowedListeners: &gatewayv1.AllowedListeners{
+					Namespaces: &gatewayv1.ListenerNamespaces{From: lo.ToPtr(gatewayv1.NamespacesFromAll)},
+				},
+			},
+		}
+		listenerSet.Status = pendingListenerSetStatus(*listenerSet, gateway)
+		controller, _ := makeController(
+			listenerSet,
+			&gateway,
+			&gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "oci"},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: gatewayv1.GatewayController(ControllerClassName),
+				},
+			},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+		)
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(listenerSet))
+
+		require.NoError(t, err)
+		assert.Zero(t, result)
+	})
+
+	t.Run("returns status update errors", func(t *testing.T) {
+		wantErr := errors.New("status update failed")
+		invalidKind := gatewayv1.Kind("Service")
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Kind: &invalidKind, Name: "edge"},
+			},
+		}
+		mockClient := NewMockk8sClient(t)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+			RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.ListenerSet) = listenerSet
+				return nil
+			})
+		mockClient.EXPECT().
+			Status().
+			Return(mockStatusWriter)
+		mockStatusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.ListenerSet")).
+			Return(wantErr)
+		controller := NewListenerSetController(ListenerSetControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+		})
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(&listenerSet))
+
+		require.ErrorIs(t, err, wantErr)
+		assert.Zero(t, result)
+	})
+
+	t.Run("treats missing ListenerSet as not found", func(t *testing.T) {
+		listenerSet := gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"}}
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "listenersets"}, listenerSet.Name))
+		controller := NewListenerSetController(ListenerSetControllerDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+		})
+
+		result, err := controller.Reconcile(t.Context(), makeRequest(&listenerSet))
+
+		require.NoError(t, err)
+		assert.Zero(t, result)
+	})
+
+	t.Run("updateParentGatewayAnnotation", func(t *testing.T) {
+		t.Run("skips missing ListenerSet refresh", func(t *testing.T) {
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+				},
+			}
+			mockClient := NewMockk8sClient(t)
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+				Return(apierrors.NewNotFound(schema.GroupResource{Resource: "listenersets"}, listenerSet.Name))
+			controller := NewListenerSetController(ListenerSetControllerDeps{
+				RootLogger: diag.RootTestLogger(),
+				K8sClient:  mockClient,
+			})
+
+			err := controller.updateParentGatewayAnnotation(
+				t.Context(),
+				client.ObjectKeyFromObject(&listenerSet),
+				listenerSet,
+			)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("returns refresh errors", func(t *testing.T) {
+			wantErr := errors.New("refresh failed")
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+				},
+			}
+			mockClient := NewMockk8sClient(t)
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+				Return(wantErr)
+			controller := NewListenerSetController(ListenerSetControllerDeps{
+				RootLogger: diag.RootTestLogger(),
+				K8sClient:  mockClient,
+			})
+
+			err := controller.updateParentGatewayAnnotation(
+				t.Context(),
+				client.ObjectKeyFromObject(&listenerSet),
+				listenerSet,
+			)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("skips current annotation", func(t *testing.T) {
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps",
+					Name:      "extra",
+					Annotations: map[string]string{
+						ListenerSetParentGatewayAnnotation: "apps/edge",
+					},
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+				},
+			}
+			mockClient := NewMockk8sClient(t)
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.ListenerSet) = listenerSet
+					return nil
+				})
+			controller := NewListenerSetController(ListenerSetControllerDeps{
+				RootLogger: diag.RootTestLogger(),
+				K8sClient:  mockClient,
+			})
+
+			err := controller.updateParentGatewayAnnotation(
+				t.Context(),
+				client.ObjectKeyFromObject(&listenerSet),
+				listenerSet,
+			)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("removes stale annotation for invalid parent ref", func(t *testing.T) {
+			invalidKind := gatewayv1.Kind("Service")
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps",
+					Name:      "extra",
+					Annotations: map[string]string{
+						ListenerSetParentGatewayAnnotation: "apps/edge",
+					},
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Kind: &invalidKind, Name: "edge"},
+				},
+			}
+			mockClient := NewMockk8sClient(t)
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.ListenerSet) = listenerSet
+					return nil
+				})
+			mockClient.EXPECT().
+				Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+					updated, ok := obj.(*gatewayv1.ListenerSet)
+					return ok && updated.Annotations[ListenerSetParentGatewayAnnotation] == ""
+				})).
+				Return(nil)
+			controller := NewListenerSetController(ListenerSetControllerDeps{
+				RootLogger: diag.RootTestLogger(),
+				K8sClient:  mockClient,
+			})
+
+			err := controller.updateParentGatewayAnnotation(
+				t.Context(),
+				client.ObjectKeyFromObject(&listenerSet),
+				listenerSet,
+			)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("returns annotation update errors", func(t *testing.T) {
+			wantErr := errors.New("update failed")
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+				},
+			}
+			mockClient := NewMockk8sClient(t)
+			mockClient.EXPECT().
+				Get(t.Context(), client.ObjectKeyFromObject(&listenerSet), mock.AnythingOfType("*v1.ListenerSet")).
+				RunAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					*obj.(*gatewayv1.ListenerSet) = listenerSet
+					return nil
+				})
+			mockClient.EXPECT().
+				Update(t.Context(), mock.AnythingOfType("*v1.ListenerSet")).
+				Return(wantErr)
+			controller := NewListenerSetController(ListenerSetControllerDeps{
+				RootLogger: diag.RootTestLogger(),
+				K8sClient:  mockClient,
+			})
+
+			err := controller.updateParentGatewayAnnotation(
+				t.Context(),
+				client.ObjectKeyFromObject(&listenerSet),
+				listenerSet,
+			)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+	})
+}

--- a/internal/app/listenerset_model.go
+++ b/internal/app/listenerset_model.go
@@ -1,0 +1,690 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
+)
+
+const maxOCIListenerNameLength = 32
+const ListenerSetParentGatewayAnnotation = "oke-gateway-api.gemyago.github.io/listenerset-parent-gateway"
+
+type effectiveListenerSourceKind string
+
+const (
+	effectiveListenerSourceGateway     effectiveListenerSourceKind = "Gateway"
+	effectiveListenerSourceListenerSet effectiveListenerSourceKind = "ListenerSet"
+)
+
+type effectiveListener struct {
+	listener           v1.Listener
+	sourceKind         effectiveListenerSourceKind
+	sourceNamespace    string
+	sourceName         string
+	ociName            string
+	conflicted         bool
+	conflictReason     v1.ListenerConditionReason
+	unsupported        bool
+	unsupportedReason  v1.ListenerConditionReason
+	unsupportedMessage string
+}
+
+func effectiveListenerObjectKey(listener effectiveListener) string {
+	return path.Join(listener.sourceNamespace, listener.sourceName, string(listener.listener.Name))
+}
+
+func effectiveListenerOCIListener(listener effectiveListener) v1.Listener {
+	ociListener := listener.listener
+	ociListener.Name = v1.SectionName(listener.ociName)
+	if listener.sourceKind == effectiveListenerSourceListenerSet && ociListener.TLS != nil {
+		ociListener.TLS = ociListener.TLS.DeepCopy()
+		for i := range ociListener.TLS.CertificateRefs {
+			if ociListener.TLS.CertificateRefs[i].Namespace == nil {
+				namespace := v1.Namespace(listener.sourceNamespace)
+				ociListener.TLS.CertificateRefs[i].Namespace = &namespace
+			}
+		}
+	}
+	return ociListener
+}
+
+func listenerSetParentRefTargetsGateway(parentRef v1.ParentGatewayReference) bool {
+	if parentRef.Group != nil && string(*parentRef.Group) != v1.GroupName {
+		return false
+	}
+	if parentRef.Kind != nil && string(*parentRef.Kind) != "Gateway" {
+		return false
+	}
+	return true
+}
+
+func listenerSetParentGatewayName(listenerSet v1.ListenerSet) (string, bool) {
+	parentRef := listenerSet.Spec.ParentRef
+	if !listenerSetParentRefTargetsGateway(parentRef) {
+		return "", false
+	}
+	namespace := listenerSet.Namespace
+	if parentRef.Namespace != nil {
+		namespace = string(*parentRef.Namespace)
+	}
+	return path.Join(namespace, string(parentRef.Name)), true
+}
+
+func listenerSetParentGatewayTarget(
+	ctx context.Context,
+	k8sClient k8sClient,
+	routeNamespace string,
+	parentRef v1.ParentReference,
+) (apitypes.NamespacedName, bool, error) {
+	parentName := parentRefTargetName(parentRef, routeNamespace)
+	var listenerSet v1.ListenerSet
+	if err := k8sClient.Get(ctx, parentName, &listenerSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			return apitypes.NamespacedName{}, false, nil
+		}
+		return apitypes.NamespacedName{}, false, fmt.Errorf(
+			"failed to get ListenerSet %s: %w",
+			parentName.String(),
+			err,
+		)
+	}
+	parentGatewayName, ok := listenerSetParentGatewayName(listenerSet)
+	if !ok {
+		return apitypes.NamespacedName{}, false, nil
+	}
+	namespace, name, ok := strings.Cut(parentGatewayName, "/")
+	if !ok {
+		return apitypes.NamespacedName{}, false, nil
+	}
+	return apitypes.NamespacedName{Namespace: namespace, Name: name}, true, nil
+}
+
+func listenerSetAllowedByGateway(
+	gateway v1.Gateway,
+	listenerSet v1.ListenerSet,
+	listenerSetNamespace corev1.Namespace,
+) bool {
+	if gateway.Spec.AllowedListeners == nil || gateway.Spec.AllowedListeners.Namespaces == nil {
+		return false
+	}
+
+	namespaces := gateway.Spec.AllowedListeners.Namespaces
+	from := v1.NamespacesFromNone
+	if namespaces.From != nil {
+		from = *namespaces.From
+	}
+
+	switch from {
+	case v1.NamespacesFromAll:
+		return true
+	case v1.NamespacesFromSame:
+		return listenerSet.Namespace == gateway.Namespace
+	case v1.NamespacesFromSelector:
+		if namespaces.Selector == nil {
+			return false
+		}
+		selector, err := metav1.LabelSelectorAsSelector(namespaces.Selector)
+		if err != nil {
+			return false
+		}
+		return selector.Matches(labels.Set(listenerSetNamespace.Labels))
+	case v1.NamespacesFromNone:
+		return false
+	default:
+		return false
+	}
+}
+
+func effectiveListenersForGateway(gateway v1.Gateway, listenerSets []v1.ListenerSet) []effectiveListener {
+	result := make([]effectiveListener, 0, len(gateway.Spec.Listeners)+len(listenerSets))
+	for _, listener := range gateway.Spec.Listeners {
+		result = append(result, effectiveListener{
+			listener:        listener,
+			sourceKind:      effectiveListenerSourceGateway,
+			sourceNamespace: gateway.Namespace,
+			sourceName:      gateway.Name,
+			ociName:         string(listener.Name),
+		})
+	}
+
+	sort.SliceStable(listenerSets, func(i, j int) bool {
+		left := listenerSets[i]
+		right := listenerSets[j]
+		if !left.CreationTimestamp.Equal(&right.CreationTimestamp) {
+			return left.CreationTimestamp.Before(&right.CreationTimestamp)
+		}
+		return path.Join(left.Namespace, left.Name) < path.Join(right.Namespace, right.Name)
+	})
+
+	for _, listenerSet := range listenerSets {
+		for _, entry := range listenerSet.Spec.Listeners {
+			listener := listenerFromListenerSetEntry(entry)
+			result = append(result, effectiveListener{
+				listener:        listener,
+				sourceKind:      effectiveListenerSourceListenerSet,
+				sourceNamespace: listenerSet.Namespace,
+				sourceName:      listenerSet.Name,
+				ociName:         listenerSetOCIListenerName(gateway, listenerSet, listener),
+			})
+		}
+	}
+
+	markConflictedEffectiveListeners(result)
+	return result
+}
+
+func effectiveOCIListenersForGateway(data *resolvedGatewayDetails) []v1.Listener {
+	effectiveListeners := data.effectiveListeners
+	if len(effectiveListeners) == 0 {
+		effectiveListeners = effectiveListenersForGateway(data.gateway, nil)
+	}
+	listeners := make([]v1.Listener, 0, len(effectiveListeners))
+	for _, listener := range effectiveListeners {
+		if listener.conflicted || listener.unsupported {
+			continue
+		}
+		listeners = append(listeners, effectiveListenerOCIListener(listener))
+	}
+	return listeners
+}
+
+func gatewayManagedOCIListenersForLoadBalancer(data *resolvedGatewayDetails) []v1.Listener {
+	return lo.Filter(effectiveOCIListenersForGateway(data), func(listener v1.Listener, _ int) bool {
+		return listener.Protocol != v1.TLSProtocolType
+	})
+}
+
+func gatewayManagedOCIListenersForNetworkLoadBalancer(data *resolvedGatewayDetails) []v1.Listener {
+	return lo.Filter(effectiveOCIListenersForGateway(data), func(listener v1.Listener, _ int) bool {
+		return listener.Protocol == v1.TCPProtocolType || listener.Protocol == v1.UDPProtocolType
+	})
+}
+
+func markUnsupportedListenerSetListeners(
+	listeners []effectiveListener,
+	controllerName v1.GatewayController,
+) {
+	for i := range listeners {
+		if listeners[i].sourceKind != effectiveListenerSourceListenerSet || listeners[i].conflicted {
+			continue
+		}
+		reason, message, unsupported := listenerSetListenerUnsupported(
+			listeners[i].listener,
+			controllerName,
+		)
+		if unsupported {
+			listeners[i].unsupported = true
+			listeners[i].unsupportedReason = reason
+			listeners[i].unsupportedMessage = message
+		}
+	}
+}
+
+func listenerSetListenerUnsupported(
+	listener v1.Listener,
+	controllerName v1.GatewayController,
+) (v1.ListenerConditionReason, string, bool) {
+	switch controllerName {
+	case v1.GatewayController(ControllerClassName):
+		return loadBalancerListenerSetListenerUnsupported(listener)
+	case v1.GatewayController(NetworkLoadBalancerControllerClassName):
+		return networkLoadBalancerListenerSetListenerUnsupported(listener)
+	default:
+		return "", "", false
+	}
+}
+
+func loadBalancerListenerSetListenerUnsupported(listener v1.Listener) (v1.ListenerConditionReason, string, bool) {
+	switch listener.Protocol {
+	case v1.HTTPProtocolType, v1.HTTPSProtocolType:
+		return "", "", false
+	case v1.TLSProtocolType:
+		if lo.FromPtr(listener.TLS).Mode != nil && *listener.TLS.Mode == v1.TLSModeTerminate {
+			return "", "", false
+		}
+		return v1.ListenerReasonUnsupportedValue,
+			fmt.Sprintf("listener %s uses unsupported TLS mode for OCI Load Balancer", listener.Name),
+			true
+	case v1.TCPProtocolType, v1.UDPProtocolType:
+		return v1.ListenerReasonUnsupportedProtocol,
+			fmt.Sprintf(
+				"listener %s uses unsupported protocol %s for OCI Load Balancer",
+				listener.Name,
+				listener.Protocol,
+			),
+			true
+	default:
+		return v1.ListenerReasonUnsupportedProtocol,
+			fmt.Sprintf(
+				"listener %s uses unsupported protocol %s for OCI Load Balancer",
+				listener.Name,
+				listener.Protocol,
+			),
+			true
+	}
+}
+
+func networkLoadBalancerListenerSetListenerUnsupported(
+	listener v1.Listener,
+) (v1.ListenerConditionReason, string, bool) {
+	switch listener.Protocol {
+	case v1.TCPProtocolType, v1.UDPProtocolType:
+		return "", "", false
+	case v1.TLSProtocolType:
+		if lo.FromPtr(listener.TLS).Mode != nil && *listener.TLS.Mode == v1.TLSModePassthrough {
+			return "", "", false
+		}
+		return v1.ListenerReasonUnsupportedValue,
+			fmt.Sprintf("listener %s uses unsupported TLS mode for OCI Network Load Balancer", listener.Name),
+			true
+	case v1.HTTPProtocolType, v1.HTTPSProtocolType:
+		return v1.ListenerReasonUnsupportedProtocol,
+			fmt.Sprintf(
+				"listener %s uses unsupported protocol %s for OCI Network Load Balancer",
+				listener.Name,
+				listener.Protocol,
+			),
+			true
+	default:
+		return v1.ListenerReasonUnsupportedProtocol,
+			fmt.Sprintf(
+				"listener %s uses unsupported protocol %s for OCI Network Load Balancer",
+				listener.Name,
+				listener.Protocol,
+			),
+			true
+	}
+}
+
+func effectiveListenersForParentRef(
+	gatewayDetails resolvedGatewayDetails,
+	parentRef v1.ParentReference,
+	routeNamespace string,
+	matchesListener func(v1.ParentReference, v1.Listener) bool,
+) []v1.Listener {
+	effectiveListeners := gatewayDetails.effectiveListeners
+	if len(effectiveListeners) == 0 {
+		effectiveListeners = effectiveListenersForGateway(gatewayDetails.gateway, nil)
+	}
+
+	results := make([]v1.Listener, 0)
+	for _, listener := range effectiveListeners {
+		if listener.conflicted {
+			continue
+		}
+		if !parentRefTargetsEffectiveListener(parentRef, routeNamespace, gatewayDetails.gateway, listener) {
+			continue
+		}
+		if matchesListener(parentRef, listener.listener) {
+			results = append(results, effectiveListenerOCIListener(listener))
+		}
+	}
+	return results
+}
+
+func parentRefTargetsEffectiveListener(
+	parentRef v1.ParentReference,
+	routeNamespace string,
+	gateway v1.Gateway,
+	listener effectiveListener,
+) bool {
+	switch {
+	case parentRefTargetsGateway(parentRef):
+		target := parentRefTargetName(parentRef, routeNamespace)
+		return listener.sourceKind == effectiveListenerSourceGateway &&
+			target.Namespace == gateway.Namespace &&
+			target.Name == gateway.Name
+	case parentRefTargetsListenerSet(parentRef):
+		target := parentRefTargetName(parentRef, routeNamespace)
+		return listener.sourceKind == effectiveListenerSourceListenerSet &&
+			target.Namespace == listener.sourceNamespace &&
+			target.Name == listener.sourceName
+	default:
+		return false
+	}
+}
+
+func listenerFromListenerSetEntry(entry v1.ListenerEntry) v1.Listener {
+	return v1.Listener(entry)
+}
+
+func listenerSetOCIListenerName(gateway v1.Gateway, listenerSet v1.ListenerSet, listener v1.Listener) string {
+	return ociapi.ConstructOCIResourceName(
+		fmt.Sprintf(
+			"ls_%s",
+			path.Join(
+				gateway.Namespace,
+				gateway.Name,
+				listenerSet.Namespace,
+				listenerSet.Name,
+				string(listener.Name),
+			),
+		),
+		ociapi.OCIResourceNameConfig{
+			MaxLength:           maxOCIListenerNameLength,
+			InvalidCharsPattern: invalidCharsForPolicyNamePattern,
+		},
+	)
+}
+
+func markConflictedEffectiveListeners(listeners []effectiveListener) {
+	for i := range listeners {
+		markEffectiveListenerConflict(&listeners[i], listeners[:i])
+	}
+}
+
+func markEffectiveListenerConflict(listener *effectiveListener, previousListeners []effectiveListener) {
+	if listener.conflicted {
+		return
+	}
+	for _, previous := range previousListeners {
+		reason, conflicted := effectiveListenersConflict(previous.listener, listener.listener)
+		if conflicted {
+			listener.conflicted = true
+			listener.conflictReason = reason
+			return
+		}
+	}
+}
+
+func effectiveListenersConflict(left v1.Listener, right v1.Listener) (v1.ListenerConditionReason, bool) {
+	if left.Port != right.Port {
+		return "", false
+	}
+	if left.Protocol != right.Protocol {
+		return v1.ListenerReasonProtocolConflict, true
+	}
+	if listenersHaveHostnameConflict(left, right) {
+		return v1.ListenerReasonHostnameConflict, true
+	}
+	return "", false
+}
+
+func listenersHaveHostnameConflict(left v1.Listener, right v1.Listener) bool {
+	leftHostname := ""
+	if left.Hostname != nil {
+		leftHostname = string(*left.Hostname)
+	}
+	rightHostname := ""
+	if right.Hostname != nil {
+		rightHostname = string(*right.Hostname)
+	}
+	return l7HostnamePatternsIntersect(v1.Hostname(leftHostname), v1.Hostname(rightHostname))
+}
+
+func listenerSetStatusForGateway(
+	gateway v1.Gateway,
+	listenerSet v1.ListenerSet,
+	effectiveListeners []effectiveListener,
+	controllerName v1.GatewayController,
+) v1.ListenerSetStatus {
+	listenersByKey := make(map[string]effectiveListener, len(effectiveListeners))
+	for _, listener := range effectiveListeners {
+		listenersByKey[effectiveListenerObjectKey(listener)] = listener
+	}
+
+	status := listenerSetTopLevelStatusForGateway(gateway, listenerSet, listenersByKey, controllerName)
+	status.Listeners = make([]v1.ListenerEntryStatus, 0, len(listenerSet.Spec.Listeners))
+	for _, listener := range listenerSet.Spec.Listeners {
+		effective := listenersByKey[path.Join(listenerSet.Namespace, listenerSet.Name, string(listener.Name))]
+		entryStatus := v1.ListenerEntryStatus{
+			Name:           listener.Name,
+			SupportedKinds: supportedRouteKindsForListener(listenerFromListenerSetEntry(listener)),
+		}
+		if effective.conflicted || effective.unsupported {
+			reason := effective.conflictReason
+			message := fmt.Sprintf(
+				"listener %s conflicts with an earlier Gateway or ListenerSet listener",
+				listener.Name,
+			)
+			if effective.unsupported {
+				reason = effective.unsupportedReason
+				message = effective.unsupportedMessage
+			}
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerConditionAccepted,
+				metav1.ConditionFalse,
+				reason,
+				listenerSet.Generation,
+				message,
+			)
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerConditionProgrammed,
+				metav1.ConditionFalse,
+				reason,
+				listenerSet.Generation,
+				message,
+			)
+		} else {
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerConditionAccepted,
+				metav1.ConditionTrue,
+				v1.ListenerReasonAccepted,
+				listenerSet.Generation,
+				fmt.Sprintf("listener %s accepted", listener.Name),
+			)
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerConditionProgrammed,
+				metav1.ConditionTrue,
+				v1.ListenerReasonProgrammed,
+				listenerSet.Generation,
+				fmt.Sprintf("listener %s programmed", listener.Name),
+			)
+		}
+		status.Listeners = append(status.Listeners, entryStatus)
+	}
+	return status
+}
+
+func listenerSetTopLevelStatusForGateway(
+	gateway v1.Gateway,
+	listenerSet v1.ListenerSet,
+	listenersByKey map[string]effectiveListener,
+	controllerName v1.GatewayController,
+) v1.ListenerSetStatus {
+	acceptedStatus := metav1.ConditionTrue
+	acceptedReason := string(v1.ListenerSetReasonAccepted)
+	acceptedMessage := fmt.Sprintf(
+		"ListenerSet %s/%s accepted by Gateway %s/%s",
+		listenerSet.Namespace,
+		listenerSet.Name,
+		gateway.Namespace,
+		gateway.Name,
+	)
+	programmedStatus := metav1.ConditionTrue
+	programmedReason := string(v1.ListenerSetReasonProgrammed)
+	programmedMessage := fmt.Sprintf(
+		"ListenerSet %s/%s programmed by %s",
+		listenerSet.Namespace,
+		listenerSet.Name,
+		controllerName,
+	)
+	if !listenerSetListenersValid(listenerSet, listenersByKey) {
+		acceptedStatus = metav1.ConditionFalse
+		acceptedReason = string(v1.ListenerSetReasonListenersNotValid)
+		acceptedMessage = fmt.Sprintf(
+			"ListenerSet %s/%s has invalid listeners",
+			listenerSet.Namespace,
+			listenerSet.Name,
+		)
+		programmedStatus = metav1.ConditionFalse
+		programmedReason = string(v1.ListenerSetReasonListenersNotValid)
+		programmedMessage = acceptedMessage
+	}
+
+	status := v1.ListenerSetStatus{}
+	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+		Type:               string(v1.ListenerSetConditionAccepted),
+		Status:             acceptedStatus,
+		Reason:             acceptedReason,
+		ObservedGeneration: listenerSet.Generation,
+		LastTransitionTime: metav1.Now(),
+		Message:            acceptedMessage,
+	})
+	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+		Type:               string(v1.ListenerSetConditionProgrammed),
+		Status:             programmedStatus,
+		Reason:             programmedReason,
+		ObservedGeneration: listenerSet.Generation,
+		LastTransitionTime: metav1.Now(),
+		Message:            programmedMessage,
+	})
+	return status
+}
+
+func listenerSetListenersValid(listenerSet v1.ListenerSet, listenersByKey map[string]effectiveListener) bool {
+	for _, listener := range listenerSet.Spec.Listeners {
+		effective := listenersByKey[path.Join(listenerSet.Namespace, listenerSet.Name, string(listener.Name))]
+		if effective.conflicted || effective.unsupported {
+			return false
+		}
+	}
+	return true
+}
+
+func setListenerEntryCondition(
+	status *v1.ListenerEntryStatus,
+	conditionType v1.ListenerConditionType,
+	conditionStatus metav1.ConditionStatus,
+	reason v1.ListenerConditionReason,
+	generation int64,
+	message string,
+) {
+	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+		Type:               string(conditionType),
+		Status:             conditionStatus,
+		Reason:             string(reason),
+		ObservedGeneration: generation,
+		LastTransitionTime: metav1.Now(),
+		Message:            message,
+	})
+}
+
+func supportedRouteKindsForListener(listener v1.Listener) []v1.RouteGroupKind {
+	kindNames := supportedRouteKindNamesForProtocol(listener.Protocol)
+	if listener.AllowedRoutes != nil && len(listener.AllowedRoutes.Kinds) > 0 {
+		allowedKinds := make(map[v1.Kind]struct{}, len(listener.AllowedRoutes.Kinds))
+		for _, allowedKind := range listener.AllowedRoutes.Kinds {
+			group := gatewayAPIGroup
+			if allowedKind.Group != nil {
+				group = string(*allowedKind.Group)
+			}
+			if group == gatewayAPIGroup {
+				allowedKinds[allowedKind.Kind] = struct{}{}
+			}
+		}
+		kindNames = lo.Filter(kindNames, func(kind v1.Kind, _ int) bool {
+			_, allowed := allowedKinds[kind]
+			return allowed
+		})
+	}
+	result := make([]v1.RouteGroupKind, 0, len(kindNames))
+	group := v1.Group(v1.GroupName)
+	for _, kind := range kindNames {
+		result = append(result, v1.RouteGroupKind{Group: &group, Kind: kind})
+	}
+	return result
+}
+
+func supportedRouteKindNamesForProtocol(protocol v1.ProtocolType) []v1.Kind {
+	switch protocol {
+	case v1.HTTPProtocolType, v1.HTTPSProtocolType:
+		return []v1.Kind{"HTTPRoute", "GRPCRoute"}
+	case v1.TLSProtocolType:
+		return []v1.Kind{"TLSRoute"}
+	case v1.TCPProtocolType:
+		return []v1.Kind{"TCPRoute"}
+	case v1.UDPProtocolType:
+		return []v1.Kind{"UDPRoute"}
+	default:
+		return nil
+	}
+}
+
+func listenerSetStatusSemanticallyEqual(left v1.ListenerSetStatus, right v1.ListenerSetStatus) bool {
+	if !conditionsSemanticallyEqual(left.Conditions, right.Conditions) || len(left.Listeners) != len(right.Listeners) {
+		return false
+	}
+	leftListeners := lo.SliceToMap(
+		left.Listeners,
+		func(listener v1.ListenerEntryStatus) (v1.SectionName, v1.ListenerEntryStatus) {
+			return listener.Name, listener
+		},
+	)
+	for _, rightListener := range right.Listeners {
+		leftListener, found := leftListeners[rightListener.Name]
+		if !found ||
+			leftListener.AttachedRoutes != rightListener.AttachedRoutes ||
+			!routeGroupKindsEqual(leftListener.SupportedKinds, rightListener.SupportedKinds) ||
+			!conditionsSemanticallyEqual(leftListener.Conditions, rightListener.Conditions) {
+			return false
+		}
+	}
+	return true
+}
+
+func attachedListenerSetCount(listenerSets []v1.ListenerSet) *int32 {
+	const maxInt32 = int32(1<<31 - 1)
+
+	var count int32
+	for range listenerSets {
+		if count == maxInt32 {
+			break
+		}
+		count++
+	}
+	return &count
+}
+
+func routeGroupKindsEqual(left []v1.RouteGroupKind, right []v1.RouteGroupKind) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	left = append([]v1.RouteGroupKind(nil), left...)
+	right = append([]v1.RouteGroupKind(nil), right...)
+	sort.Slice(left, func(i, j int) bool { return string(left[i].Kind) < string(left[j].Kind) })
+	sort.Slice(right, func(i, j int) bool { return string(right[i].Kind) < string(right[j].Kind) })
+	for i := range left {
+		if lo.FromPtr(left[i].Group) != lo.FromPtr(right[i].Group) || left[i].Kind != right[i].Kind {
+			return false
+		}
+	}
+	return true
+}
+
+func conditionsSemanticallyEqual(left []metav1.Condition, right []metav1.Condition) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftByType := lo.SliceToMap(left, func(condition metav1.Condition) (string, metav1.Condition) {
+		return condition.Type, condition
+	})
+	for _, rightCondition := range right {
+		leftCondition, found := leftByType[rightCondition.Type]
+		if !found ||
+			leftCondition.Status != rightCondition.Status ||
+			leftCondition.Reason != rightCondition.Reason ||
+			leftCondition.Message != rightCondition.Message ||
+			leftCondition.ObservedGeneration != rightCondition.ObservedGeneration {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/listenerset_model.go
+++ b/internal/app/listenerset_model.go
@@ -410,7 +410,7 @@ func effectiveListenersConflict(left v1.Listener, right v1.Listener) (v1.Listene
 	if listenersHaveHostnameConflict(left, right) {
 		return v1.ListenerReasonHostnameConflict, true
 	}
-	return "", false
+	return v1.ListenerReasonPortUnavailable, true
 }
 
 func listenersHaveHostnameConflict(left v1.Listener, right v1.Listener) bool {

--- a/internal/app/listenerset_model.go
+++ b/internal/app/listenerset_model.go
@@ -335,6 +335,25 @@ func effectiveListenersForParentRef(
 	return results
 }
 
+func effectiveListenerSourceNamespaceForOCIListener(
+	gatewayDetails resolvedGatewayDetails,
+	listener v1.Listener,
+) string {
+	effectiveListeners := gatewayDetails.effectiveListeners
+	if len(effectiveListeners) == 0 {
+		effectiveListeners = effectiveListenersForGateway(gatewayDetails.gateway, nil)
+	}
+	for _, effective := range effectiveListeners {
+		if effective.conflicted || effective.unsupported {
+			continue
+		}
+		if effectiveListenerOCIListener(effective).Name == listener.Name {
+			return effective.sourceNamespace
+		}
+	}
+	return gatewayDetails.gateway.Namespace
+}
+
 func parentRefTargetsEffectiveListener(
 	parentRef v1.ParentReference,
 	routeNamespace string,
@@ -430,6 +449,7 @@ func listenerSetStatusForGateway(
 	listenerSet v1.ListenerSet,
 	effectiveListeners []effectiveListener,
 	controllerName v1.GatewayController,
+	attachedRoutes map[v1.SectionName]int32,
 ) v1.ListenerSetStatus {
 	listenersByKey := make(map[string]effectiveListener, len(effectiveListeners))
 	for _, listener := range effectiveListeners {
@@ -443,20 +463,21 @@ func listenerSetStatusForGateway(
 		entryStatus := v1.ListenerEntryStatus{
 			Name:           listener.Name,
 			SupportedKinds: supportedRouteKindsForListener(listenerFromListenerSetEntry(listener)),
+			AttachedRoutes: attachedRoutes[listener.Name],
 		}
 		if effective.conflicted || effective.unsupported {
-			reason := effective.conflictReason
+			reason := listenerEntryReasonFromListenerReason(effective.conflictReason)
 			message := fmt.Sprintf(
 				"listener %s conflicts with an earlier Gateway or ListenerSet listener",
 				listener.Name,
 			)
 			if effective.unsupported {
-				reason = effective.unsupportedReason
+				reason = listenerEntryReasonFromListenerReason(effective.unsupportedReason)
 				message = effective.unsupportedMessage
 			}
 			setListenerEntryCondition(
 				&entryStatus,
-				v1.ListenerConditionAccepted,
+				v1.ListenerEntryConditionAccepted,
 				metav1.ConditionFalse,
 				reason,
 				listenerSet.Generation,
@@ -464,28 +485,60 @@ func listenerSetStatusForGateway(
 			)
 			setListenerEntryCondition(
 				&entryStatus,
-				v1.ListenerConditionProgrammed,
+				v1.ListenerEntryConditionProgrammed,
 				metav1.ConditionFalse,
 				reason,
+				listenerSet.Generation,
+				message,
+			)
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerEntryConditionResolvedRefs,
+				listenerEntryResolvedRefsStatus(reason),
+				listenerEntryResolvedRefsReason(reason),
+				listenerSet.Generation,
+				message,
+			)
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerEntryConditionConflicted,
+				listenerEntryConflictedStatus(effective),
+				listenerEntryConflictedReason(effective),
 				listenerSet.Generation,
 				message,
 			)
 		} else {
 			setListenerEntryCondition(
 				&entryStatus,
-				v1.ListenerConditionAccepted,
+				v1.ListenerEntryConditionAccepted,
 				metav1.ConditionTrue,
-				v1.ListenerReasonAccepted,
+				v1.ListenerEntryReasonAccepted,
 				listenerSet.Generation,
 				fmt.Sprintf("listener %s accepted", listener.Name),
 			)
 			setListenerEntryCondition(
 				&entryStatus,
-				v1.ListenerConditionProgrammed,
+				v1.ListenerEntryConditionProgrammed,
 				metav1.ConditionTrue,
-				v1.ListenerReasonProgrammed,
+				v1.ListenerEntryReasonProgrammed,
 				listenerSet.Generation,
 				fmt.Sprintf("listener %s programmed", listener.Name),
+			)
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerEntryConditionResolvedRefs,
+				metav1.ConditionTrue,
+				v1.ListenerEntryReasonResolvedRefs,
+				listenerSet.Generation,
+				fmt.Sprintf("listener %s references resolved", listener.Name),
+			)
+			setListenerEntryCondition(
+				&entryStatus,
+				v1.ListenerEntryConditionConflicted,
+				metav1.ConditionFalse,
+				v1.ListenerReasonNoConflicts,
+				listenerSet.Generation,
+				fmt.Sprintf("listener %s has no conflicts", listener.Name),
 			)
 		}
 		status.Listeners = append(status.Listeners, entryStatus)
@@ -516,7 +569,7 @@ func listenerSetTopLevelStatusForGateway(
 		listenerSet.Name,
 		controllerName,
 	)
-	if !listenerSetListenersValid(listenerSet, listenersByKey) {
+	if !listenerSetHasAcceptedListener(listenerSet, listenersByKey) {
 		acceptedStatus = metav1.ConditionFalse
 		acceptedReason = string(v1.ListenerSetReasonListenersNotValid)
 		acceptedMessage = fmt.Sprintf(
@@ -549,21 +602,74 @@ func listenerSetTopLevelStatusForGateway(
 	return status
 }
 
-func listenerSetListenersValid(listenerSet v1.ListenerSet, listenersByKey map[string]effectiveListener) bool {
+func listenerSetHasAcceptedListener(listenerSet v1.ListenerSet, listenersByKey map[string]effectiveListener) bool {
 	for _, listener := range listenerSet.Spec.Listeners {
 		effective := listenersByKey[path.Join(listenerSet.Namespace, listenerSet.Name, string(listener.Name))]
-		if effective.conflicted || effective.unsupported {
-			return false
+		if !effective.conflicted && !effective.unsupported {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
-func setListenerEntryCondition(
+func listenerEntryReasonFromListenerReason(reason v1.ListenerConditionReason) v1.ListenerEntryConditionReason {
+	switch string(reason) {
+	case string(v1.ListenerReasonHostnameConflict):
+		return v1.ListenerEntryReasonHostnameConflict
+	case string(v1.ListenerReasonProtocolConflict):
+		return v1.ListenerEntryReasonProtocolConflict
+	case string(v1.ListenerReasonInvalidCertificateRef):
+		return v1.ListenerEntryReasonInvalidCertificateRef
+	case string(v1.ListenerReasonInvalidRouteKinds):
+		return v1.ListenerEntryReasonInvalidRouteKinds
+	case string(v1.ListenerReasonRefNotPermitted):
+		return v1.ListenerEntryReasonRefNotPermitted
+	case string(v1.ListenerReasonUnsupportedProtocol):
+		return v1.ListenerEntryReasonUnsupportedProtocol
+	case string(v1.ListenerReasonPortUnavailable):
+		return v1.ListenerEntryReasonPortUnavailable
+	default:
+		return v1.ListenerEntryReasonInvalid
+	}
+}
+
+func listenerEntryResolvedRefsStatus(reason v1.ListenerEntryConditionReason) metav1.ConditionStatus {
+	switch string(reason) {
+	case string(v1.ListenerEntryReasonInvalidCertificateRef),
+		string(v1.ListenerEntryReasonInvalidRouteKinds),
+		string(v1.ListenerEntryReasonRefNotPermitted):
+		return metav1.ConditionFalse
+	default:
+		return metav1.ConditionTrue
+	}
+}
+
+func listenerEntryResolvedRefsReason(reason v1.ListenerEntryConditionReason) v1.ListenerEntryConditionReason {
+	if listenerEntryResolvedRefsStatus(reason) == metav1.ConditionFalse {
+		return reason
+	}
+	return v1.ListenerEntryReasonResolvedRefs
+}
+
+func listenerEntryConflictedStatus(listener effectiveListener) metav1.ConditionStatus {
+	if listener.conflicted {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}
+
+func listenerEntryConflictedReason(listener effectiveListener) v1.ListenerEntryConditionReason {
+	if listener.conflicted {
+		return listenerEntryReasonFromListenerReason(listener.conflictReason)
+	}
+	return v1.ListenerEntryConditionReason(v1.ListenerReasonNoConflicts)
+}
+
+func setListenerEntryCondition[CT ~string, CR ~string](
 	status *v1.ListenerEntryStatus,
-	conditionType v1.ListenerConditionType,
+	conditionType CT,
 	conditionStatus metav1.ConditionStatus,
-	reason v1.ListenerConditionReason,
+	reason CR,
 	generation int64,
 	message string,
 ) {
@@ -640,11 +746,26 @@ func listenerSetStatusSemanticallyEqual(left v1.ListenerSetStatus, right v1.List
 	return true
 }
 
-func attachedListenerSetCount(listenerSets []v1.ListenerSet) *int32 {
+func attachedListenerSetCount(listenerSets []v1.ListenerSet, effectiveListeners []effectiveListener) *int32 {
 	const maxInt32 = int32(1<<31 - 1)
 
+	acceptedListenerSetKeys := map[string]struct{}{}
+	for _, listener := range effectiveListeners {
+		if listener.sourceKind != effectiveListenerSourceListenerSet ||
+			listener.conflicted ||
+			listener.unsupported {
+			continue
+		}
+		acceptedListenerSetKeys[path.Join(listener.sourceNamespace, listener.sourceName)] = struct{}{}
+	}
+
 	var count int32
-	for range listenerSets {
+	for _, listenerSet := range listenerSets {
+		if len(effectiveListeners) > 0 {
+			if _, accepted := acceptedListenerSetKeys[path.Join(listenerSet.Namespace, listenerSet.Name)]; !accepted {
+				continue
+			}
+		}
 		if count == maxInt32 {
 			break
 		}

--- a/internal/app/listenerset_model_test.go
+++ b/internal/app/listenerset_model_test.go
@@ -1,0 +1,514 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaswdr/faker/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestListenerSetModel(t *testing.T) {
+	fake := faker.New()
+
+	makeListenerSet := func(opts ...func(*v1.ListenerSet)) v1.ListenerSet {
+		listenerSet := v1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "ls-ns-" + fake.Lorem().Word(),
+				Name:              "ls-" + fake.Lorem().Word(),
+				CreationTimestamp: metav1.NewTime(time.Now().Add(time.Duration(fake.IntBetween(1, 100)) * time.Minute)),
+			},
+			Spec: v1.ListenerSetSpec{
+				ParentRef: v1.ParentGatewayReference{Name: "gw-" + v1.ObjectName(fake.Lorem().Word())},
+				Listeners: []v1.ListenerEntry{{
+					Name:     "http-" + v1.SectionName(fake.Lorem().Word()),
+					Port:     80,
+					Protocol: v1.HTTPProtocolType,
+				}},
+			},
+		}
+		for _, opt := range opts {
+			opt(&listenerSet)
+		}
+		return listenerSet
+	}
+
+	makeGateway := func(opts ...func(*v1.Gateway)) v1.Gateway {
+		gateway := v1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "gw-ns-" + fake.Lorem().Word(),
+				Name:      "gw-" + fake.Lorem().Word(),
+			},
+			Spec: v1.GatewaySpec{
+				Listeners: []v1.Listener{{
+					Name:     "web",
+					Port:     80,
+					Protocol: v1.HTTPProtocolType,
+				}},
+			},
+		}
+		for _, opt := range opts {
+			opt(&gateway)
+		}
+		return gateway
+	}
+
+	t.Run("listenerSetParentGatewayName", func(t *testing.T) {
+		parentNamespace := v1.Namespace("infra-" + fake.Lorem().Word())
+		parentName := v1.ObjectName("edge-" + fake.Lorem().Word())
+		listenerSet := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "apps-" + fake.Lorem().Word()
+			listenerSet.Spec.ParentRef = v1.ParentGatewayReference{
+				Namespace: &parentNamespace,
+				Name:      parentName,
+			}
+		})
+
+		got, ok := listenerSetParentGatewayName(listenerSet)
+
+		require.True(t, ok)
+		assert.Equal(t, fmt.Sprintf("%s/%s", parentNamespace, parentName), got)
+
+		otherKind := v1.Kind("Service")
+		listenerSet.Spec.ParentRef.Kind = &otherKind
+		_, ok = listenerSetParentGatewayName(listenerSet)
+		assert.False(t, ok)
+
+		listenerSet.Spec.ParentRef.Kind = nil
+		otherGroup := v1.Group("example.com")
+		listenerSet.Spec.ParentRef.Group = &otherGroup
+		_, ok = listenerSetParentGatewayName(listenerSet)
+		assert.False(t, ok)
+	})
+
+	t.Run("listenerSetAllowedByGateway", func(t *testing.T) {
+		listenerSet := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "apps-" + fake.Lorem().Word()
+		})
+		namespace := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   listenerSet.Namespace,
+				Labels: map[string]string{"team": "media"},
+			},
+		}
+
+		gateway := makeGateway()
+		assert.False(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+
+		gateway.Spec.AllowedListeners = &v1.AllowedListeners{
+			Namespaces: &v1.ListenerNamespaces{From: lo.ToPtr(v1.NamespacesFromAll)},
+		}
+		assert.True(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+
+		gateway.Spec.AllowedListeners.Namespaces.From = lo.ToPtr(v1.NamespacesFromSame)
+		assert.False(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+		listenerSet.Namespace = gateway.Namespace
+		namespace.Name = listenerSet.Namespace
+		assert.True(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+
+		listenerSet.Namespace = "selected-" + fake.Lorem().Word()
+		namespace.Name = listenerSet.Namespace
+		gateway.Spec.AllowedListeners.Namespaces.From = lo.ToPtr(v1.NamespacesFromSelector)
+		gateway.Spec.AllowedListeners.Namespaces.Selector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{"team": "media"},
+		}
+		assert.True(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+		namespace.Labels["team"] = "payments"
+		assert.False(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+
+		gateway.Spec.AllowedListeners.Namespaces.Selector = nil
+		assert.False(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+
+		gateway.Spec.AllowedListeners.Namespaces.Selector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "team",
+				Operator: "unknown",
+				Values:   []string{"media"},
+			}},
+		}
+		assert.False(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+
+		gateway.Spec.AllowedListeners.Namespaces.From = lo.ToPtr(v1.FromNamespaces("invalid"))
+		assert.False(t, listenerSetAllowedByGateway(gateway, listenerSet, namespace))
+	})
+
+	t.Run("listenerSetOCIListenerName", func(t *testing.T) {
+		gateway := makeGateway(func(gateway *v1.Gateway) {
+			gateway.Namespace = strings.Repeat("g", 20)
+			gateway.Name = strings.Repeat("w", 20)
+		})
+		listenerSet := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = strings.Repeat("s", 20)
+			listenerSet.Name = strings.Repeat("l", 20)
+		})
+		listener := v1.Listener{Name: v1.SectionName(strings.Repeat("https", 10))}
+
+		got := listenerSetOCIListenerName(gateway, listenerSet, listener)
+		other := listenerSetOCIListenerName(gateway, listenerSet, v1.Listener{Name: "http"})
+
+		assert.LessOrEqual(t, len(got), maxOCIListenerNameLength)
+		assert.True(t, strings.HasPrefix(got, "ls_"))
+		assert.NotEqual(t, other, got)
+	})
+
+	t.Run("effectiveListenersForGateway", func(t *testing.T) {
+		gateway := makeGateway(func(gateway *v1.Gateway) {
+			gateway.Namespace = "infra"
+			gateway.Name = "edge"
+			hostname := v1.Hostname("api.example.com")
+			gateway.Spec.Listeners = []v1.Listener{{
+				Name:     "https",
+				Port:     443,
+				Protocol: v1.HTTPSProtocolType,
+				Hostname: &hostname,
+			}}
+		})
+		older := metav1.NewTime(time.Now().Add(-2 * time.Hour))
+		newer := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+		conflictingHostname := v1.Hostname("api.example.com")
+		listenerSet1 := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "team-a"
+			listenerSet.Name = "edge-extra"
+			listenerSet.CreationTimestamp = older
+			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
+				Name:     "grpc",
+				Port:     443,
+				Protocol: v1.HTTPSProtocolType,
+				Hostname: lo.ToPtr(v1.Hostname("grpc.example.com")),
+			}}
+		})
+		listenerSet2 := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "team-b"
+			listenerSet.Name = "edge-extra"
+			listenerSet.CreationTimestamp = newer
+			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
+				Name:     "api",
+				Port:     443,
+				Protocol: v1.HTTPSProtocolType,
+				Hostname: &conflictingHostname,
+			}}
+		})
+
+		got := effectiveListenersForGateway(gateway, []v1.ListenerSet{listenerSet2, listenerSet1})
+
+		require.Len(t, got, 3)
+		assert.Equal(t, effectiveListenerSourceGateway, got[0].sourceKind)
+		assert.Equal(t, effectiveListenerSourceListenerSet, got[1].sourceKind)
+		assert.Equal(t, "team-a", got[1].sourceNamespace)
+		assert.False(t, got[1].conflicted)
+		assert.True(t, got[2].conflicted)
+		assert.Equal(t, v1.ListenerReasonHostnameConflict, got[2].conflictReason)
+
+		conflictingProtocol := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "team-c"
+			listenerSet.Name = "edge-tcp"
+			listenerSet.CreationTimestamp = metav1.NewTime(time.Now())
+			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
+				Name:     "tcp",
+				Port:     443,
+				Protocol: v1.TCPProtocolType,
+			}}
+		})
+		got = effectiveListenersForGateway(gateway, []v1.ListenerSet{conflictingProtocol})
+		require.Len(t, got, 2)
+		assert.True(t, got[1].conflicted)
+		assert.Equal(t, v1.ListenerReasonProtocolConflict, got[1].conflictReason)
+	})
+
+	t.Run("effectiveListenersForParentRef", func(t *testing.T) {
+		gateway := makeGateway(func(gateway *v1.Gateway) {
+			gateway.Namespace = "infra"
+			gateway.Name = "edge"
+			gateway.Spec.Listeners = []v1.Listener{{
+				Name:     "gateway-http",
+				Port:     80,
+				Protocol: v1.HTTPProtocolType,
+			}}
+		})
+		listenerSetKind := v1.Kind("ListenerSet")
+		listenerSet := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "apps"
+			listenerSet.Name = "extra"
+			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
+				Name:     "ls-http",
+				Port:     8080,
+				Protocol: v1.HTTPProtocolType,
+			}}
+		})
+		gatewayDetails := resolvedGatewayDetails{
+			gateway:            gateway,
+			effectiveListeners: effectiveListenersForGateway(gateway, []v1.ListenerSet{listenerSet}),
+		}
+
+		got := effectiveListenersForParentRef(
+			gatewayDetails,
+			v1.ParentReference{Name: v1.ObjectName(gateway.Name)},
+			gateway.Namespace,
+			func(v1.ParentReference, v1.Listener) bool { return true },
+		)
+		require.Len(t, got, 1)
+		assert.Equal(t, v1.SectionName("gateway-http"), got[0].Name)
+
+		listenerSetNamespace := v1.Namespace(listenerSet.Namespace)
+		got = effectiveListenersForParentRef(
+			gatewayDetails,
+			v1.ParentReference{
+				Kind:      &listenerSetKind,
+				Namespace: &listenerSetNamespace,
+				Name:      v1.ObjectName(listenerSet.Name),
+			},
+			gateway.Namespace,
+			func(v1.ParentReference, v1.Listener) bool { return true },
+		)
+		require.Len(t, got, 1)
+		assert.NotEqual(t, v1.SectionName("ls-http"), got[0].Name)
+		assert.True(t, strings.HasPrefix(string(got[0].Name), "ls_"))
+
+		serviceKind := v1.Kind("Service")
+		got = effectiveListenersForParentRef(
+			gatewayDetails,
+			v1.ParentReference{Kind: &serviceKind, Name: "edge"},
+			gateway.Namespace,
+			func(v1.ParentReference, v1.Listener) bool { return true },
+		)
+		assert.Empty(t, got)
+
+		conflicted := gatewayDetails
+		conflicted.effectiveListeners = []effectiveListener{{
+			listener:   v1.Listener{Name: "conflicted", Port: 80, Protocol: v1.HTTPProtocolType},
+			conflicted: true,
+		}}
+		assert.Empty(t, effectiveOCIListenersForGateway(&conflicted))
+		assert.Empty(t, effectiveListenersForParentRef(
+			conflicted,
+			v1.ParentReference{Name: v1.ObjectName(gateway.Name)},
+			gateway.Namespace,
+			func(v1.ParentReference, v1.Listener) bool { return true },
+		))
+	})
+
+	t.Run("markConflictedEffectiveListeners skips already conflicted listeners", func(t *testing.T) {
+		listeners := []effectiveListener{
+			{
+				listener:   v1.Listener{Name: "https", Port: 443, Protocol: v1.HTTPSProtocolType},
+				conflicted: true,
+			},
+			{
+				listener: v1.Listener{Name: "other", Port: 443, Protocol: v1.TCPProtocolType},
+			},
+		}
+
+		markConflictedEffectiveListeners(listeners)
+
+		assert.True(t, listeners[0].conflicted)
+		assert.True(t, listeners[1].conflicted)
+		assert.Equal(t, v1.ListenerReasonProtocolConflict, listeners[1].conflictReason)
+	})
+
+	t.Run("effectiveListenerOCIListener", func(t *testing.T) {
+		secretName := v1.ObjectName("tls-cert")
+		listener := effectiveListener{
+			listener: v1.Listener{
+				Name:     "https",
+				Port:     443,
+				Protocol: v1.HTTPSProtocolType,
+				TLS: &v1.ListenerTLSConfig{
+					CertificateRefs: []v1.SecretObjectReference{{Name: secretName}},
+				},
+			},
+			sourceKind:      effectiveListenerSourceListenerSet,
+			sourceNamespace: "apps",
+			ociName:         "ls_apps_edge_https",
+		}
+
+		got := effectiveListenerOCIListener(listener)
+
+		require.NotNil(t, got.TLS)
+		require.Len(t, got.TLS.CertificateRefs, 1)
+		assert.Equal(t, v1.SectionName("ls_apps_edge_https"), got.Name)
+		assert.Equal(t, lo.ToPtr(v1.Namespace("apps")), got.TLS.CertificateRefs[0].Namespace)
+		assert.Nil(t, listener.listener.TLS.CertificateRefs[0].Namespace)
+	})
+
+	t.Run("listenerSetStatusForGateway", func(t *testing.T) {
+		gateway := makeGateway(func(gateway *v1.Gateway) {
+			gateway.Namespace = "infra"
+			gateway.Name = "edge"
+			gateway.Spec.Listeners = []v1.Listener{{
+				Name:     "https",
+				Port:     443,
+				Protocol: v1.HTTPSProtocolType,
+				Hostname: lo.ToPtr(v1.Hostname("api.example.com")),
+			}}
+		})
+		listenerSet := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "apps"
+			listenerSet.Name = "extra"
+			listenerSet.Generation = 7
+			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
+				Name:     "api",
+				Port:     443,
+				Protocol: v1.HTTPSProtocolType,
+				Hostname: lo.ToPtr(v1.Hostname("api.example.com")),
+			}}
+		})
+		effectiveListeners := effectiveListenersForGateway(gateway, []v1.ListenerSet{listenerSet})
+
+		got := listenerSetStatusForGateway(
+			gateway,
+			listenerSet,
+			effectiveListeners,
+			v1.GatewayController(ControllerClassName),
+		)
+
+		require.Len(t, got.Conditions, 2)
+		require.Len(t, got.Listeners, 1)
+		accepted := lo.FindOrElse(got.Listeners[0].Conditions, metav1.Condition{},
+			func(condition metav1.Condition) bool {
+				return condition.Type == string(v1.ListenerConditionAccepted)
+			})
+		assert.Equal(t, metav1.ConditionFalse, accepted.Status)
+		assert.Equal(t, string(v1.ListenerReasonHostnameConflict), accepted.Reason)
+		assert.Equal(t, int64(7), accepted.ObservedGeneration)
+		assert.ElementsMatch(t, []v1.RouteGroupKind{{
+			Group: lo.ToPtr(v1.Group(v1.GroupName)),
+			Kind:  "HTTPRoute",
+		}, {
+			Group: lo.ToPtr(v1.Group(v1.GroupName)),
+			Kind:  "GRPCRoute",
+		}}, got.Listeners[0].SupportedKinds)
+		assert.True(t, listenerSetStatusSemanticallyEqual(got, got))
+
+		changed := got.DeepCopy()
+		changed.Listeners[0].Conditions[0].Reason = "Other"
+		assert.False(t, listenerSetStatusSemanticallyEqual(got, *changed))
+
+		acceptedListenerSet := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "apps"
+			listenerSet.Name = "accepted"
+			listenerSet.Generation = 3
+			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
+				Name:     "grpc",
+				Port:     8443,
+				Protocol: v1.HTTPSProtocolType,
+				AllowedRoutes: &v1.AllowedRoutes{Kinds: []v1.RouteGroupKind{{
+					Group: lo.ToPtr(v1.Group(v1.GroupName)),
+					Kind:  "GRPCRoute",
+				}}},
+			}, {
+				Name:     "tcp",
+				Port:     9000,
+				Protocol: v1.TCPProtocolType,
+			}, {
+				Name:     "udp",
+				Port:     9001,
+				Protocol: v1.UDPProtocolType,
+			}, {
+				Name:     "tls",
+				Port:     9443,
+				Protocol: v1.TLSProtocolType,
+			}, {
+				Name:     "raw",
+				Port:     9999,
+				Protocol: v1.ProtocolType("CUSTOM"),
+			}}
+		})
+		status := listenerSetStatusForGateway(
+			gateway,
+			acceptedListenerSet,
+			effectiveListenersForGateway(gateway, []v1.ListenerSet{acceptedListenerSet}),
+			v1.GatewayController(ControllerClassName),
+		)
+		require.Len(t, status.Listeners, 5)
+		assert.ElementsMatch(t, []v1.RouteGroupKind{{
+			Group: lo.ToPtr(v1.Group(v1.GroupName)),
+			Kind:  "GRPCRoute",
+		}}, status.Listeners[0].SupportedKinds)
+		assert.ElementsMatch(t, []v1.RouteGroupKind{{
+			Group: lo.ToPtr(v1.Group(v1.GroupName)),
+			Kind:  "TCPRoute",
+		}}, status.Listeners[1].SupportedKinds)
+		assert.ElementsMatch(t, []v1.RouteGroupKind{{
+			Group: lo.ToPtr(v1.Group(v1.GroupName)),
+			Kind:  "UDPRoute",
+		}}, status.Listeners[2].SupportedKinds)
+		assert.ElementsMatch(t, []v1.RouteGroupKind{{
+			Group: lo.ToPtr(v1.Group(v1.GroupName)),
+			Kind:  "TLSRoute",
+		}}, status.Listeners[3].SupportedKinds)
+		assert.Empty(t, status.Listeners[4].SupportedKinds)
+
+		unsupportedListeners := effectiveListenersForGateway(gateway, []v1.ListenerSet{acceptedListenerSet})
+		markUnsupportedListenerSetListeners(
+			unsupportedListeners,
+			v1.GatewayController(ControllerClassName),
+		)
+		status = listenerSetStatusForGateway(
+			gateway,
+			acceptedListenerSet,
+			unsupportedListeners,
+			v1.GatewayController(ControllerClassName),
+		)
+		assert.False(t, meta.IsStatusConditionTrue(status.Conditions, string(v1.ListenerSetConditionAccepted)))
+		listenerSetAccepted := lo.FindOrElse(
+			status.Conditions,
+			metav1.Condition{},
+			func(condition metav1.Condition) bool {
+				return condition.Type == string(v1.ListenerSetConditionAccepted)
+			},
+		)
+		assert.Equal(t, string(v1.ListenerSetReasonListenersNotValid), listenerSetAccepted.Reason)
+		tcpAccepted := lo.FindOrElse(status.Listeners[1].Conditions, metav1.Condition{},
+			func(condition metav1.Condition) bool {
+				return condition.Type == string(v1.ListenerConditionAccepted)
+			})
+		assert.Equal(t, metav1.ConditionFalse, tcpAccepted.Status)
+		assert.Equal(t, string(v1.ListenerReasonUnsupportedProtocol), tcpAccepted.Reason)
+		assert.NotContains(t,
+			lo.Map(effectiveOCIListenersForGateway(&resolvedGatewayDetails{
+				gateway:            gateway,
+				effectiveListeners: unsupportedListeners,
+			}), func(listener v1.Listener, _ int) v1.SectionName {
+				return listener.Name
+			}),
+			v1.SectionName("tcp"),
+		)
+
+		nlbUnsupportedListeners := effectiveListenersForGateway(gateway, []v1.ListenerSet{acceptedListenerSet})
+		markUnsupportedListenerSetListeners(
+			nlbUnsupportedListeners,
+			v1.GatewayController(NetworkLoadBalancerControllerClassName),
+		)
+		status = listenerSetStatusForGateway(
+			gateway,
+			acceptedListenerSet,
+			nlbUnsupportedListeners,
+			v1.GatewayController(NetworkLoadBalancerControllerClassName),
+		)
+		httpAccepted := lo.FindOrElse(status.Listeners[0].Conditions, metav1.Condition{},
+			func(condition metav1.Condition) bool {
+				return condition.Type == string(v1.ListenerConditionAccepted)
+			})
+		assert.Equal(t, metav1.ConditionFalse, httpAccepted.Status)
+		assert.Equal(t, string(v1.ListenerReasonUnsupportedProtocol), httpAccepted.Reason)
+
+		assert.False(t, listenerSetStatusSemanticallyEqual(got, status))
+		assert.False(t, routeGroupKindsEqual(status.Listeners[0].SupportedKinds, nil))
+		assert.False(t, routeGroupKindsEqual([]v1.RouteGroupKind{{
+			Group: lo.ToPtr(v1.Group("example.com")),
+			Kind:  "GRPCRoute",
+		}}, []v1.RouteGroupKind{{
+			Group: lo.ToPtr(v1.Group(v1.GroupName)),
+			Kind:  "GRPCRoute",
+		}}))
+		assert.False(t, conditionsSemanticallyEqual(got.Conditions, nil))
+	})
+}

--- a/internal/app/listenerset_model_test.go
+++ b/internal/app/listenerset_model_test.go
@@ -180,7 +180,7 @@ func TestListenerSetModel(t *testing.T) {
 			listenerSet.CreationTimestamp = older
 			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
 				Name:     "grpc",
-				Port:     443,
+				Port:     8443,
 				Protocol: v1.HTTPSProtocolType,
 				Hostname: lo.ToPtr(v1.Hostname("grpc.example.com")),
 			}}
@@ -196,19 +196,32 @@ func TestListenerSetModel(t *testing.T) {
 				Hostname: &conflictingHostname,
 			}}
 		})
+		listenerSet3 := makeListenerSet(func(listenerSet *v1.ListenerSet) {
+			listenerSet.Namespace = "team-c"
+			listenerSet.Name = "edge-extra"
+			listenerSet.CreationTimestamp = metav1.NewTime(time.Now())
+			listenerSet.Spec.Listeners = []v1.ListenerEntry{{
+				Name:     "admin",
+				Port:     8443,
+				Protocol: v1.HTTPSProtocolType,
+				Hostname: lo.ToPtr(v1.Hostname("admin.example.com")),
+			}}
+		})
 
-		got := effectiveListenersForGateway(gateway, []v1.ListenerSet{listenerSet2, listenerSet1})
+		got := effectiveListenersForGateway(gateway, []v1.ListenerSet{listenerSet3, listenerSet2, listenerSet1})
 
-		require.Len(t, got, 3)
+		require.Len(t, got, 4)
 		assert.Equal(t, effectiveListenerSourceGateway, got[0].sourceKind)
 		assert.Equal(t, effectiveListenerSourceListenerSet, got[1].sourceKind)
 		assert.Equal(t, "team-a", got[1].sourceNamespace)
 		assert.False(t, got[1].conflicted)
 		assert.True(t, got[2].conflicted)
 		assert.Equal(t, v1.ListenerReasonHostnameConflict, got[2].conflictReason)
+		assert.True(t, got[3].conflicted)
+		assert.Equal(t, v1.ListenerReasonPortUnavailable, got[3].conflictReason)
 
 		conflictingProtocol := makeListenerSet(func(listenerSet *v1.ListenerSet) {
-			listenerSet.Namespace = "team-c"
+			listenerSet.Namespace = "team-d"
 			listenerSet.Name = "edge-tcp"
 			listenerSet.CreationTimestamp = metav1.NewTime(time.Now())
 			listenerSet.Spec.Listeners = []v1.ListenerEntry{{

--- a/internal/app/listenerset_model_test.go
+++ b/internal/app/listenerset_model_test.go
@@ -380,6 +380,7 @@ func TestListenerSetModel(t *testing.T) {
 			listenerSet,
 			effectiveListeners,
 			v1.GatewayController(ControllerClassName),
+			nil,
 		)
 
 		require.Len(t, got.Conditions, 2)
@@ -439,6 +440,7 @@ func TestListenerSetModel(t *testing.T) {
 			acceptedListenerSet,
 			effectiveListenersForGateway(gateway, []v1.ListenerSet{acceptedListenerSet}),
 			v1.GatewayController(ControllerClassName),
+			nil,
 		)
 		require.Len(t, status.Listeners, 5)
 		assert.ElementsMatch(t, []v1.RouteGroupKind{{
@@ -469,8 +471,9 @@ func TestListenerSetModel(t *testing.T) {
 			acceptedListenerSet,
 			unsupportedListeners,
 			v1.GatewayController(ControllerClassName),
+			nil,
 		)
-		assert.False(t, meta.IsStatusConditionTrue(status.Conditions, string(v1.ListenerSetConditionAccepted)))
+		assert.True(t, meta.IsStatusConditionTrue(status.Conditions, string(v1.ListenerSetConditionAccepted)))
 		listenerSetAccepted := lo.FindOrElse(
 			status.Conditions,
 			metav1.Condition{},
@@ -478,7 +481,7 @@ func TestListenerSetModel(t *testing.T) {
 				return condition.Type == string(v1.ListenerSetConditionAccepted)
 			},
 		)
-		assert.Equal(t, string(v1.ListenerSetReasonListenersNotValid), listenerSetAccepted.Reason)
+		assert.Equal(t, string(v1.ListenerSetReasonAccepted), listenerSetAccepted.Reason)
 		tcpAccepted := lo.FindOrElse(status.Listeners[1].Conditions, metav1.Condition{},
 			func(condition metav1.Condition) bool {
 				return condition.Type == string(v1.ListenerConditionAccepted)
@@ -505,6 +508,7 @@ func TestListenerSetModel(t *testing.T) {
 			acceptedListenerSet,
 			nlbUnsupportedListeners,
 			v1.GatewayController(NetworkLoadBalancerControllerClassName),
+			nil,
 		)
 		httpAccepted := lo.FindOrElse(status.Listeners[0].Conditions, metav1.Condition{},
 			func(condition metav1.Condition) bool {
@@ -523,5 +527,109 @@ func TestListenerSetModel(t *testing.T) {
 			Kind:  "GRPCRoute",
 		}}))
 		assert.False(t, conditionsSemanticallyEqual(got.Conditions, nil))
+	})
+
+	t.Run("listener entry reason helpers map Gateway listener reasons", func(t *testing.T) {
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonHostnameConflict,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonHostnameConflict),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonProtocolConflict,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonProtocolConflict),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonInvalidCertificateRef,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonInvalidCertificateRef),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonInvalidRouteKinds,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonInvalidRouteKinds),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonRefNotPermitted,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonRefNotPermitted),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonUnsupportedProtocol,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonUnsupportedProtocol),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonPortUnavailable,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonPortUnavailable),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonInvalid,
+			listenerEntryReasonFromListenerReason(v1.ListenerReasonPending),
+		)
+	})
+
+	t.Run("listener entry condition helper statuses", func(t *testing.T) {
+		assert.Equal(
+			t,
+			metav1.ConditionFalse,
+			listenerEntryResolvedRefsStatus(v1.ListenerEntryReasonRefNotPermitted),
+		)
+		assert.Equal(
+			t,
+			metav1.ConditionTrue,
+			listenerEntryResolvedRefsStatus(v1.ListenerEntryReasonAccepted),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonInvalidCertificateRef,
+			listenerEntryResolvedRefsReason(v1.ListenerEntryReasonInvalidCertificateRef),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonResolvedRefs,
+			listenerEntryResolvedRefsReason(v1.ListenerEntryReasonAccepted),
+		)
+		assert.Equal(t, metav1.ConditionTrue, listenerEntryConflictedStatus(effectiveListener{conflicted: true}))
+		assert.Equal(t, metav1.ConditionFalse, listenerEntryConflictedStatus(effectiveListener{}))
+		assert.Equal(
+			t,
+			v1.ListenerEntryReasonProtocolConflict,
+			listenerEntryConflictedReason(effectiveListener{
+				conflicted:     true,
+				conflictReason: v1.ListenerReasonProtocolConflict,
+			}),
+		)
+		assert.Equal(
+			t,
+			v1.ListenerEntryConditionReason(v1.ListenerReasonNoConflicts),
+			listenerEntryConflictedReason(effectiveListener{}),
+		)
+	})
+
+	t.Run("attachedListenerSetCount only counts sets with accepted effective listeners", func(t *testing.T) {
+		listenerSets := []v1.ListenerSet{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "accepted"}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "rejected"}},
+		}
+		count := attachedListenerSetCount(listenerSets, []effectiveListener{
+			{
+				sourceKind:      effectiveListenerSourceListenerSet,
+				sourceNamespace: "apps",
+				sourceName:      "accepted",
+			},
+			{
+				sourceKind:      effectiveListenerSourceListenerSet,
+				sourceNamespace: "apps",
+				sourceName:      "rejected",
+				unsupported:     true,
+			},
+		})
+
+		require.NotNil(t, count)
+		assert.Equal(t, int32(1), *count)
 	})
 }

--- a/internal/app/mock_http_route_model.go
+++ b/internal/app/mock_http_route_model.go
@@ -13,8 +13,6 @@ import (
 
 	reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	types "k8s.io/apimachinery/pkg/types"
-
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -321,23 +319,23 @@ func (_c *MockhttpRouteModel_resolveBackendRefs_Call) RunAndReturn(run func(cont
 }
 
 // resolveRequest provides a mock function with given fields: ctx, req
-func (_m *MockhttpRouteModel) resolveRequest(ctx context.Context, req reconcile.Request) (map[types.NamespacedName]resolvedRouteDetails, error) {
+func (_m *MockhttpRouteModel) resolveRequest(ctx context.Context, req reconcile.Request) (map[routeParentResultKey]resolvedRouteDetails, error) {
 	ret := _m.Called(ctx, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for resolveRequest")
 	}
 
-	var r0 map[types.NamespacedName]resolvedRouteDetails
+	var r0 map[routeParentResultKey]resolvedRouteDetails
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, reconcile.Request) (map[types.NamespacedName]resolvedRouteDetails, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedRouteDetails, error)); ok {
 		return rf(ctx, req)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, reconcile.Request) map[types.NamespacedName]resolvedRouteDetails); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, reconcile.Request) map[routeParentResultKey]resolvedRouteDetails); ok {
 		r0 = rf(ctx, req)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[types.NamespacedName]resolvedRouteDetails)
+			r0 = ret.Get(0).(map[routeParentResultKey]resolvedRouteDetails)
 		}
 	}
 
@@ -369,12 +367,12 @@ func (_c *MockhttpRouteModel_resolveRequest_Call) Run(run func(ctx context.Conte
 	return _c
 }
 
-func (_c *MockhttpRouteModel_resolveRequest_Call) Return(_a0 map[types.NamespacedName]resolvedRouteDetails, _a1 error) *MockhttpRouteModel_resolveRequest_Call {
+func (_c *MockhttpRouteModel_resolveRequest_Call) Return(_a0 map[routeParentResultKey]resolvedRouteDetails, _a1 error) *MockhttpRouteModel_resolveRequest_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockhttpRouteModel_resolveRequest_Call) RunAndReturn(run func(context.Context, reconcile.Request) (map[types.NamespacedName]resolvedRouteDetails, error)) *MockhttpRouteModel_resolveRequest_Call {
+func (_c *MockhttpRouteModel_resolveRequest_Call) RunAndReturn(run func(context.Context, reconcile.Request) (map[routeParentResultKey]resolvedRouteDetails, error)) *MockhttpRouteModel_resolveRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/app/mock_oci_load_balancer_model.go
+++ b/internal/app/mock_oci_load_balancer_model.go
@@ -118,6 +118,54 @@ func (_c *MockociLoadBalancerModel_deprovisionBackendSet_Call) RunAndReturn(run 
 	return _c
 }
 
+// deprovisionBackendSetByName provides a mock function with given fields: ctx, loadBalancerID, backendSetName
+func (_m *MockociLoadBalancerModel) deprovisionBackendSetByName(ctx context.Context, loadBalancerID string, backendSetName string) error {
+	ret := _m.Called(ctx, loadBalancerID, backendSetName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for deprovisionBackendSetByName")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, loadBalancerID, backendSetName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockociLoadBalancerModel_deprovisionBackendSetByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deprovisionBackendSetByName'
+type MockociLoadBalancerModel_deprovisionBackendSetByName_Call struct {
+	*mock.Call
+}
+
+// deprovisionBackendSetByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - loadBalancerID string
+//   - backendSetName string
+func (_e *MockociLoadBalancerModel_Expecter) deprovisionBackendSetByName(ctx interface{}, loadBalancerID interface{}, backendSetName interface{}) *MockociLoadBalancerModel_deprovisionBackendSetByName_Call {
+	return &MockociLoadBalancerModel_deprovisionBackendSetByName_Call{Call: _e.mock.On("deprovisionBackendSetByName", ctx, loadBalancerID, backendSetName)}
+}
+
+func (_c *MockociLoadBalancerModel_deprovisionBackendSetByName_Call) Run(run func(ctx context.Context, loadBalancerID string, backendSetName string)) *MockociLoadBalancerModel_deprovisionBackendSetByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockociLoadBalancerModel_deprovisionBackendSetByName_Call) Return(_a0 error) *MockociLoadBalancerModel_deprovisionBackendSetByName_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockociLoadBalancerModel_deprovisionBackendSetByName_Call) RunAndReturn(run func(context.Context, string, string) error) *MockociLoadBalancerModel_deprovisionBackendSetByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ensureHTTP2ListenerProtocol provides a mock function with given fields: ctx, params
 func (_m *MockociLoadBalancerModel) ensureHTTP2ListenerProtocol(ctx context.Context, params ensureHTTP2ListenerProtocolParams) error {
 	ret := _m.Called(ctx, params)

--- a/internal/app/network_load_balancer_gateway_controller.go
+++ b/internal/app/network_load_balancer_gateway_controller.go
@@ -42,6 +42,12 @@ func NewNetworkLoadBalancerGatewayController(
 	}
 }
 
+func (r *NetworkLoadBalancerGatewayController) SetListenerSetEnabled(enabled bool) {
+	if model, ok := r.gatewayModel.(interface{ setListenerSetEnabled(bool) }); ok {
+		model.setListenerSetEnabled(enabled)
+	}
+}
+
 func (r *NetworkLoadBalancerGatewayController) processResourceError(
 	ctx context.Context,
 	err error,

--- a/internal/app/network_load_balancer_gateway_controller_test.go
+++ b/internal/app/network_load_balancer_gateway_controller_test.go
@@ -102,6 +102,19 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 		},
 	}
 
+	t.Run("SetListenerSetEnabled", func(t *testing.T) {
+		gatewayModel := &networkLoadBalancerGatewayModelImpl{}
+		controller := NewNetworkLoadBalancerGatewayController(NetworkLoadBalancerGatewayControllerDeps{
+			RootLogger:     diag.RootTestLogger(),
+			ResourcesModel: &stubResourcesModel{},
+			GatewayModel:   gatewayModel,
+		})
+
+		controller.SetListenerSetEnabled(true)
+
+		assert.True(t, gatewayModel.listenerSetEnabled)
+	})
+
 	t.Run("programs relevant gateway", func(t *testing.T) {
 		nlb := &networkloadbalancer.NetworkLoadBalancer{}
 		gatewayModel := &stubNLBGatewayModel{relevant: true, data: baseData, nlb: nlb}

--- a/internal/app/network_load_balancer_gateway_model.go
+++ b/internal/app/network_load_balancer_gateway_model.go
@@ -61,6 +61,11 @@ type networkLoadBalancerGatewayModelImpl struct {
 	resourcesModel      resourcesModel
 	workRequestsWatcher workRequestsWatcher
 	operationLocks      *networkLoadBalancerOperationLocks
+	listenerSetEnabled  bool
+}
+
+func (m *networkLoadBalancerGatewayModelImpl) setListenerSetEnabled(enabled bool) {
+	m.listenerSetEnabled = enabled
 }
 
 func networkLoadBalancerBackendSetName(listener gatewayv1.Listener) string {
@@ -239,9 +244,7 @@ func (m *networkLoadBalancerGatewayModelImpl) resolveReconcileRequest(
 	}
 
 	if receiver.gateway.Spec.Infrastructure == nil || receiver.gateway.Spec.Infrastructure.ParametersRef == nil {
-		if receiver.gateway.DeletionTimestamp != nil &&
-			controllerutil.ContainsFinalizer(&receiver.gateway, NetworkLoadBalancerGatewayProgrammedFinalizer) &&
-			receiver.gateway.Annotations[NetworkLoadBalancerGatewayIDAnnotation] != "" {
+		if networkLoadBalancerGatewayCanFinalizeWithoutConfig(receiver.gateway) {
 			return true, nil
 		}
 		return false, &resourceStatusError{
@@ -257,9 +260,7 @@ func (m *networkLoadBalancerGatewayModelImpl) resolveReconcileRequest(
 	}
 	if err := m.client.Get(ctx, configName, &receiver.config); err != nil {
 		if apierrors.IsNotFound(err) {
-			if receiver.gateway.DeletionTimestamp != nil &&
-				controllerutil.ContainsFinalizer(&receiver.gateway, NetworkLoadBalancerGatewayProgrammedFinalizer) &&
-				receiver.gateway.Annotations[NetworkLoadBalancerGatewayIDAnnotation] != "" {
+			if networkLoadBalancerGatewayCanFinalizeWithoutConfig(receiver.gateway) {
 				return true, nil
 			}
 			return false, &resourceStatusError{
@@ -270,8 +271,19 @@ func (m *networkLoadBalancerGatewayModelImpl) resolveReconcileRequest(
 		}
 		return false, fmt.Errorf("failed to get GatewayConfig %s: %w", configName, err)
 	}
+	if m.listenerSetEnabled {
+		if err := populateAttachedListenerSets(ctx, m.client, receiver); err != nil {
+			return false, err
+		}
+	}
 
 	return true, nil
+}
+
+func networkLoadBalancerGatewayCanFinalizeWithoutConfig(gateway gatewayv1.Gateway) bool {
+	return gateway.DeletionTimestamp != nil &&
+		controllerutil.ContainsFinalizer(&gateway, NetworkLoadBalancerGatewayProgrammedFinalizer) &&
+		gateway.Annotations[NetworkLoadBalancerGatewayIDAnnotation] != ""
 }
 
 func (m *networkLoadBalancerGatewayModelImpl) ensureNetworkLoadBalancer(
@@ -474,7 +486,7 @@ func desiredNetworkLoadBalancerListenerNames(
 ) map[string]struct{} {
 	desired := make(map[string]struct{})
 	for _, listener := range listeners {
-		if _, supported := networkLoadBalancerListenerProtocol(listener.Protocol); !supported {
+		if !networkLoadBalancerListenerPreservedByGateway(listener.Protocol) {
 			continue
 		}
 		desired[string(listener.Name)] = struct{}{}
@@ -487,12 +499,19 @@ func desiredNetworkLoadBalancerBackendSetNames(
 ) map[string]struct{} {
 	desired := make(map[string]struct{})
 	for _, listener := range listeners {
-		if _, supported := networkLoadBalancerListenerProtocol(listener.Protocol); !supported {
+		if !networkLoadBalancerListenerPreservedByGateway(listener.Protocol) {
 			continue
 		}
 		desired[networkLoadBalancerBackendSetName(listener)] = struct{}{}
 	}
 	return desired
+}
+
+func networkLoadBalancerListenerPreservedByGateway(protocol gatewayv1.ProtocolType) bool {
+	if _, supported := networkLoadBalancerListenerProtocol(protocol); supported {
+		return true
+	}
+	return protocol == gatewayv1.TLSProtocolType
 }
 
 func (m *networkLoadBalancerGatewayModelImpl) removeMissingListeners(
@@ -630,19 +649,51 @@ func (m *networkLoadBalancerGatewayModelImpl) programGateway(
 	}
 
 	return m.operationLocks.withLock(nlb.Id, func() error {
-		for _, listener := range data.gateway.Spec.Listeners {
+		gatewayListeners := effectiveOCIListenersForGateway(data)
+		if err = validateNetworkLoadBalancerGatewayListeners(data); err != nil {
+			return err
+		}
+		gatewayManagedListeners := gatewayManagedOCIListenersForNetworkLoadBalancer(data)
+		for _, listener := range gatewayManagedListeners {
 			if err = m.reconcileListener(ctx, *nlb, listener); err != nil {
 				return fmt.Errorf("failed to reconcile Network Load Balancer listener %s: %w", listener.Name, err)
 			}
 		}
-		if err = m.removeMissingListeners(ctx, *nlb, data.gateway.Spec.Listeners); err != nil {
+		if err = m.removeMissingListeners(ctx, *nlb, gatewayListeners); err != nil {
 			return err
 		}
-		if err = m.removeMissingBackendSets(ctx, *nlb, data.gateway.Spec.Listeners); err != nil {
+		if err = m.removeMissingBackendSets(ctx, *nlb, gatewayListeners); err != nil {
 			return err
 		}
 		return nil
 	})
+}
+
+func validateNetworkLoadBalancerGatewayListeners(data *resolvedGatewayDetails) error {
+	effectiveListeners := data.effectiveListeners
+	if len(effectiveListeners) == 0 {
+		effectiveListeners = effectiveListenersForGateway(data.gateway, nil)
+	}
+	for _, listener := range effectiveListeners {
+		if listener.sourceKind != effectiveListenerSourceGateway ||
+			listener.conflicted ||
+			listener.listener.Protocol == gatewayv1.TLSProtocolType {
+			continue
+		}
+		if _, supported := networkLoadBalancerListenerProtocol(listener.listener.Protocol); supported {
+			continue
+		}
+		return &resourceStatusError{
+			conditionType: string(gatewayv1.GatewayConditionAccepted),
+			reason:        string(gatewayv1.GatewayReasonInvalid),
+			message: fmt.Sprintf(
+				"listener %s uses unsupported protocol %s for OCI Network Load Balancer",
+				listener.listener.Name,
+				listener.listener.Protocol,
+			),
+		}
+	}
+	return nil
 }
 
 func (m *networkLoadBalancerGatewayModelImpl) isProgrammed(_ context.Context, data *resolvedGatewayDetails) bool {
@@ -680,6 +731,7 @@ func (m *networkLoadBalancerGatewayModelImpl) setProgrammed(
 	}
 
 	data.gateway.Status.Addresses = gatewayStatusAddressesFromNetworkLoadBalancer(nlb)
+	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets)
 	annotations := map[string]string{
 		NetworkLoadBalancerGatewayProgrammingRevisionAnnotation: NetworkLoadBalancerGatewayProgrammingRevisionValue,
 	}
@@ -701,6 +753,14 @@ func (m *networkLoadBalancerGatewayModelImpl) setProgrammed(
 		finalizer:   NetworkLoadBalancerGatewayProgrammedFinalizer,
 	}); err != nil {
 		return fmt.Errorf("failed to set programmed condition for Gateway %s: %w", data.gateway.Name, err)
+	}
+	if err := setListenerSetsProgrammed(
+		ctx,
+		m.client,
+		data,
+		gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+	); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/app/network_load_balancer_gateway_model.go
+++ b/internal/app/network_load_balancer_gateway_model.go
@@ -731,7 +731,7 @@ func (m *networkLoadBalancerGatewayModelImpl) setProgrammed(
 	}
 
 	data.gateway.Status.Addresses = gatewayStatusAddressesFromNetworkLoadBalancer(nlb)
-	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets)
+	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets, data.effectiveListeners)
 	annotations := map[string]string{
 		NetworkLoadBalancerGatewayProgrammingRevisionAnnotation: NetworkLoadBalancerGatewayProgrammingRevisionValue,
 	}

--- a/internal/app/network_load_balancer_gateway_model_test.go
+++ b/internal/app/network_load_balancer_gateway_model_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -335,6 +336,60 @@ func TestNetworkLoadBalancerGatewayModelResolveBranches(t *testing.T) {
 
 		assert.False(t, relevant)
 		require.ErrorContains(t, err, "failed to get GatewayClass")
+	})
+
+	t.Run("resolves attached ListenerSets when enabled", func(t *testing.T) {
+		parentNamespace := gatewayv1.Namespace("iot")
+		fromAll := gatewayv1.NamespacesFromAll
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(
+				gateway(func(g *gatewayv1.Gateway) {
+					g.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+						Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+					}
+				}),
+				gatewayClass(gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName)),
+				config,
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+				&gatewayv1.ListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+					Spec: gatewayv1.ListenerSetSpec{
+						ParentRef: gatewayv1.ParentGatewayReference{
+							Namespace: &parentNamespace,
+							Name:      "edge",
+						},
+						Listeners: []gatewayv1.ListenerEntry{{
+							Name:     "rtmp",
+							Port:     1935,
+							Protocol: gatewayv1.TCPProtocolType,
+						}},
+					},
+				},
+			).
+			WithIndex(&gatewayv1.ListenerSet{}, listenerSetParentGatewayIndexKey, func(obj client.Object) []string {
+				listenerSet, ok := obj.(*gatewayv1.ListenerSet)
+				require.True(t, ok)
+				parentName, ok := listenerSetParentGatewayName(*listenerSet)
+				require.True(t, ok)
+				return []string{parentName}
+			}).
+			Build()
+		model := newNetworkLoadBalancerGatewayModel(networkLoadBalancerGatewayModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  k8sClient,
+		})
+		model.setListenerSetEnabled(true)
+
+		var details resolvedGatewayDetails
+		relevant, err := model.resolveReconcileRequest(t.Context(), reconcile.Request{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "iot", Name: "edge"},
+		}, &details)
+
+		require.NoError(t, err)
+		assert.True(t, relevant)
+		require.Len(t, details.listenerSets, 1)
+		require.Len(t, details.effectiveListeners, 1)
 	})
 }
 
@@ -693,6 +748,100 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			lo.FromPtr(client.createListenerRequests[1].UdpIdleTimeout))
 	})
 
+	t.Run("programs ListenerSet tcp and udp listeners with derived OCI listener names", func(t *testing.T) {
+		client := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
+					DisplayName: new("shared-nlb"),
+				},
+			},
+			createBackendSetResponse: networkloadbalancer.CreateBackendSetResponse{
+				OpcWorkRequestId: new("create-backend-set-work"),
+			},
+			createListenerResponse: networkloadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: new("create-listener-work"),
+			},
+		}
+		model := newModel(client, &stubWorkRequestsWatcher{})
+		details := newDetails()
+		details.gateway.Spec.Listeners = nil
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "iot",
+				Name:              "media",
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(details.gateway.Name)},
+				Listeners: []gatewayv1.ListenerEntry{
+					{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+					{Name: "coap-dtls", Protocol: gatewayv1.UDPProtocolType, Port: 5684},
+				},
+			},
+		}
+		details.listenerSets = []gatewayv1.ListenerSet{listenerSet}
+		details.effectiveListeners = effectiveListenersForGateway(details.gateway, details.listenerSets)
+		wantListeners := gatewayManagedOCIListenersForNetworkLoadBalancer(details)
+
+		err := model.programGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		require.Len(t, wantListeners, 2)
+		require.Len(t, client.createBackendSetRequests, 2)
+		assert.Equal(t,
+			networkLoadBalancerBackendSetName(wantListeners[0]),
+			lo.FromPtr(client.createBackendSetRequests[0].Name),
+		)
+		assert.Equal(t,
+			networkLoadBalancerBackendSetName(wantListeners[1]),
+			lo.FromPtr(client.createBackendSetRequests[1].Name),
+		)
+		require.Len(t, client.createListenerRequests, 2)
+		assert.Equal(t, string(wantListeners[0].Name), lo.FromPtr(client.createListenerRequests[0].Name))
+		assert.Equal(t, string(wantListeners[1].Name), lo.FromPtr(client.createListenerRequests[1].Name))
+		assert.NotEqual(t, "rtmp", lo.FromPtr(client.createListenerRequests[0].Name))
+		assert.Contains(t, lo.FromPtr(client.createListenerRequests[0].Name), "ls_")
+	})
+
+	t.Run("skips TLS passthrough gateway listeners owned by TLSRoute", func(t *testing.T) {
+		client := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
+					DisplayName: new("shared-nlb"),
+					Listeners: map[string]networkloadbalancer.Listener{
+						"tls": {
+							Name: new("tls"),
+						},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_tls": {
+							Name: new("bs_tls"),
+						},
+					},
+				},
+			},
+		}
+		model := newModel(client, &stubWorkRequestsWatcher{})
+		mode := gatewayv1.TLSModePassthrough
+		details := newDetails()
+		details.gateway.Spec.Listeners = []gatewayv1.Listener{{
+			Name:     "tls",
+			Protocol: gatewayv1.TLSProtocolType,
+			Port:     443,
+			TLS:      &gatewayv1.ListenerTLSConfig{Mode: &mode},
+		}}
+
+		err := model.programGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		assert.Empty(t, client.createBackendSetRequests)
+		assert.Empty(t, client.createListenerRequests)
+		assert.Empty(t, client.deleteListenerRequests)
+		assert.Empty(t, client.deleteBackendSetRequests)
+	})
+
 	t.Run("programs existing network load balancer by id without marking it managed", func(t *testing.T) {
 		client := &stubNetworkLoadBalancerClient{
 			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
@@ -987,6 +1136,54 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 				"delete-listener-work-request",
 				"delete-backend-set-work-request",
 			},
+			watcher.waited,
+		)
+	})
+
+	t.Run("removes stale ListenerSet derived listeners and backend sets", func(t *testing.T) {
+		details := newDetails()
+		details.gateway.Spec.Listeners = nil
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "media"},
+		}
+		staleListenerName := listenerSetOCIListenerName(details.gateway, listenerSet, listener)
+		staleBackendSetName := networkLoadBalancerBackendSetName(gatewayv1.Listener{
+			Name:     gatewayv1.SectionName(staleListenerName),
+			Protocol: listener.Protocol,
+		})
+		watcher := &stubWorkRequestsWatcher{}
+		client := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
+					DisplayName: new("shared-nlb"),
+					Listeners: map[string]networkloadbalancer.Listener{
+						staleListenerName: {Name: &staleListenerName},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						staleBackendSetName: {Name: &staleBackendSetName},
+					},
+				},
+			},
+			deleteListenerResponse: networkloadbalancer.DeleteListenerResponse{
+				OpcWorkRequestId: new("delete-listener-work-request"),
+			},
+			deleteBackendSetResponse: networkloadbalancer.DeleteBackendSetResponse{
+				OpcWorkRequestId: new("delete-backend-set-work-request"),
+			},
+		}
+		model := newModel(client, watcher)
+
+		err := model.programGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		require.Len(t, client.deleteListenerRequests, 1)
+		assert.Equal(t, staleListenerName, lo.FromPtr(client.deleteListenerRequests[0].ListenerName))
+		require.Len(t, client.deleteBackendSetRequests, 1)
+		assert.Equal(t, staleBackendSetName, lo.FromPtr(client.deleteBackendSetRequests[0].BackendSetName))
+		assert.ElementsMatch(t,
+			[]string{"delete-listener-work-request", "delete-backend-set-work-request"},
 			watcher.waited,
 		)
 	})

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -72,6 +72,7 @@ type reconcileHTTPListenerParams struct {
 type reconcileListenersCertificatesParams struct {
 	loadBalancerID    string
 	gateway           *gatewayv1.Gateway
+	gatewayListeners  []gatewayv1.Listener
 	knownCertificates map[string]loadbalancer.Certificate
 }
 
@@ -462,9 +463,13 @@ func (m *ociLoadBalancerModelImpl) reconcileListenersCertificates(
 
 	resultingCertificates := maps.Clone(params.knownCertificates)
 	listenerCertificates := make(map[string][]loadbalancer.Certificate)
-	certificateIDsByListener := gatewayCertificateIDsByListener(*params.gateway)
+	gatewayListeners := params.gatewayListeners
+	if len(gatewayListeners) == 0 {
+		gatewayListeners = params.gateway.Spec.Listeners
+	}
+	certificateIDsByListener := certificateIDsByListener(gatewayListeners)
 
-	for _, listenerSpec := range params.gateway.Spec.Listeners {
+	for _, listenerSpec := range gatewayListeners {
 		if _, usesOCICertificate := certificateIDsByListener[string(listenerSpec.Name)]; usesOCICertificate {
 			continue
 		}

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -163,6 +163,12 @@ type ociLoadBalancerModel interface {
 		params deprovisionBackendSetParams,
 	) error
 
+	deprovisionBackendSetByName(
+		ctx context.Context,
+		loadBalancerID string,
+		backendSetName string,
+	) error
+
 	// makeRoutingRule appends a new routing rule to the routing policy.
 	makeRoutingRule(
 		ctx context.Context,
@@ -1091,21 +1097,28 @@ func (m *ociLoadBalancerModelImpl) deprovisionBackendSet(
 		params.routeNamespace,
 		params.backendRef.BackendObjectReference,
 	)
+	return m.deprovisionBackendSetByName(ctx, params.loadBalancerID, backendSetName)
+}
 
+func (m *ociLoadBalancerModelImpl) deprovisionBackendSetByName(
+	ctx context.Context,
+	loadBalancerID string,
+	backendSetName string,
+) error {
 	m.logger.InfoContext(ctx, "Deprovisioning backend set",
-		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("loadBalancerId", loadBalancerID),
 		slog.String("backendSetName", backendSetName),
 	)
 
 	deleteRes, err := m.ociClient.DeleteBackendSet(ctx, loadbalancer.DeleteBackendSetRequest{
-		LoadBalancerId: &params.loadBalancerID,
+		LoadBalancerId: &loadBalancerID,
 		BackendSetName: &backendSetName,
 	})
 	if err != nil {
 		serviceErr, ok := common.IsServiceError(err)
 		if ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound {
 			m.logger.InfoContext(ctx, "Backend set not found, assuming already deprovisioned",
-				slog.String("loadBalancerId", params.loadBalancerID),
+				slog.String("loadBalancerId", loadBalancerID),
 				slog.String("backendSetName", backendSetName),
 			)
 			return nil // Already gone
@@ -1114,7 +1127,7 @@ func (m *ociLoadBalancerModelImpl) deprovisionBackendSet(
 			serviceErr.GetCode() == "InvalidParameter" &&
 			strings.Contains(serviceErr.GetMessage(), "used in routing policy") {
 			m.logger.InfoContext(ctx, "Backend set is used in routing policy, skipping deletion",
-				slog.String("loadBalancerId", params.loadBalancerID),
+				slog.String("loadBalancerId", loadBalancerID),
 				slog.String("backendSetName", backendSetName),
 				slog.Any("serviceError", err),
 			)
@@ -1134,7 +1147,7 @@ func (m *ociLoadBalancerModelImpl) deprovisionBackendSet(
 	}
 
 	m.logger.InfoContext(ctx, "Successfully deprovisioned backend set",
-		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("loadBalancerId", loadBalancerID),
 		slog.String("backendSetName", backendSetName),
 	)
 	return nil

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -2253,6 +2253,50 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes stale ListenerSet derived listeners", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			gateway := gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "infra-" + fake.Lorem().Word(),
+					Name:      "edge-" + fake.Lorem().Word(),
+				},
+			}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps-" + fake.Lorem().Word(),
+					Name:      "media-" + fake.Lorem().Word(),
+				},
+			}
+			staleListenerName := listenerSetOCIListenerName(
+				gateway,
+				listenerSet,
+				gatewayv1.Listener{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+			)
+			staleListener := makeRandomOCIListener(func(listener *loadbalancer.Listener) {
+				listener.Name = &staleListenerName
+			})
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					staleListenerName: staleListener,
+				},
+			}
+			workRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteListener(t.Context(), loadbalancer.DeleteListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				ListenerName:   &staleListenerName,
+			}).Return(loadbalancer.DeleteListenerResponse{OpcWorkRequestId: &workRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			err := model.removeMissingListeners(t.Context(), params)
+
+			require.NoError(t, err)
+		})
+
 		t.Run("some listeners to remove with routing policy", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)

--- a/internal/app/referencegrant_policy.go
+++ b/internal/app/referencegrant_policy.go
@@ -37,6 +37,33 @@ func referenceGrantAllowsServiceBackend(
 	return false, nil
 }
 
+func referenceGrantAllowsSecretRef(
+	ctx context.Context,
+	k8sClient k8sClient,
+	fromKind gatewayv1.Kind,
+	fromNamespace string,
+	secretName apitypes.NamespacedName,
+) (bool, error) {
+	if secretName.Namespace == fromNamespace {
+		return true, nil
+	}
+
+	var grants gatewayv1beta1.ReferenceGrantList
+	if err := k8sClient.List(ctx, &grants, client.InNamespace(secretName.Namespace)); err != nil {
+		return false, fmt.Errorf("failed to list ReferenceGrants in namespace %s: %w", secretName.Namespace, err)
+	}
+
+	for _, grant := range grants.Items {
+		if !referenceGrantHasMatchingFrom(grant, fromKind, fromNamespace) {
+			continue
+		}
+		if referenceGrantHasMatchingSecretTo(grant, secretName.Name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func referenceGrantHasMatchingFrom(
 	grant gatewayv1beta1.ReferenceGrant,
 	routeKind gatewayv1.Kind,
@@ -52,12 +79,20 @@ func referenceGrantHasMatchingFrom(
 	return false
 }
 
+func referenceGrantHasMatchingSecretTo(grant gatewayv1beta1.ReferenceGrant, secretName string) bool {
+	return referenceGrantHasMatchingCoreTo(grant, "Secret", secretName)
+}
+
 func referenceGrantHasMatchingServiceTo(grant gatewayv1beta1.ReferenceGrant, serviceName string) bool {
+	return referenceGrantHasMatchingCoreTo(grant, serviceKind, serviceName)
+}
+
+func referenceGrantHasMatchingCoreTo(grant gatewayv1beta1.ReferenceGrant, kind gatewayv1.Kind, name string) bool {
 	for _, to := range grant.Spec.To {
-		if string(to.Group) != "" || string(to.Kind) != serviceKind {
+		if string(to.Group) != "" || to.Kind != kind {
 			continue
 		}
-		if to.Name == nil || string(*to.Name) == serviceName {
+		if to.Name == nil || string(*to.Name) == name {
 			return true
 		}
 	}

--- a/internal/app/referencegrant_policy_test.go
+++ b/internal/app/referencegrant_policy_test.go
@@ -172,4 +172,144 @@ func TestReferenceGrantPolicy(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, allowed)
 	})
+
+	t.Run("referenceGrantAllowsSecretRef permits same namespace secret", func(t *testing.T) {
+		allowed, err := referenceGrantAllowsSecretRef(
+			t.Context(),
+			NewMockk8sClient(t),
+			"ListenerSet",
+			"apps",
+			types.NamespacedName{Namespace: "apps", Name: "tls-cert"},
+		)
+
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("referenceGrantAllowsSecretRef permits matching cross namespace secret grant", func(t *testing.T) {
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			List(t.Context(), mock.AnythingOfType("*v1beta1.ReferenceGrantList"), mock.Anything).
+			RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().Set(reflect.ValueOf(gatewayv1beta1.ReferenceGrantList{
+					Items: []gatewayv1beta1.ReferenceGrant{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "certs", Name: "allow-listenersets"},
+						Spec: gatewayv1beta1.ReferenceGrantSpec{
+							From: []gatewayv1beta1.ReferenceGrantFrom{{
+								Group:     gatewayv1.Group(gatewayAPIGroup),
+								Kind:      gatewayv1.Kind("ListenerSet"),
+								Namespace: gatewayv1.Namespace("apps"),
+							}},
+							To: []gatewayv1beta1.ReferenceGrantTo{{
+								Group: gatewayv1.Group(""),
+								Kind:  gatewayv1.Kind("Secret"),
+								Name:  lo.ToPtr(gatewayv1.ObjectName("tls-cert")),
+							}},
+						},
+					}},
+				}))
+				return nil
+			})
+
+		allowed, err := referenceGrantAllowsSecretRef(
+			t.Context(),
+			mockClient,
+			"ListenerSet",
+			"apps",
+			types.NamespacedName{Namespace: "certs", Name: "tls-cert"},
+		)
+
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("referenceGrantAllowsSecretRef wraps grant list errors", func(t *testing.T) {
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			List(t.Context(), mock.AnythingOfType("*v1beta1.ReferenceGrantList"), mock.Anything).
+			Return(errors.New("secret grant list failed"))
+
+		allowed, err := referenceGrantAllowsSecretRef(
+			t.Context(),
+			mockClient,
+			"ListenerSet",
+			"apps",
+			types.NamespacedName{Namespace: "certs", Name: "tls-cert"},
+		)
+
+		require.ErrorContains(t, err, "failed to list ReferenceGrants")
+		assert.False(t, allowed)
+	})
+
+	t.Run("referenceGrantAllowsSecretRef ignores non matching grants", func(t *testing.T) {
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			List(t.Context(), mock.AnythingOfType("*v1beta1.ReferenceGrantList"), mock.Anything).
+			RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().Set(reflect.ValueOf(gatewayv1beta1.ReferenceGrantList{
+					Items: []gatewayv1beta1.ReferenceGrant{
+						{
+							Spec: gatewayv1beta1.ReferenceGrantSpec{
+								From: []gatewayv1beta1.ReferenceGrantFrom{{
+									Group:     gatewayv1.Group(gatewayAPIGroup),
+									Kind:      gatewayv1.Kind("Gateway"),
+									Namespace: gatewayv1.Namespace("apps"),
+								}},
+								To: []gatewayv1beta1.ReferenceGrantTo{{
+									Group: gatewayv1.Group(""),
+									Kind:  gatewayv1.Kind("Secret"),
+								}},
+							},
+						},
+						{
+							Spec: gatewayv1beta1.ReferenceGrantSpec{
+								From: []gatewayv1beta1.ReferenceGrantFrom{{
+									Group:     gatewayv1.Group(gatewayAPIGroup),
+									Kind:      gatewayv1.Kind("ListenerSet"),
+									Namespace: gatewayv1.Namespace("apps"),
+								}},
+								To: []gatewayv1beta1.ReferenceGrantTo{{
+									Group: gatewayv1.Group(""),
+									Kind:  gatewayv1.Kind("Secret"),
+									Name:  lo.ToPtr(gatewayv1.ObjectName("other-cert")),
+								}},
+							},
+						},
+					},
+				}))
+				return nil
+			})
+
+		allowed, err := referenceGrantAllowsSecretRef(
+			t.Context(),
+			mockClient,
+			"ListenerSet",
+			"apps",
+			types.NamespacedName{Namespace: "certs", Name: "tls-cert"},
+		)
+
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+
+	t.Run("referenceGrantAllowsSecretRef rejects cross namespace secret without grant", func(t *testing.T) {
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			List(t.Context(), mock.AnythingOfType("*v1beta1.ReferenceGrantList"), mock.Anything).
+			RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().Set(reflect.ValueOf(gatewayv1beta1.ReferenceGrantList{}))
+				return nil
+			})
+
+		allowed, err := referenceGrantAllowsSecretRef(
+			t.Context(),
+			mockClient,
+			"ListenerSet",
+			"apps",
+			types.NamespacedName{Namespace: "certs", Name: "tls-cert"},
+		)
+
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
 }

--- a/internal/app/register.go
+++ b/internal/app/register.go
@@ -25,6 +25,7 @@ func Register(container *dig.Container) error {
 		NewGatewayClassController,
 		NewGatewayController,
 		NewNetworkLoadBalancerGatewayController,
+		NewListenerSetController,
 		NewHTTPRouteController,
 		NewGRPCRouteController,
 		NewTCPRouteController,

--- a/internal/app/tcproute_model.go
+++ b/internal/app/tcproute_model.go
@@ -85,14 +85,7 @@ func tcpRouteBackendRefName(backendRef gatewayv1.BackendRef, defaultNamespace st
 }
 
 func tcpParentRefTarget(parentRef gatewayv1.ParentReference, routeNamespace string) apitypes.NamespacedName {
-	namespace := routeNamespace
-	if parentRef.Namespace != nil {
-		namespace = string(*parentRef.Namespace)
-	}
-	return apitypes.NamespacedName{
-		Namespace: namespace,
-		Name:      string(parentRef.Name),
-	}
+	return parentRefTargetName(parentRef, routeNamespace)
 }
 
 func tcpRouteMatchesListener(parentRef gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
@@ -119,14 +112,20 @@ func desiredTCPRouteBackendSetNames(details resolvedTCPRouteDetails) map[string]
 		Name:      details.gatewayDetails.gateway.Name,
 	}
 	for _, parentRef := range details.tcpRoute.Spec.ParentRefs {
-		if !parentRefTargetsGateway(parentRef) ||
+		if !parentRefTargetsGateway(parentRef) && !parentRefTargetsListenerSet(parentRef) {
+			continue
+		}
+		if parentRefTargetsGateway(parentRef) &&
 			tcpParentRefTarget(parentRef, details.tcpRoute.Namespace) != gatewayName {
 			continue
 		}
-		for _, listener := range details.gatewayDetails.gateway.Spec.Listeners {
-			if tcpRouteMatchesListener(parentRef, listener) {
-				desired[networkLoadBalancerBackendSetName(listener)] = struct{}{}
-			}
+		for _, listener := range effectiveListenersForParentRef(
+			details.gatewayDetails,
+			parentRef,
+			details.tcpRoute.Namespace,
+			tcpRouteMatchesListener,
+		) {
+			desired[networkLoadBalancerBackendSetName(listener)] = struct{}{}
 		}
 	}
 	return desired
@@ -186,20 +185,9 @@ func resolveL4RouteRequest[D any](
 
 	var results []D
 	for _, parentRef := range params.parentRefs() {
-		if !parentRefTargetsGateway(parentRef) {
-			continue
-		}
-		parentResults, resolved, err := params.resolveParentRef(parentRef)
+		parentResults, err := resolveL4RouteParentRef(params, parentRef)
 		if err != nil {
 			return nil, err
-		}
-		if !resolved {
-			continue
-		}
-		if len(parentResults) == 0 && params.route.GetDeletionTimestamp() == nil {
-			if err = params.rejectNoMatchingListener(parentRef); err != nil {
-				return nil, err
-			}
 		}
 		results = append(results, parentResults...)
 	}
@@ -210,6 +198,25 @@ func resolveL4RouteRequest[D any](
 		}
 	}
 	return results, nil
+}
+
+func resolveL4RouteParentRef[D any](
+	params resolveL4RouteRequestParams[D],
+	parentRef gatewayv1.ParentReference,
+) ([]D, error) {
+	if !parentRefTargetsGateway(parentRef) && !parentRefTargetsListenerSet(parentRef) {
+		return nil, nil
+	}
+	parentResults, resolved, err := params.resolveParentRef(parentRef)
+	if err != nil || !resolved {
+		return nil, err
+	}
+	if len(parentResults) == 0 && params.route.GetDeletionTimestamp() == nil {
+		if err = params.rejectNoMatchingListener(parentRef); err != nil {
+			return nil, err
+		}
+	}
+	return parentResults, nil
 }
 
 func (m *tcpRouteModelImpl) resolveParentRef(
@@ -223,10 +230,7 @@ func (m *tcpRouteModelImpl) resolveParentRef(
 	}
 
 	results := make([]resolvedTCPRouteDetails, 0)
-	for _, listener := range gatewayDetails.gateway.Spec.Listeners {
-		if !tcpRouteMatchesListener(parentRef, listener) {
-			continue
-		}
+	for _, listener := range effectiveListenersForParentRef(gatewayDetails, parentRef, route.Namespace, tcpRouteMatchesListener) {
 		results = append(results, resolvedTCPRouteDetails{
 			tcpRoute:        route,
 			gatewayDetails:  gatewayDetails,
@@ -242,7 +246,34 @@ func (m *tcpRouteModelImpl) resolveParentGateway(
 	routeNamespace string,
 	parentRef gatewayv1.ParentReference,
 ) (resolvedGatewayDetails, bool, error) {
-	return resolveL4ParentGateway(ctx, m.client, tcpParentRefTarget(parentRef, routeNamespace))
+	return resolveL4ParentGatewayForRouteParentRef(ctx, m.client, routeNamespace, parentRef)
+}
+
+func resolveL4ParentGatewayForRouteParentRef(
+	ctx context.Context,
+	k8sClient k8sClient,
+	routeNamespace string,
+	parentRef gatewayv1.ParentReference,
+) (resolvedGatewayDetails, bool, error) {
+	if parentRefTargetsGateway(parentRef) {
+		return resolveL4ParentGateway(ctx, k8sClient, parentRefTargetName(parentRef, routeNamespace))
+	}
+	if !parentRefTargetsListenerSet(parentRef) {
+		return resolvedGatewayDetails{}, false, nil
+	}
+
+	gatewayName, resolved, err := listenerSetParentGatewayTarget(ctx, k8sClient, routeNamespace, parentRef)
+	if err != nil || !resolved {
+		return resolvedGatewayDetails{}, resolved, err
+	}
+	details, resolved, err := resolveL4ParentGateway(ctx, k8sClient, gatewayName)
+	if err != nil || !resolved {
+		return details, resolved, err
+	}
+	if err = populateAttachedListenerSetsUnindexed(ctx, k8sClient, &details); err != nil {
+		return resolvedGatewayDetails{}, false, err
+	}
+	return details, true, nil
 }
 
 func resolveL4ParentGateway(

--- a/internal/app/tcproute_model.go
+++ b/internal/app/tcproute_model.go
@@ -356,9 +356,6 @@ func (m *tcpRouteModelImpl) handleUnresolvedFinalizedRoute(
 	ctx context.Context,
 	route gatewayv1.TCPRoute,
 ) error {
-	if route.DeletionTimestamp != nil {
-		return m.removeDeletingRouteFinalizer(ctx, route)
-	}
 	return m.deprovisionDetachedRoute(ctx, route)
 }
 
@@ -369,6 +366,7 @@ func (m *tcpRouteModelImpl) removeDeletingRouteFinalizer(
 	routeToUpdate := route.DeepCopy()
 	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerTCPRouteProgrammedFinalizer)
 	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return fmt.Errorf("failed to remove finalizer from deleting TCPRoute %s/%s: %w",
 			routeToUpdate.Namespace,
@@ -1123,6 +1121,7 @@ func deprovisionL4Route[D any](ctx context.Context, params deprovisionL4RoutePar
 
 	controllerutil.RemoveFinalizer(params.routeToUpdate, params.finalizer)
 	setAnnotatedBackendSetNames(params.routeToUpdate, params.backendSetAnnotKey, nil)
+	delete(params.routeToUpdate.GetAnnotations(), L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err = params.k8sClient.Update(ctx, params.routeToUpdate); err != nil {
 		return fmt.Errorf("failed to remove finalizer from %s %s/%s: %w",
 			params.routeKind,
@@ -1156,6 +1155,14 @@ func (m *tcpRouteModelImpl) deprovisionDetachedRoute(
 		}
 	}
 
+	cleaned, err := m.cleanupDetachedRouteByAnnotatedNetworkLoadBalancer(ctx, route, programmedBackendSets)
+	if err != nil || cleaned {
+		return err
+	}
+	if route.DeletionTimestamp != nil {
+		return m.removeDeletingRouteFinalizer(ctx, route)
+	}
+
 	return nil
 }
 
@@ -1179,7 +1186,41 @@ func (m *tcpRouteModelImpl) cleanupDetachedRouteParent(
 	routeToUpdate := route.DeepCopy()
 	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerTCPRouteProgrammedFinalizer)
 	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err = m.client.Update(ctx, routeToUpdate); err != nil {
+		return false, fmt.Errorf("failed to update detached TCPRoute %s/%s after cleanup: %w",
+			routeToUpdate.Namespace,
+			routeToUpdate.Name,
+			err,
+		)
+	}
+	return true, nil
+}
+
+func (m *tcpRouteModelImpl) cleanupDetachedRouteByAnnotatedNetworkLoadBalancer(
+	ctx context.Context,
+	route gatewayv1.TCPRoute,
+	programmedBackendSets map[string]struct{},
+) (bool, error) {
+	nlbID := route.Annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation]
+	if nlbID == "" {
+		return false, nil
+	}
+
+	gatewayDetails := resolvedGatewayDetails{
+		config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: nlbID}},
+	}
+	for backendSetName := range programmedBackendSets {
+		if err := m.clearBackendSetByName(ctx, gatewayDetails, tcpRouteKey(route), backendSetName, nil); err != nil {
+			return false, err
+		}
+	}
+
+	routeToUpdate := route.DeepCopy()
+	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerTCPRouteProgrammedFinalizer)
+	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
+	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return false, fmt.Errorf("failed to update detached TCPRoute %s/%s after cleanup: %w",
 			routeToUpdate.Namespace,
 			routeToUpdate.Name,
@@ -1264,6 +1305,7 @@ func (m *tcpRouteModelImpl) removeDetachedRouteFinalizer(
 ) error {
 	routeToUpdate := route.DeepCopy()
 	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerTCPRouteProgrammedFinalizer)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return fmt.Errorf("failed to remove finalizer from detached TCPRoute %s/%s: %w",
 			routeToUpdate.Namespace,
@@ -1326,6 +1368,7 @@ func (m *tcpRouteModelImpl) setProgrammed(ctx context.Context, details resolvedT
 		routeToUpdate:      routeToUpdate,
 		finalizer:          NetworkLoadBalancerTCPRouteProgrammedFinalizer,
 		backendSetAnnotKey: NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation,
+		loadBalancerID:     details.gatewayDetails.config.Spec.LoadBalancerID,
 		desiredBackendSets: desiredTCPRouteBackendSetNames(details),
 		updateParentStatus: func(conditions []metav1.Condition) error {
 			return m.updateParentStatus(ctx, resolvedTCPRouteDetails{
@@ -1345,6 +1388,7 @@ type setL4RouteProgrammedParams struct {
 	routeToUpdate      client.Object
 	finalizer          string
 	backendSetAnnotKey string
+	loadBalancerID     string
 	desiredBackendSets map[string]struct{}
 	updateParentStatus func([]metav1.Condition) error
 }
@@ -1353,6 +1397,16 @@ func setL4RouteProgrammed(ctx context.Context, params setL4RouteProgrammedParams
 	needsUpdate := controllerutil.AddFinalizer(params.routeToUpdate, params.finalizer)
 	if len(params.desiredBackendSets) > 0 {
 		setAnnotatedBackendSetNames(params.routeToUpdate, params.backendSetAnnotKey, params.desiredBackendSets)
+		needsUpdate = true
+	}
+	if params.loadBalancerID != "" &&
+		params.routeToUpdate.GetAnnotations()[L4RouteProgrammedNetworkLoadBalancerIDAnnotation] != params.loadBalancerID {
+		annotations := params.routeToUpdate.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation] = params.loadBalancerID
+		params.routeToUpdate.SetAnnotations(annotations)
 		needsUpdate = true
 	}
 	if needsUpdate {

--- a/internal/app/tcproute_model.go
+++ b/internal/app/tcproute_model.go
@@ -616,7 +616,7 @@ func (m *tcpRouteModelImpl) matchingRoutesForListener(
 		routeList:       &routeList,
 		listError:       listError,
 		items:           func() []gatewayv1.TCPRoute { return routeList.Items },
-		gatewayName:     client.ObjectKeyFromObject(&details.gatewayDetails.gateway),
+		gatewayDetails:  details.gatewayDetails,
 		listener:        details.matchedListener,
 		excludeRouteKey: excludeRouteKey,
 		routeKey:        tcpRouteKey,
@@ -624,7 +624,6 @@ func (m *tcpRouteModelImpl) matchingRoutesForListener(
 		routeCreatedAt:  func(route gatewayv1.TCPRoute) metav1.Time { return route.CreationTimestamp },
 		parentRefs:      func(route gatewayv1.TCPRoute) []gatewayv1.ParentReference { return route.Spec.ParentRefs },
 		routeDeleted:    func(route gatewayv1.TCPRoute) bool { return route.DeletionTimestamp != nil },
-		parentTarget:    tcpParentRefTarget,
 		matchesListener: tcpRouteMatchesListener,
 	})
 }
@@ -657,7 +656,7 @@ type l4RouteListenerMatch[T any] struct {
 
 func matchingL4RoutesForListener[T any](
 	routes []T,
-	gatewayName apitypes.NamespacedName,
+	gatewayDetails resolvedGatewayDetails,
 	listener gatewayv1.Listener,
 	excludeRouteKey string,
 	routeKey func(T) string,
@@ -665,7 +664,6 @@ func matchingL4RoutesForListener[T any](
 	routeCreatedAt func(T) metav1.Time,
 	parentRefs func(T) []gatewayv1.ParentReference,
 	routeDeleted func(T) bool,
-	parentTarget func(gatewayv1.ParentReference, string) apitypes.NamespacedName,
 	matchesListener func(gatewayv1.ParentReference, gatewayv1.Listener) bool,
 ) []l4RouteListenerMatch[T] {
 	matches := make([]l4RouteListenerMatch[T], 0)
@@ -675,13 +673,13 @@ func matchingL4RoutesForListener[T any](
 			continue
 		}
 		for _, parentRef := range parentRefs(route) {
-			if !parentRefTargetsGateway(parentRef) {
-				continue
-			}
-			if parentTarget(parentRef, routeNamespace(route)) != gatewayName {
-				continue
-			}
-			if matchesListener(parentRef, listener) {
+			if l4ParentRefMatchesListener(
+				gatewayDetails,
+				parentRef,
+				routeNamespace(route),
+				listener,
+				matchesListener,
+			) {
 				matches = append(matches, l4RouteListenerMatch[T]{
 					route:      route,
 					key:        key,
@@ -702,12 +700,39 @@ func matchingL4RoutesForListener[T any](
 	return matches
 }
 
+func l4ParentRefMatchesListener(
+	gatewayDetails resolvedGatewayDetails,
+	parentRef gatewayv1.ParentReference,
+	routeNamespace string,
+	listener gatewayv1.Listener,
+	matchesListener func(gatewayv1.ParentReference, gatewayv1.Listener) bool,
+) bool {
+	if !parentRefTargetsGateway(parentRef) && !parentRefTargetsListenerSet(parentRef) {
+		return false
+	}
+	matchedListeners := effectiveListenersForParentRef(
+		gatewayDetails,
+		parentRef,
+		routeNamespace,
+		matchesListener,
+	)
+	if parentRefTargetsGateway(parentRef) &&
+		len(matchedListeners) == 0 &&
+		parentRefTargetName(parentRef, routeNamespace) == client.ObjectKeyFromObject(&gatewayDetails.gateway) &&
+		matchesListener(parentRef, listener) {
+		matchedListeners = []gatewayv1.Listener{listener}
+	}
+	return lo.ContainsBy(matchedListeners, func(matched gatewayv1.Listener) bool {
+		return matched.Name == listener.Name
+	})
+}
+
 type listMatchingL4RoutesForListenerParams[T any] struct {
 	k8sClient       k8sClient
 	routeList       client.ObjectList
 	listError       string
 	items           func() []T
-	gatewayName     apitypes.NamespacedName
+	gatewayDetails  resolvedGatewayDetails
 	listener        gatewayv1.Listener
 	excludeRouteKey string
 	routeKey        func(T) string
@@ -715,7 +740,6 @@ type listMatchingL4RoutesForListenerParams[T any] struct {
 	routeCreatedAt  func(T) metav1.Time
 	parentRefs      func(T) []gatewayv1.ParentReference
 	routeDeleted    func(T) bool
-	parentTarget    func(gatewayv1.ParentReference, string) apitypes.NamespacedName
 	matchesListener func(gatewayv1.ParentReference, gatewayv1.Listener) bool
 }
 
@@ -728,7 +752,7 @@ func listMatchingL4RoutesForListener[T any](
 	}
 	return matchingL4RoutesForListener(
 		params.items(),
-		params.gatewayName,
+		params.gatewayDetails,
 		params.listener,
 		params.excludeRouteKey,
 		params.routeKey,
@@ -736,7 +760,6 @@ func listMatchingL4RoutesForListener[T any](
 		params.routeCreatedAt,
 		params.parentRefs,
 		params.routeDeleted,
-		params.parentTarget,
 		params.matchesListener,
 	), nil
 }
@@ -872,15 +895,18 @@ func (m *tcpRouteModelImpl) programRouteParams(
 	details resolvedTCPRouteDetails,
 ) programL4RouteParams {
 	return newProgramL4RouteParams(newProgramL4RouteParamsInput{
-		k8sClient:        m.client,
-		routeKind:        "TCPRoute",
-		route:            &details.tcpRoute,
-		gatewayNamespace: details.gatewayDetails.gateway.Namespace,
-		listener:         details.matchedListener,
-		finalizer:        NetworkLoadBalancerTCPRouteProgrammedFinalizer,
-		clearBackendSet:  func() error { return m.clearBackendSet(ctx, details) },
-		ensureOwner:      func() error { return m.ensureExclusiveListenerOwner(ctx, details) },
-		clearStale:       func() error { return m.clearStaleBackendSets(ctx, details) },
+		k8sClient: m.client,
+		routeKind: "TCPRoute",
+		route:     &details.tcpRoute,
+		listenerNamespace: effectiveListenerSourceNamespaceForOCIListener(
+			details.gatewayDetails,
+			details.matchedListener,
+		),
+		listener:        details.matchedListener,
+		finalizer:       NetworkLoadBalancerTCPRouteProgrammedFinalizer,
+		clearBackendSet: func() error { return m.clearBackendSet(ctx, details) },
+		ensureOwner:     func() error { return m.ensureExclusiveListenerOwner(ctx, details) },
+		clearStale:      func() error { return m.clearStaleBackendSets(ctx, details) },
 		resolveBackends: func() ([]networkloadbalancer.BackendDetails, error) {
 			return m.endpointBackendsForRoute(ctx, details.tcpRoute)
 		},
@@ -901,7 +927,7 @@ type newProgramL4RouteParamsInput struct {
 	k8sClient           k8sClient
 	routeKind           gatewayv1.Kind
 	route               client.Object
-	gatewayNamespace    string
+	listenerNamespace   string
 	listener            gatewayv1.Listener
 	finalizer           string
 	clearBackendSet     func() error
@@ -918,7 +944,7 @@ func newProgramL4RouteParams(input newProgramL4RouteParamsInput) programL4RouteP
 		k8sClient:                    input.k8sClient,
 		routeKind:                    input.routeKind,
 		route:                        input.route,
-		gatewayNamespace:             input.gatewayNamespace,
+		listenerNamespace:            input.listenerNamespace,
 		listener:                     input.listener,
 		finalizer:                    input.finalizer,
 		clearBackendSet:              input.clearBackendSet,
@@ -935,7 +961,7 @@ type programL4RouteParams struct {
 	k8sClient                    k8sClient
 	routeKind                    gatewayv1.Kind
 	route                        client.Object
-	gatewayNamespace             string
+	listenerNamespace            string
 	listener                     gatewayv1.Listener
 	finalizer                    string
 	clearBackendSet              func() error
@@ -951,7 +977,7 @@ func programL4Route(ctx context.Context, params programL4RouteParams) error {
 	allowed, err := l4ListenerAllowsRoute(
 		ctx,
 		params.k8sClient,
-		params.gatewayNamespace,
+		params.listenerNamespace,
 		params.route.GetNamespace(),
 		params.listener,
 		params.routeKind,

--- a/internal/app/tcproute_model_test.go
+++ b/internal/app/tcproute_model_test.go
@@ -135,6 +135,178 @@ func TestTCPRouteModel(t *testing.T) {
 		assert.Empty(t, desiredTCPRouteBackendSetNames(details))
 	})
 
+	t.Run("resolveL4ParentGatewayForRouteParentRef", func(t *testing.T) {
+		t.Run("resolves ListenerSet parent refs through their parent Gateway", func(t *testing.T) {
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			parentNamespace := gatewayv1.Namespace("infra")
+			fromAll := gatewayv1.NamespacesFromAll
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(
+					&gatewayv1.GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{Name: "oke-nlb"},
+						Spec: gatewayv1.GatewayClassSpec{
+							ControllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+						},
+					},
+					&gatewayv1.Gateway{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"},
+						Spec: gatewayv1.GatewaySpec{
+							GatewayClassName: "oke-nlb",
+							Infrastructure: &gatewayv1.GatewayInfrastructure{
+								ParametersRef: &gatewayv1.LocalParametersReference{Name: "nlb-config"},
+							},
+							AllowedListeners: &gatewayv1.AllowedListeners{
+								Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+							},
+						},
+					},
+					&types.GatewayConfig{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "nlb-config"},
+						Spec:       types.GatewayConfigSpec{LoadBalancerID: "ocid1.networkloadbalancer.oc1..existing"},
+					},
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+					&gatewayv1.ListenerSet{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+						Spec: gatewayv1.ListenerSetSpec{
+							ParentRef: gatewayv1.ParentGatewayReference{
+								Namespace: &parentNamespace,
+								Name:      "edge",
+							},
+							Listeners: []gatewayv1.ListenerEntry{
+								{Name: "rtmp", Port: 1935, Protocol: gatewayv1.TCPProtocolType},
+							},
+						},
+					},
+				).
+				Build()
+
+			details, resolved, err := resolveL4ParentGatewayForRouteParentRef(
+				t.Context(),
+				k8sClient,
+				"apps",
+				gatewayv1.ParentReference{Kind: &listenerSetKind, Name: "extra"},
+			)
+
+			require.NoError(t, err)
+			assert.True(t, resolved)
+			assert.Equal(t, "edge", details.gateway.Name)
+			require.Len(t, details.listenerSets, 1)
+			require.Len(t, details.effectiveListeners, 1)
+		})
+
+		t.Run("ignores missing and invalid ListenerSet parent refs", func(t *testing.T) {
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			otherKind := gatewayv1.Kind("Service")
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(&gatewayv1.ListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "invalid"},
+					Spec: gatewayv1.ListenerSetSpec{
+						ParentRef: gatewayv1.ParentGatewayReference{Kind: &otherKind, Name: "edge"},
+					},
+				}).
+				Build()
+
+			_, resolved, err := resolveL4ParentGatewayForRouteParentRef(
+				t.Context(),
+				k8sClient,
+				"apps",
+				gatewayv1.ParentReference{Kind: &listenerSetKind, Name: "missing"},
+			)
+			require.NoError(t, err)
+			assert.False(t, resolved)
+
+			_, resolved, err = resolveL4ParentGatewayForRouteParentRef(
+				t.Context(),
+				k8sClient,
+				"apps",
+				gatewayv1.ParentReference{Kind: &listenerSetKind, Name: "invalid"},
+			)
+			require.NoError(t, err)
+			assert.False(t, resolved)
+		})
+
+		t.Run("ignores unsupported parent refs", func(t *testing.T) {
+			serviceKind := gatewayv1.Kind("Service")
+			k8sClient := NewMockk8sClient(t)
+
+			_, resolved, err := resolveL4ParentGatewayForRouteParentRef(
+				t.Context(),
+				k8sClient,
+				"apps",
+				gatewayv1.ParentReference{Kind: &serviceKind, Name: "backend"},
+			)
+
+			require.NoError(t, err)
+			assert.False(t, resolved)
+		})
+
+		t.Run("wraps ListenerSet lookup errors", func(t *testing.T) {
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			k8sClient := NewMockk8sClient(t)
+			wantErr := errors.New("listenerset get failed")
+			k8sClient.EXPECT().
+				Get(t.Context(), apitypes.NamespacedName{Namespace: "apps", Name: "extra"}, mock.AnythingOfType("*v1.ListenerSet")).
+				Return(wantErr)
+
+			_, _, err := resolveL4ParentGatewayForRouteParentRef(
+				t.Context(),
+				k8sClient,
+				"apps",
+				gatewayv1.ParentReference{Kind: &listenerSetKind, Name: "extra"},
+			)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to get ListenerSet apps/extra")
+		})
+
+		t.Run("wraps attached ListenerSet list errors", func(t *testing.T) {
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			parentNamespace := gatewayv1.Namespace("infra")
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+					Namespace: &parentNamespace,
+					Name:      "edge",
+				}},
+			}
+			gateway := gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "oke-nlb",
+					Infrastructure: &gatewayv1.GatewayInfrastructure{
+						ParametersRef: &gatewayv1.LocalParametersReference{Name: "nlb-config"},
+					},
+				},
+			}
+			gatewayClass := gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "oke-nlb"},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+				},
+			}
+			config := types.GatewayConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "nlb-config"}}
+			wantErr := errors.New("list failed")
+			k8sClient := NewMockk8sClient(t)
+			setupClientGet(t, k8sClient, apitypes.NamespacedName{Namespace: "apps", Name: "extra"}, listenerSet)
+			setupClientGet(t, k8sClient, apitypes.NamespacedName{Namespace: "infra", Name: "edge"}, gateway)
+			setupClientGet(t, k8sClient, apitypes.NamespacedName{Name: "oke-nlb"}, gatewayClass)
+			setupClientGet(t, k8sClient, apitypes.NamespacedName{Namespace: "infra", Name: "nlb-config"}, config)
+			k8sClient.EXPECT().List(t.Context(), &gatewayv1.ListenerSetList{}).Return(wantErr)
+
+			_, _, err := resolveL4ParentGatewayForRouteParentRef(
+				t.Context(),
+				k8sClient,
+				"apps",
+				gatewayv1.ParentReference{Kind: &listenerSetKind, Name: "extra"},
+			)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to list ListenerSets")
+		})
+	})
+
 	t.Run("resolveRequest wraps Kubernetes read errors", func(t *testing.T) {
 		route := gatewayv1.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "rtmp"},

--- a/internal/app/tcproute_model_test.go
+++ b/internal/app/tcproute_model_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -831,6 +833,11 @@ func TestTCPRouteModel(t *testing.T) {
 					"bs_rtmp",
 					obj.GetAnnotations()[NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation],
 				)
+				assert.Equal(
+					t,
+					"nlb-id",
+					obj.GetAnnotations()[L4RouteProgrammedNetworkLoadBalancerIDAnnotation],
+				)
 				return nil
 			})
 
@@ -850,6 +857,7 @@ func TestTCPRouteModel(t *testing.T) {
 						},
 					},
 				},
+				config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: "nlb-id"}},
 			},
 			matchedRef: gatewayv1.ParentReference{
 				Name: "edge",
@@ -934,6 +942,36 @@ func TestTCPRouteModel(t *testing.T) {
 		require.ErrorContains(t, err, "failed to update TCPRoute rtmp status")
 	})
 
+	t.Run("setL4RouteProgrammed records load balancer id when annotations are nil", func(t *testing.T) {
+		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "iot",
+			Name:       "rtmp",
+			Generation: 1,
+		}}
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				assert.Equal(t, "nlb-id", obj.GetAnnotations()[L4RouteProgrammedNetworkLoadBalancerIDAnnotation])
+				return nil
+			})
+
+		err := setL4RouteProgrammed(t.Context(), setL4RouteProgrammedParams{
+			k8sClient:      mockClient,
+			routeKind:      "TCPRoute",
+			controllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+			routeToUpdate:  route,
+			finalizer:      NetworkLoadBalancerTCPRouteProgrammedFinalizer,
+			loadBalancerID: "nlb-id",
+			updateParentStatus: func(conditions []metav1.Condition) error {
+				require.Len(t, conditions, 2)
+				return nil
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
 	t.Run("deprovisionDetachedRoute clears annotated backend set and removes finalizer", func(t *testing.T) {
 		route := gatewayv1.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -942,6 +980,7 @@ func TestTCPRouteModel(t *testing.T) {
 				Finalizers: []string{NetworkLoadBalancerTCPRouteProgrammedFinalizer},
 				Annotations: map[string]string{
 					NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation: "bs_old",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
 				},
 			},
 			Status: gatewayv1.TCPRouteStatus{
@@ -991,6 +1030,7 @@ func TestTCPRouteModel(t *testing.T) {
 			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 				assert.NotContains(t, obj.GetFinalizers(), NetworkLoadBalancerTCPRouteProgrammedFinalizer)
 				assert.NotContains(t, obj.GetAnnotations(), NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation)
+				assert.NotContains(t, obj.GetAnnotations(), L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 				return nil
 			})
 
@@ -1031,6 +1071,139 @@ func TestTCPRouteModel(t *testing.T) {
 			request.UpdateBackendSetDetails.HealthChecker.Protocol,
 		)
 		assert.Equal(t, 1935, lo.FromPtr(request.UpdateBackendSetDetails.HealthChecker.Port))
+	})
+
+	t.Run("deprovisionDetachedRoute clears annotated backend set by load balancer id", func(t *testing.T) {
+		listenerSetKind := gatewayv1.Kind("ListenerSet")
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "rtmp",
+				Finalizers: []string{NetworkLoadBalancerTCPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation: "bs_listener_set",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+			Status: gatewayv1.TCPRouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
+					Parents: []gatewayv1.RouteParentStatus{{
+						ParentRef: gatewayv1.ParentReference{
+							Kind: &listenerSetKind,
+							Name: "extra",
+						},
+						ControllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+					}},
+				},
+			},
+		}
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Get(
+				t.Context(),
+				apitypes.NamespacedName{Namespace: "iot", Name: "extra"},
+				mock.AnythingOfType("*v1.Gateway"),
+			).
+			Return(apierrors.NewNotFound(schema.GroupResource{
+				Group:    gatewayv1.GroupName,
+				Resource: "gateways",
+			}, "extra"))
+		mockClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				assert.NotContains(t, obj.GetFinalizers(), NetworkLoadBalancerTCPRouteProgrammedFinalizer)
+				assert.NotContains(t, obj.GetAnnotations(), NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation)
+				assert.NotContains(t, obj.GetAnnotations(), L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
+				return nil
+			})
+		nlbClient := &stubNetworkLoadBalancerClient{}
+		model := newTCPRouteModel(tcpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_listener_set": {
+							Name: new("bs_listener_set"),
+							HealthChecker: &networkloadbalancer.HealthChecker{
+								Protocol: networkloadbalancer.HealthCheckProtocolsTcp,
+							},
+						},
+					},
+				},
+			},
+			OciNetworkLoadBalancerAPI: nlbClient,
+		})
+		modelImpl := mustTCPRouteModelImpl(t, model)
+
+		err := modelImpl.deprovisionDetachedRoute(t.Context(), route)
+
+		require.NoError(t, err)
+		require.Len(t, nlbClient.updateBackendSetRequests, 1)
+		request := nlbClient.updateBackendSetRequests[0]
+		assert.Equal(t, "nlb-id", lo.FromPtr(request.NetworkLoadBalancerId))
+		assert.Equal(t, "bs_listener_set", lo.FromPtr(request.BackendSetName))
+		assert.Empty(t, request.UpdateBackendSetDetails.Backends)
+	})
+
+	t.Run("deprovisionDetachedRoute returns annotated load balancer cleanup update errors", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "rtmp",
+				Finalizers: []string{NetworkLoadBalancerTCPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation: "bs_listener_set",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+		}
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			Return(errors.New("update failed"))
+		model := newTCPRouteModel(tcpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_listener_set": {Name: new("bs_listener_set")},
+					},
+				},
+			},
+			OciNetworkLoadBalancerAPI: &stubNetworkLoadBalancerClient{},
+		})
+		modelImpl := mustTCPRouteModelImpl(t, model)
+
+		err := modelImpl.deprovisionDetachedRoute(t.Context(), route)
+
+		require.ErrorContains(t, err, "failed to update detached TCPRoute")
+	})
+
+	t.Run("deprovisionDetachedRoute returns annotated load balancer cleanup errors", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "rtmp",
+				Finalizers: []string{NetworkLoadBalancerTCPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation: "bs_listener_set",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+		}
+		model := newTCPRouteModel(tcpRouteModelDeps{
+			RootLogger:               diag.RootTestLogger(),
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{err: errors.New("nlb failed")},
+		})
+		modelImpl := mustTCPRouteModelImpl(t, model)
+
+		err := modelImpl.deprovisionDetachedRoute(t.Context(), route)
+
+		require.ErrorContains(t, err, "nlb failed")
 	})
 
 	t.Run("deprovisionDetachedRoute removes finalizer when no backend sets are annotated", func(t *testing.T) {

--- a/internal/app/tcproute_model_test.go
+++ b/internal/app/tcproute_model_test.go
@@ -646,6 +646,67 @@ func TestTCPRouteModel(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("listener ownership includes ListenerSet parent refs", func(t *testing.T) {
+		listenerSetKind := gatewayv1.Kind("ListenerSet")
+		listenerSetNamespace := gatewayv1.Namespace("apps")
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: string(listenerSetNamespace), Name: "extra"},
+			Spec: gatewayv1.ListenerSetSpec{Listeners: []gatewayv1.ListenerEntry{{
+				Name:     "rtmp",
+				Protocol: gatewayv1.TCPProtocolType,
+				Port:     1935,
+			}}},
+		}
+		gateway := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}}
+		effectiveListeners := effectiveListenersForGateway(gateway, []gatewayv1.ListenerSet{listenerSet})
+		matchedListener := effectiveListenerOCIListener(effectiveListeners[0])
+		currentRoute := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "apps",
+				Name:              "current",
+				CreationTimestamp: metav1.Unix(2, 0),
+			},
+			Spec: gatewayv1.TCPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Kind:        &listenerSetKind,
+					Namespace:   &listenerSetNamespace,
+					Name:        gatewayv1.ObjectName(listenerSet.Name),
+					SectionName: lo.ToPtr(gatewayv1.SectionName("rtmp")),
+				}},
+			}},
+		}
+		olderRoute := currentRoute.DeepCopy()
+		olderRoute.Name = "older"
+		olderRoute.CreationTimestamp = metav1.Unix(1, 0)
+
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			List(t.Context(), mock.AnythingOfType("*v1.TCPRouteList")).
+			RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().Set(reflect.ValueOf(gatewayv1.TCPRouteList{
+					Items: []gatewayv1.TCPRoute{currentRoute, *olderRoute},
+				}))
+				return nil
+			})
+		model := newTCPRouteModel(tcpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		modelImpl := mustTCPRouteModelImpl(t, model)
+
+		err := modelImpl.ensureExclusiveListenerOwner(t.Context(), resolvedTCPRouteDetails{
+			gatewayDetails:  resolvedGatewayDetails{gateway: gateway, effectiveListeners: effectiveListeners},
+			tcpRoute:        currentRoute,
+			matchedListener: matchedListener,
+		})
+
+		var statusErr tcpRouteStatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, gatewayv1.RouteReasonNotAllowedByListeners, statusErr.reason)
+		assert.Equal(
+			t,
+			"listener "+string(matchedListener.Name)+" already has an attached TCPRoute apps/older",
+			statusErr.message,
+		)
+	})
+
 	t.Run("deprovisionRoute clears backend set and removes finalizer when no successor exists", func(t *testing.T) {
 		currentRoute := gatewayv1.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -209,10 +209,7 @@ func (m *tlsRouteModelImpl) resolveParentRef(
 	}
 
 	results := make([]resolvedTLSRouteDetails, 0)
-	for _, listener := range gatewayDetails.gateway.Spec.Listeners {
-		if !tlsRouteMatchesListener(parentRef, listener) {
-			continue
-		}
+	for _, listener := range effectiveListenersForParentRef(gatewayDetails, parentRef, route.Namespace, tlsRouteMatchesListener) {
 		results = append(results, resolvedTLSRouteDetails{
 			tlsRoute:        route,
 			gatewayDetails:  gatewayDetails,
@@ -229,6 +226,16 @@ func (m *tlsRouteModelImpl) resolveParentGateway(
 	parentRef gatewayv1.ParentReference,
 ) (resolvedGatewayDetails, bool, error) {
 	gatewayName := tlsRouteParentRefTarget(parentRef, routeNamespace)
+	if parentRefTargetsListenerSet(parentRef) {
+		resolvedName, resolved, err := listenerSetParentGatewayTarget(ctx, m.client, routeNamespace, parentRef)
+		if err != nil || !resolved {
+			return resolvedGatewayDetails{}, resolved, err
+		}
+		gatewayName = resolvedName
+	} else if !parentRefTargetsGateway(parentRef) {
+		return resolvedGatewayDetails{}, false, nil
+	}
+
 	var gateway gatewayv1.Gateway
 	if err := m.client.Get(ctx, gatewayName, &gateway); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -274,7 +281,14 @@ func (m *tlsRouteModelImpl) resolveParentGateway(
 		)
 	}
 
-	return resolvedGatewayDetails{gateway: gateway, gatewayClass: gatewayClass, config: config}, true, nil
+	details := resolvedGatewayDetails{gateway: gateway, gatewayClass: gatewayClass, config: config}
+	if parentRefTargetsListenerSet(parentRef) {
+		if err := populateAttachedListenerSetsUnindexed(ctx, m.client, &details); err != nil {
+			return resolvedGatewayDetails{}, false, err
+		}
+	}
+
+	return details, true, nil
 }
 
 func (m *tlsRouteModelImpl) rejectNoMatchingListener(

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -314,9 +314,6 @@ func (m *tlsRouteModelImpl) rejectNoMatchingListener(
 }
 
 func (m *tlsRouteModelImpl) handleUnresolvedFinalizedRoute(ctx context.Context, route gatewayv1.TLSRoute) error {
-	if route.DeletionTimestamp != nil {
-		return m.removeDeletingRouteFinalizers(ctx, route)
-	}
 	return m.deprovisionDetachedRoute(ctx, route)
 }
 
@@ -326,6 +323,7 @@ func (m *tlsRouteModelImpl) removeDeletingRouteFinalizers(ctx context.Context, r
 	controllerutil.RemoveFinalizer(routeToUpdate, LoadBalancerTLSRouteProgrammedFinalizer)
 	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation, nil)
 	setAnnotatedBackendSetNames(routeToUpdate, LoadBalancerTLSRouteProgrammedBackendSetAnnotation, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return fmt.Errorf("failed to remove finalizers from deleting TLSRoute %s/%s: %w",
 			routeToUpdate.Namespace,
@@ -1234,8 +1232,11 @@ func (m *tlsRouteModelImpl) deprovisionDetachedNetworkLoadBalancerRoute(
 			tlsRouteParentRefTarget(parentStatus.ParentRef, route.Namespace),
 			"TLSRoute",
 		)
-		if err != nil || !resolved {
+		if err != nil {
 			return err
+		}
+		if !resolved {
+			continue
 		}
 
 		tcpModel := &tcpRouteModelImpl{
@@ -1260,7 +1261,53 @@ func (m *tlsRouteModelImpl) deprovisionDetachedNetworkLoadBalancerRoute(
 		return m.removeDetachedRouteFinalizers(ctx, route)
 	}
 
+	if err := m.deprovisionDetachedNetworkLoadBalancerRouteByAnnotation(
+		ctx,
+		route,
+		programmedBackendSets,
+	); err != nil {
+		return err
+	}
+	if route.DeletionTimestamp != nil {
+		return m.removeDeletingRouteFinalizers(ctx, route)
+	}
+
 	return nil
+}
+
+func (m *tlsRouteModelImpl) deprovisionDetachedNetworkLoadBalancerRouteByAnnotation(
+	ctx context.Context,
+	route gatewayv1.TLSRoute,
+	programmedBackendSets map[string]struct{},
+) error {
+	nlbID := route.Annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation]
+	if nlbID == "" {
+		return nil
+	}
+
+	tcpModel := &tcpRouteModelImpl{
+		client:                    m.client,
+		logger:                    m.logger,
+		networkLoadBalancerModel:  m.networkLoadBalancerModel,
+		ociNetworkLoadBalancerAPI: m.ociNetworkLoadBalancerAPI,
+		workRequestsWatcher:       m.nlbWorkRequestsWatcher,
+		operationLocks:            m.operationLocks,
+	}
+	gatewayDetails := resolvedGatewayDetails{
+		config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: nlbID}},
+	}
+	for backendSetName := range programmedBackendSets {
+		if err := tcpModel.clearBackendSetByName(
+			ctx,
+			gatewayDetails,
+			tlsRouteKey(route),
+			backendSetName,
+			nil,
+		); err != nil {
+			return err
+		}
+	}
+	return m.removeDetachedRouteFinalizers(ctx, route)
 }
 
 func (m *tlsRouteModelImpl) deprovisionDetachedLoadBalancerRoute(
@@ -1368,6 +1415,7 @@ func (m *tlsRouteModelImpl) removeDetachedRouteFinalizers(ctx context.Context, r
 	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation, nil)
 	setAnnotatedBackendSetNames(routeToUpdate, LoadBalancerTLSRouteProgrammedBackendSetAnnotation, nil)
 	setAnnotatedLoadBalancerTLSRouteResources(routeToUpdate, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return fmt.Errorf("failed to update detached TLSRoute %s/%s after cleanup: %w",
 			routeToUpdate.Namespace,
@@ -1391,6 +1439,7 @@ func (m *tlsRouteModelImpl) cleanupStaleNetworkLoadBalancerProgrammedState(
 		return m.removeProgrammedState(ctx, route,
 			NetworkLoadBalancerTLSRouteProgrammedFinalizer,
 			NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation,
+			L4RouteProgrammedNetworkLoadBalancerIDAnnotation,
 		)
 	}
 
@@ -1404,8 +1453,11 @@ func (m *tlsRouteModelImpl) cleanupStaleNetworkLoadBalancerProgrammedState(
 			tlsRouteParentRefTarget(parentStatus.ParentRef, route.Namespace),
 			"TLSRoute",
 		)
-		if err != nil || !resolved {
+		if err != nil {
 			return err
+		}
+		if !resolved {
+			continue
 		}
 
 		tcpModel := &tcpRouteModelImpl{
@@ -1430,7 +1482,11 @@ func (m *tlsRouteModelImpl) cleanupStaleNetworkLoadBalancerProgrammedState(
 		return m.removeProgrammedState(ctx, route,
 			NetworkLoadBalancerTLSRouteProgrammedFinalizer,
 			NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation,
+			L4RouteProgrammedNetworkLoadBalancerIDAnnotation,
 		)
+	}
+	if err := m.deprovisionDetachedNetworkLoadBalancerRouteByAnnotation(ctx, route, backendSets); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1499,6 +1555,8 @@ func (m *tlsRouteModelImpl) removeProgrammedState(
 		switch annotationKey {
 		case LoadBalancerTLSRouteProgrammedResourcesAnnotation:
 			setAnnotatedLoadBalancerTLSRouteResources(routeToUpdate, nil)
+		case L4RouteProgrammedNetworkLoadBalancerIDAnnotation:
+			delete(routeToUpdate.Annotations, annotationKey)
 		default:
 			setAnnotatedBackendSetNames(routeToUpdate, annotationKey, nil)
 		}
@@ -1581,6 +1639,7 @@ func (m *tlsRouteModelImpl) setProgrammed(ctx context.Context, details resolvedT
 		)
 		controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerTLSRouteProgrammedFinalizer)
 		setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation, nil)
+		delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	} else {
 		desiredBackendSets[networkLoadBalancerBackendSetName(details.matchedListener)] = struct{}{}
 		controllerutil.RemoveFinalizer(routeToUpdate, LoadBalancerTLSRouteProgrammedFinalizer)
@@ -1594,6 +1653,11 @@ func (m *tlsRouteModelImpl) setProgrammed(ctx context.Context, details resolvedT
 		routeToUpdate:      routeToUpdate,
 		finalizer:          finalizer,
 		backendSetAnnotKey: annotationKey,
+		loadBalancerID: lo.Ternary(
+			details.gatewayDetails.gatewayClass.Spec.ControllerName == NetworkLoadBalancerControllerClassName,
+			details.gatewayDetails.config.Spec.LoadBalancerID,
+			"",
+		),
 		desiredBackendSets: desiredBackendSets,
 		updateParentStatus: func(conditions []metav1.Condition) error {
 			return m.updateParentStatus(ctx, resolvedTLSRouteDetails{

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -457,7 +457,7 @@ func (m *tlsRouteModelImpl) matchingRoutesForListener(
 		routeList:       &routeList,
 		listError:       "failed to list TLSRoutes for listener ownership check",
 		items:           func() []gatewayv1.TLSRoute { return routeList.Items },
-		gatewayName:     client.ObjectKeyFromObject(&details.gatewayDetails.gateway),
+		gatewayDetails:  details.gatewayDetails,
 		listener:        details.matchedListener,
 		excludeRouteKey: excludeRouteKey,
 		routeKey:        tlsRouteKey,
@@ -465,7 +465,6 @@ func (m *tlsRouteModelImpl) matchingRoutesForListener(
 		routeCreatedAt:  func(route gatewayv1.TLSRoute) metav1.Time { return route.CreationTimestamp },
 		parentRefs:      func(route gatewayv1.TLSRoute) []gatewayv1.ParentReference { return route.Spec.ParentRefs },
 		routeDeleted:    func(route gatewayv1.TLSRoute) bool { return route.DeletionTimestamp != nil },
-		parentTarget:    tlsRouteParentRefTarget,
 		matchesListener: tlsRouteMatchesListener,
 	})
 }
@@ -516,15 +515,18 @@ func (m *tlsRouteModelImpl) programNetworkLoadBalancerPassthroughRoute(
 	details resolvedTLSRouteDetails,
 ) error {
 	return programL4Route(ctx, newProgramL4RouteParams(newProgramL4RouteParamsInput{
-		k8sClient:        m.client,
-		routeKind:        "TLSRoute",
-		route:            &details.tlsRoute,
-		gatewayNamespace: details.gatewayDetails.gateway.Namespace,
-		listener:         details.matchedListener,
-		finalizer:        NetworkLoadBalancerTLSRouteProgrammedFinalizer,
-		clearBackendSet:  func() error { return m.clearNLBBackendSet(ctx, details) },
-		ensureOwner:      func() error { return nil },
-		clearStale:       func() error { return nil },
+		k8sClient: m.client,
+		routeKind: "TLSRoute",
+		route:     &details.tlsRoute,
+		listenerNamespace: effectiveListenerSourceNamespaceForOCIListener(
+			details.gatewayDetails,
+			details.matchedListener,
+		),
+		listener:        details.matchedListener,
+		finalizer:       NetworkLoadBalancerTLSRouteProgrammedFinalizer,
+		clearBackendSet: func() error { return m.clearNLBBackendSet(ctx, details) },
+		ensureOwner:     func() error { return nil },
+		clearStale:      func() error { return nil },
 		resolveBackends: func() ([]networkloadbalancer.BackendDetails, error) {
 			return m.endpointBackendsForRoute(ctx, details.tlsRoute)
 		},

--- a/internal/app/tlsroute_model_test.go
+++ b/internal/app/tlsroute_model_test.go
@@ -3928,6 +3928,66 @@ func TestTLSRouteModelResolveParentRefMatchesTLSListeners(t *testing.T) {
 	assert.True(t, matchedParent)
 	require.Len(t, resolved, 1)
 	assert.Equal(t, gatewayv1.SectionName("mqtts"), resolved[0].matchedListener.Name)
+
+	t.Run("matches ListenerSet TLS listeners", func(t *testing.T) {
+		listenerSetKind := gatewayv1.Kind("ListenerSet")
+		parentNamespace := gatewayv1.Namespace("media")
+		fromAll := gatewayv1.NamespacesFromAll
+		listenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "streaming", Name: "extra"},
+			Spec: gatewayv1.ListenerSetSpec{
+				ParentRef: gatewayv1.ParentGatewayReference{
+					Namespace: &parentNamespace,
+					Name:      "edge",
+				},
+				Listeners: []gatewayv1.ListenerEntry{{
+					Name:     "rtmps",
+					Port:     8443,
+					Protocol: gatewayv1.TLSProtocolType,
+					TLS:      &gatewayv1.ListenerTLSConfig{Mode: &mode},
+				}},
+			},
+		}
+		gatewayWithAllowedListeners := gateway.DeepCopy()
+		gatewayWithAllowedListeners.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+			Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+		}
+		gatewayWithAllowedListeners.Spec.Listeners = nil
+		listenerSetModel := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient: fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithRuntimeObjects(
+					gatewayWithAllowedListeners,
+					gatewayClass,
+					gatewayConfig,
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: listenerSet.Namespace}},
+					listenerSet,
+				).
+				Build(),
+		})
+		listenerSetRoute := gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: listenerSet.Namespace, Name: "rtmps"},
+		}
+		listenerSetSectionName := gatewayv1.SectionName("rtmps")
+
+		listenerSetResolved, listenerSetMatchedParent, listenerSetErr := listenerSetModel.resolveParentRef(
+			t.Context(),
+			listenerSetRoute,
+			gatewayv1.ParentReference{
+				Kind:        &listenerSetKind,
+				Name:        gatewayv1.ObjectName(listenerSet.Name),
+				SectionName: &listenerSetSectionName,
+			},
+		)
+
+		require.NoError(t, listenerSetErr)
+		assert.True(t, listenerSetMatchedParent)
+		require.Len(t, listenerSetResolved, 1)
+		assert.Equal(t, gatewayv1.ObjectName(listenerSet.Name), listenerSetResolved[0].matchedRef.Name)
+		assert.NotEqual(t, listenerSetSectionName, listenerSetResolved[0].matchedListener.Name)
+		assert.Equal(t, gatewayv1.TLSProtocolType, listenerSetResolved[0].matchedListener.Protocol)
+	})
 }
 
 func TestTLSRouteModelProgramRouteOwnershipConflict(t *testing.T) {

--- a/internal/app/tlsroute_model_test.go
+++ b/internal/app/tlsroute_model_test.go
@@ -1396,6 +1396,64 @@ func TestTLSRouteModelCertificateAndStatus(t *testing.T) {
 		require.ErrorIs(t, err, wantErr)
 		require.ErrorContains(t, err, "failed to update TLSRoute media/rtmps finalizer and annotations")
 	})
+
+	t.Run("setProgrammed records NLB id for NLB TLSRoute", func(t *testing.T) {
+		sectionName := gatewayv1.SectionName("tls")
+		route := &gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "media",
+				Name:       "rtmps",
+				Generation: 1,
+			},
+			Spec: gatewayv1.TLSRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name:        "edge",
+					SectionName: &sectionName,
+				}},
+			}},
+		}
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		k8sClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TLSRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				updated, ok := obj.(*gatewayv1.TLSRoute)
+				require.True(t, ok)
+				assert.Equal(t, "nlb-id", updated.Annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation])
+				assert.Equal(
+					t,
+					"bs_tls",
+					updated.Annotations[NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation],
+				)
+				return nil
+			})
+		k8sClient.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TLSRoute")).
+			Return(nil)
+		statusModel := newTLSRouteModel(tlsRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+
+		err := statusModel.setProgrammed(t.Context(), resolvedTLSRouteDetails{
+			tlsRoute: *route,
+			matchedListener: gatewayv1.Listener{
+				Name:     "tls",
+				Protocol: gatewayv1.TLSProtocolType,
+				Port:     443,
+			},
+			matchedRef: gatewayv1.ParentReference{
+				Name:        "edge",
+				SectionName: &sectionName,
+			},
+			gatewayDetails: resolvedGatewayDetails{
+				gatewayClass: gatewayv1.GatewayClass{Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: NetworkLoadBalancerControllerClassName,
+				}},
+				config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: "nlb-id"}},
+			},
+		})
+
+		require.NoError(t, err)
+	})
 }
 
 func TestTLSRouteProgrammedResourceAnnotations(t *testing.T) {
@@ -1581,6 +1639,89 @@ func TestTLSRouteProgrammedResourceAnnotations(t *testing.T) {
 		err := model.cleanupStaleNetworkLoadBalancerProgrammedState(t.Context(), route)
 
 		require.NoError(t, err)
+	})
+
+	t.Run("stale NLB cleanup uses annotated load balancer id when parent is gone", func(t *testing.T) {
+		listenerSetKind := gatewayv1.Kind("ListenerSet")
+		sectionName := gatewayv1.SectionName("tls")
+		route := &gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "media",
+				Name:      "rtmps",
+				Finalizers: []string{
+					NetworkLoadBalancerTLSRouteProgrammedFinalizer,
+				},
+				Annotations: map[string]string{
+					NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation: "bs_tls",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+			Status: gatewayv1.TLSRouteStatus{RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{{
+					ParentRef: gatewayv1.ParentReference{
+						Kind:        &listenerSetKind,
+						Name:        "extra",
+						SectionName: &sectionName,
+					},
+					ControllerName: NetworkLoadBalancerControllerClassName,
+				}},
+			}},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithRuntimeObjects(route).
+			Build()
+		nlbClient := &stubNetworkLoadBalancerClient{}
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  k8sClient,
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_tls": {
+							Name: new("bs_tls"),
+							HealthChecker: &networkloadbalancer.HealthChecker{
+								Protocol: networkloadbalancer.HealthCheckProtocolsTcp,
+							},
+						},
+					},
+				},
+			},
+			OciNetworkLoadBalancerAPI: nlbClient,
+			NLBWorkRequestsWatcher:    &stubWorkRequestsWatcher{},
+		})
+
+		err := model.cleanupStaleNetworkLoadBalancerProgrammedState(t.Context(), *route)
+
+		require.NoError(t, err)
+		require.Len(t, nlbClient.updateBackendSetRequests, 1)
+		var updated gatewayv1.TLSRoute
+		require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(route), &updated))
+		assert.NotContains(t, updated.Finalizers, NetworkLoadBalancerTLSRouteProgrammedFinalizer)
+		assert.Empty(t, updated.Annotations[NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation])
+		assert.Empty(t, updated.Annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation])
+	})
+
+	t.Run("stale NLB cleanup returns annotated load balancer cleanup errors", func(t *testing.T) {
+		route := gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "media",
+				Name:      "rtmps",
+				Annotations: map[string]string{
+					NetworkLoadBalancerTLSRouteProgrammedBackendSetsAnnotation: "bs_tls",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+		}
+		model := newTLSRouteModel(tlsRouteModelDeps{
+			RootLogger:               diag.RootTestLogger(),
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{err: errors.New("nlb failed")},
+		})
+
+		err := model.cleanupStaleNetworkLoadBalancerProgrammedState(t.Context(), route)
+
+		require.ErrorContains(t, err, "nlb failed")
 	})
 
 	t.Run("stale NLB cleanup returns backend set update errors", func(t *testing.T) {

--- a/internal/app/udproute_model.go
+++ b/internal/app/udproute_model.go
@@ -18,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gemyago/oke-gateway-api/internal/types"
 )
 
 type resolvedUDPRouteDetails struct {
@@ -211,9 +213,6 @@ func (m *udpRouteModelImpl) handleUnresolvedFinalizedRoute(
 	ctx context.Context,
 	route gatewayv1.UDPRoute,
 ) error {
-	if route.DeletionTimestamp != nil {
-		return m.removeDeletingRouteFinalizer(ctx, route)
-	}
 	return m.deprovisionDetachedRoute(ctx, route)
 }
 
@@ -224,6 +223,7 @@ func (m *udpRouteModelImpl) removeDeletingRouteFinalizer(
 	routeToUpdate := route.DeepCopy()
 	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerUDPRouteProgrammedFinalizer)
 	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return fmt.Errorf("failed to remove finalizer from deleting UDPRoute %s/%s: %w",
 			routeToUpdate.Namespace,
@@ -700,6 +700,14 @@ func (m *udpRouteModelImpl) deprovisionDetachedRoute(
 		}
 	}
 
+	cleaned, err := m.cleanupDetachedRouteByAnnotatedNetworkLoadBalancer(ctx, route, programmedBackendSets)
+	if err != nil || cleaned {
+		return err
+	}
+	if route.DeletionTimestamp != nil {
+		return m.removeDeletingRouteFinalizer(ctx, route)
+	}
+
 	return nil
 }
 
@@ -723,7 +731,41 @@ func (m *udpRouteModelImpl) cleanupDetachedRouteParent(
 	routeToUpdate := route.DeepCopy()
 	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerUDPRouteProgrammedFinalizer)
 	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err = m.client.Update(ctx, routeToUpdate); err != nil {
+		return false, fmt.Errorf("failed to update detached UDPRoute %s/%s after cleanup: %w",
+			routeToUpdate.Namespace,
+			routeToUpdate.Name,
+			err,
+		)
+	}
+	return true, nil
+}
+
+func (m *udpRouteModelImpl) cleanupDetachedRouteByAnnotatedNetworkLoadBalancer(
+	ctx context.Context,
+	route gatewayv1.UDPRoute,
+	programmedBackendSets map[string]struct{},
+) (bool, error) {
+	nlbID := route.Annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation]
+	if nlbID == "" {
+		return false, nil
+	}
+
+	gatewayDetails := resolvedGatewayDetails{
+		config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: nlbID}},
+	}
+	for backendSetName := range programmedBackendSets {
+		if err := m.clearBackendSetByName(ctx, gatewayDetails, udpRouteKey(route), backendSetName, nil); err != nil {
+			return false, err
+		}
+	}
+
+	routeToUpdate := route.DeepCopy()
+	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerUDPRouteProgrammedFinalizer)
+	setAnnotatedBackendSetNames(routeToUpdate, NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation, nil)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
+	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return false, fmt.Errorf("failed to update detached UDPRoute %s/%s after cleanup: %w",
 			routeToUpdate.Namespace,
 			routeToUpdate.Name,
@@ -752,6 +794,7 @@ func (m *udpRouteModelImpl) removeDetachedRouteFinalizer(
 ) error {
 	routeToUpdate := route.DeepCopy()
 	controllerutil.RemoveFinalizer(routeToUpdate, NetworkLoadBalancerUDPRouteProgrammedFinalizer)
+	delete(routeToUpdate.Annotations, L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 	if err := m.client.Update(ctx, routeToUpdate); err != nil {
 		return fmt.Errorf("failed to remove finalizer from detached UDPRoute %s/%s: %w",
 			routeToUpdate.Namespace,
@@ -788,6 +831,7 @@ func (m *udpRouteModelImpl) setProgrammed(ctx context.Context, details resolvedU
 		routeToUpdate:      routeToUpdate,
 		finalizer:          NetworkLoadBalancerUDPRouteProgrammedFinalizer,
 		backendSetAnnotKey: NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation,
+		loadBalancerID:     details.gatewayDetails.config.Spec.LoadBalancerID,
 		desiredBackendSets: desiredUDPRouteBackendSetNames(details),
 		updateParentStatus: func(conditions []metav1.Condition) error {
 			return m.updateParentStatus(ctx, resolvedUDPRouteDetails{

--- a/internal/app/udproute_model.go
+++ b/internal/app/udproute_model.go
@@ -81,14 +81,7 @@ func udpRouteBackendRefName(backendRef gatewayv1.BackendRef, defaultNamespace st
 }
 
 func udpParentRefTarget(parentRef gatewayv1.ParentReference, routeNamespace string) apitypes.NamespacedName {
-	namespace := routeNamespace
-	if parentRef.Namespace != nil {
-		namespace = string(*parentRef.Namespace)
-	}
-	return apitypes.NamespacedName{
-		Namespace: namespace,
-		Name:      string(parentRef.Name),
-	}
+	return parentRefTargetName(parentRef, routeNamespace)
 }
 
 func udpRouteMatchesListener(parentRef gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
@@ -115,14 +108,20 @@ func desiredUDPRouteBackendSetNames(details resolvedUDPRouteDetails) map[string]
 		Name:      details.gatewayDetails.gateway.Name,
 	}
 	for _, parentRef := range details.udpRoute.Spec.ParentRefs {
-		if !parentRefTargetsGateway(parentRef) ||
+		if !parentRefTargetsGateway(parentRef) && !parentRefTargetsListenerSet(parentRef) {
+			continue
+		}
+		if parentRefTargetsGateway(parentRef) &&
 			udpParentRefTarget(parentRef, details.udpRoute.Namespace) != gatewayName {
 			continue
 		}
-		for _, listener := range details.gatewayDetails.gateway.Spec.Listeners {
-			if udpRouteMatchesListener(parentRef, listener) {
-				desired[networkLoadBalancerBackendSetName(listener)] = struct{}{}
-			}
+		for _, listener := range effectiveListenersForParentRef(
+			details.gatewayDetails,
+			parentRef,
+			details.udpRoute.Namespace,
+			udpRouteMatchesListener,
+		) {
+			desired[networkLoadBalancerBackendSetName(listener)] = struct{}{}
 		}
 	}
 	return desired
@@ -166,10 +165,7 @@ func (m *udpRouteModelImpl) resolveParentRef(
 	}
 
 	results := make([]resolvedUDPRouteDetails, 0)
-	for _, listener := range gatewayDetails.gateway.Spec.Listeners {
-		if !udpRouteMatchesListener(parentRef, listener) {
-			continue
-		}
+	for _, listener := range effectiveListenersForParentRef(gatewayDetails, parentRef, route.Namespace, udpRouteMatchesListener) {
 		results = append(results, resolvedUDPRouteDetails{
 			udpRoute:        route,
 			gatewayDetails:  gatewayDetails,
@@ -185,7 +181,7 @@ func (m *udpRouteModelImpl) resolveParentGateway(
 	routeNamespace string,
 	parentRef gatewayv1.ParentReference,
 ) (resolvedGatewayDetails, bool, error) {
-	return resolveL4ParentGateway(ctx, m.client, udpParentRefTarget(parentRef, routeNamespace))
+	return resolveL4ParentGatewayForRouteParentRef(ctx, m.client, routeNamespace, parentRef)
 }
 
 func (m *udpRouteModelImpl) rejectNoMatchingListener(

--- a/internal/app/udproute_model.go
+++ b/internal/app/udproute_model.go
@@ -376,14 +376,13 @@ func (m *udpRouteModelImpl) matchingRoutesForListener(
 ) ([]l4RouteListenerMatch[gatewayv1.UDPRoute], error) {
 	var routeList gatewayv1.UDPRouteList
 	params := listMatchingL4RoutesForListenerParams[gatewayv1.UDPRoute]{
-		k8sClient:    m.client,
-		routeList:    &routeList,
-		listError:    listError,
-		items:        func() []gatewayv1.UDPRoute { return routeList.Items },
-		routeKey:     udpRouteKey,
-		parentTarget: udpParentRefTarget,
+		k8sClient: m.client,
+		routeList: &routeList,
+		listError: listError,
+		items:     func() []gatewayv1.UDPRoute { return routeList.Items },
+		routeKey:  udpRouteKey,
 	}
-	params.gatewayName = client.ObjectKeyFromObject(&details.gatewayDetails.gateway)
+	params.gatewayDetails = details.gatewayDetails
 	params.listener = details.matchedListener
 	params.excludeRouteKey = excludeRouteKey
 	params.routeNamespace = func(route gatewayv1.UDPRoute) string { return route.Namespace }
@@ -583,7 +582,10 @@ func (m *udpRouteModelImpl) programRouteParams(
 			return m.endpointBackendsForRoute(ctx, details.udpRoute)
 		},
 	}
-	input.gatewayNamespace = details.gatewayDetails.gateway.Namespace
+	input.listenerNamespace = effectiveListenerSourceNamespaceForOCIListener(
+		details.gatewayDetails,
+		details.matchedListener,
+	)
 	input.clearBackendSet = func() error { return m.clearBackendSet(ctx, details) }
 	input.isResolvedRefsErr = func(err error) bool {
 		var statusErr udpRouteStatusError

--- a/internal/app/udproute_model_test.go
+++ b/internal/app/udproute_model_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -603,6 +605,11 @@ func TestUDPRouteModel(t *testing.T) {
 					"bs_coap",
 					obj.GetAnnotations()[NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation],
 				)
+				assert.Equal(
+					t,
+					"nlb-id",
+					obj.GetAnnotations()[L4RouteProgrammedNetworkLoadBalancerIDAnnotation],
+				)
 				return nil
 			})
 
@@ -622,6 +629,7 @@ func TestUDPRouteModel(t *testing.T) {
 						},
 					},
 				},
+				config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: "nlb-id"}},
 			},
 			matchedRef: gatewayv1.ParentReference{
 				Name: "edge",
@@ -714,6 +722,7 @@ func TestUDPRouteModel(t *testing.T) {
 				Finalizers: []string{NetworkLoadBalancerUDPRouteProgrammedFinalizer},
 				Annotations: map[string]string{
 					NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation: "bs_old",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
 				},
 			},
 			Status: gatewayv1.UDPRouteStatus{
@@ -759,6 +768,7 @@ func TestUDPRouteModel(t *testing.T) {
 			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 				assert.NotContains(t, obj.GetFinalizers(), NetworkLoadBalancerUDPRouteProgrammedFinalizer)
 				assert.NotContains(t, obj.GetAnnotations(), NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation)
+				assert.NotContains(t, obj.GetAnnotations(), L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
 				return nil
 			})
 
@@ -801,6 +811,139 @@ func TestUDPRouteModel(t *testing.T) {
 		assert.Equal(t, 5684, lo.FromPtr(request.UpdateBackendSetDetails.HealthChecker.Port))
 		assert.Empty(t, request.UpdateBackendSetDetails.HealthChecker.RequestData)
 		assert.Empty(t, request.UpdateBackendSetDetails.HealthChecker.ResponseData)
+	})
+
+	t.Run("deprovisionDetachedRoute clears annotated backend set by load balancer id", func(t *testing.T) {
+		listenerSetKind := gatewayv1.Kind("ListenerSet")
+		route := gatewayv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "coap",
+				Finalizers: []string{NetworkLoadBalancerUDPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation: "bs_listener_set",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+			Status: gatewayv1.UDPRouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
+					Parents: []gatewayv1.RouteParentStatus{{
+						ParentRef: gatewayv1.ParentReference{
+							Kind: &listenerSetKind,
+							Name: "extra",
+						},
+						ControllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+					}},
+				},
+			},
+		}
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Get(
+				t.Context(),
+				apitypes.NamespacedName{Namespace: "iot", Name: "extra"},
+				mock.AnythingOfType("*v1.Gateway"),
+			).
+			Return(apierrors.NewNotFound(schema.GroupResource{
+				Group:    gatewayv1.GroupName,
+				Resource: "gateways",
+			}, "extra"))
+		mockClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.UDPRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				assert.NotContains(t, obj.GetFinalizers(), NetworkLoadBalancerUDPRouteProgrammedFinalizer)
+				assert.NotContains(t, obj.GetAnnotations(), NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation)
+				assert.NotContains(t, obj.GetAnnotations(), L4RouteProgrammedNetworkLoadBalancerIDAnnotation)
+				return nil
+			})
+		nlbClient := &stubNetworkLoadBalancerClient{}
+		model := newUDPRouteModel(udpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_listener_set": {
+							Name: new("bs_listener_set"),
+							HealthChecker: &networkloadbalancer.HealthChecker{
+								Protocol: networkloadbalancer.HealthCheckProtocolsTcp,
+							},
+						},
+					},
+				},
+			},
+			OciNetworkLoadBalancerAPI: nlbClient,
+		})
+		modelImpl := mustUDPRouteModelImpl(t, model)
+
+		err := modelImpl.deprovisionDetachedRoute(t.Context(), route)
+
+		require.NoError(t, err)
+		require.Len(t, nlbClient.updateBackendSetRequests, 1)
+		request := nlbClient.updateBackendSetRequests[0]
+		assert.Equal(t, "nlb-id", lo.FromPtr(request.NetworkLoadBalancerId))
+		assert.Equal(t, "bs_listener_set", lo.FromPtr(request.BackendSetName))
+		assert.Empty(t, request.UpdateBackendSetDetails.Backends)
+	})
+
+	t.Run("deprovisionDetachedRoute returns annotated load balancer cleanup update errors", func(t *testing.T) {
+		route := gatewayv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "coap",
+				Finalizers: []string{NetworkLoadBalancerUDPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation: "bs_listener_set",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+		}
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.UDPRoute")).
+			Return(errors.New("update failed"))
+		model := newUDPRouteModel(udpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  mockClient,
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						"bs_listener_set": {Name: new("bs_listener_set")},
+					},
+				},
+			},
+			OciNetworkLoadBalancerAPI: &stubNetworkLoadBalancerClient{},
+		})
+		modelImpl := mustUDPRouteModelImpl(t, model)
+
+		err := modelImpl.deprovisionDetachedRoute(t.Context(), route)
+
+		require.ErrorContains(t, err, "failed to update detached UDPRoute")
+	})
+
+	t.Run("deprovisionDetachedRoute returns annotated load balancer cleanup errors", func(t *testing.T) {
+		route := gatewayv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "coap",
+				Finalizers: []string{NetworkLoadBalancerUDPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation: "bs_listener_set",
+					L4RouteProgrammedNetworkLoadBalancerIDAnnotation:           "nlb-id",
+				},
+			},
+		}
+		model := newUDPRouteModel(udpRouteModelDeps{
+			RootLogger:               diag.RootTestLogger(),
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{err: errors.New("nlb failed")},
+		})
+		modelImpl := mustUDPRouteModelImpl(t, model)
+
+		err := modelImpl.deprovisionDetachedRoute(t.Context(), route)
+
+		require.ErrorContains(t, err, "nlb failed")
 	})
 
 	t.Run("deprovisionDetachedRoute removes finalizer when no backend sets are annotated", func(t *testing.T) {

--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"strings"
 
 	"github.com/samber/lo"
 	"go.uber.org/dig"
@@ -27,6 +28,8 @@ const httpRouteParentGatewayIndexKey = ".metadata.parentRefs.gateway"
 const grpcRouteParentGatewayIndexKey = ".metadata.grpcParentRefs.gateway"
 const tlsRouteParentGatewayIndexKey = ".metadata.tlsParentRefs.gateway"
 const gatewayCertificateIndexKey = ".metadata.certificates" // Virtual field name, indexed
+const listenerSetParentGatewayIndexKey = ".metadata.parentRef.gateway"
+const listenerSetCertificateIndexKey = ".metadata.listenerSetCertificates"
 const tcpRouteBackendServiceIndexKey = ".metadata.tcpBackendRefs.serviceName"
 const udpRouteBackendServiceIndexKey = ".metadata.udpBackendRefs.serviceName"
 const tlsRouteBackendServiceIndexKey = ".metadata.tlsBackendRefs.serviceName"
@@ -46,9 +49,10 @@ type WatchesModelDeps struct {
 
 // RegisterFieldIndexersOptions controls which optional route indexers are registered.
 type RegisterFieldIndexersOptions struct {
-	EnableTCPRoute bool
-	EnableUDPRoute bool
-	EnableTLSRoute bool
+	EnableTCPRoute    bool
+	EnableUDPRoute    bool
+	EnableTLSRoute    bool
+	EnableListenerSet bool
 }
 
 // NewWatchesModel creates a new watchesModel.
@@ -137,6 +141,12 @@ func (m *WatchesModel) RegisterFieldIndexers(
 		return fmt.Errorf("failed to index Gateway by certificate: %w", err)
 	}
 
+	if opts.EnableListenerSet {
+		if err := m.registerListenerSetIndexers(ctx, indexer); err != nil {
+			return err
+		}
+	}
+
 	m.logger.DebugContext(ctx, "Field indexers registered",
 		slog.String("indexKey", httpRouteBackendServiceIndexKey),
 		slog.String("indexKey", grpcRouteBackendServiceIndexKey),
@@ -147,7 +157,30 @@ func (m *WatchesModel) RegisterFieldIndexers(
 		slog.Bool("tcpRouteIndexEnabled", opts.EnableTCPRoute),
 		slog.Bool("udpRouteIndexEnabled", opts.EnableUDPRoute),
 		slog.Bool("tlsRouteIndexEnabled", opts.EnableTLSRoute),
+		slog.Bool("listenerSetIndexEnabled", opts.EnableListenerSet),
 	)
+	return nil
+}
+
+func (m *WatchesModel) registerListenerSetIndexers(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx,
+		&gatewayv1.ListenerSet{},
+		listenerSetParentGatewayIndexKey,
+		func(o client.Object) []string {
+			return m.indexListenerSetByParentGateway(ctx, o)
+		},
+	); err != nil {
+		return fmt.Errorf("failed to index ListenerSet by parent Gateway: %w", err)
+	}
+	if err := indexer.IndexField(ctx,
+		&gatewayv1.ListenerSet{},
+		listenerSetCertificateIndexKey,
+		func(o client.Object) []string {
+			return m.indexListenerSetByCertificateSecrets(ctx, o)
+		},
+	); err != nil {
+		return fmt.Errorf("failed to index ListenerSet by certificate: %w", err)
+	}
 	return nil
 }
 
@@ -235,13 +268,55 @@ func (m *WatchesModel) indexTLSRouteByParentGateway(ctx context.Context, obj cli
 	return parentGatewayIndexKeys(tlsRoute.Namespace, tlsRoute.Spec.ParentRefs)
 }
 
+func (m *WatchesModel) indexListenerSetByParentGateway(ctx context.Context, obj client.Object) []string {
+	listenerSet, ok := obj.(*gatewayv1.ListenerSet)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ListenerSet object", slog.Any("object", obj))
+		return nil
+	}
+	if listenerSet.DeletionTimestamp != nil {
+		return nil
+	}
+	parentName, ok := listenerSetParentGatewayName(*listenerSet)
+	if !ok {
+		return nil
+	}
+	return []string{parentName}
+}
+
+func (m *WatchesModel) indexListenerSetByCertificateSecrets(ctx context.Context, obj client.Object) []string {
+	listenerSet, ok := obj.(*gatewayv1.ListenerSet)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ListenerSet object", slog.Any("object", obj))
+		return nil
+	}
+	if listenerSet.DeletionTimestamp != nil {
+		return nil
+	}
+	uniqueSecretKeys := make(map[string]struct{})
+	for _, listener := range listenerSet.Spec.Listeners {
+		if (listener.Protocol != gatewayv1.HTTPSProtocolType && listener.Protocol != gatewayv1.TLSProtocolType) ||
+			listener.TLS == nil {
+			continue
+		}
+		for _, ref := range listener.TLS.CertificateRefs {
+			ns := listenerSet.Namespace
+			if ref.Namespace != nil {
+				ns = string(*ref.Namespace)
+			}
+			uniqueSecretKeys[path.Join(ns, string(ref.Name))] = struct{}{}
+		}
+	}
+	return lo.Keys(uniqueSecretKeys)
+}
+
 func parentGatewayIndexKeys(routeNamespace string, refs []gatewayv1.ParentReference) []string {
 	uniqueGatewayKeys := make(map[string]struct{})
 	for _, ref := range refs {
 		if ref.Group != nil && string(*ref.Group) != gatewayv1.GroupName {
 			continue
 		}
-		if ref.Kind != nil && string(*ref.Kind) != "Gateway" {
+		if ref.Kind != nil && string(*ref.Kind) != "Gateway" && string(*ref.Kind) != "ListenerSet" {
 			continue
 		}
 
@@ -733,6 +808,67 @@ func (m *WatchesModel) MapGRPCRouteToHTTPRoute(ctx context.Context, obj client.O
 	)
 }
 
+func (m *WatchesModel) MapListenerSetToHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return mapListenerSetToIndexedRoutes(ctx, m.logger, m.k8sClient, obj, &gatewayv1.HTTPRouteList{},
+		httpRouteParentGatewayIndexKey,
+		"HTTPRoutes",
+		func(routeList *gatewayv1.HTTPRouteList) []reconcile.Request {
+			requests := make([]reconcile.Request, 0, len(routeList.Items))
+			for _, route := range routeList.Items {
+				if route.DeletionTimestamp != nil {
+					continue
+				}
+				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&route)})
+			}
+			return requests
+		},
+	)
+}
+
+func (m *WatchesModel) MapListenerSetToGRPCRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return mapListenerSetToIndexedRoutes(ctx, m.logger, m.k8sClient, obj, &gatewayv1.GRPCRouteList{},
+		grpcRouteParentGatewayIndexKey,
+		"GRPCRoutes",
+		func(routeList *gatewayv1.GRPCRouteList) []reconcile.Request {
+			requests := make([]reconcile.Request, 0, len(routeList.Items))
+			for _, route := range routeList.Items {
+				if route.DeletionTimestamp != nil {
+					continue
+				}
+				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&route)})
+			}
+			return requests
+		},
+	)
+}
+
+func mapListenerSetToIndexedRoutes[T client.ObjectList](
+	ctx context.Context,
+	logger *slog.Logger,
+	k8sClient k8sClient,
+	obj client.Object,
+	routeList T,
+	indexKey string,
+	routeKind string,
+	requestsFromList func(T) []reconcile.Request,
+) []reconcile.Request {
+	listenerSet, ok := obj.(*gatewayv1.ListenerSet)
+	if !ok {
+		logger.WarnContext(ctx, "Received non-ListenerSet object", slog.Any("object", obj))
+		return nil
+	}
+
+	listenerSetKey := client.ObjectKeyFromObject(listenerSet).String()
+	if err := k8sClient.List(ctx, routeList, client.MatchingFields{indexKey: listenerSetKey}); err != nil {
+		logger.ErrorContext(ctx, fmt.Sprintf("Failed to list %s for ListenerSet change", routeKind),
+			slog.String("listenerSet", listenerSetKey),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+	return requestsFromList(routeList)
+}
+
 func (m *WatchesModel) MapEndpointSliceToTCPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
 	var routeList gatewayv1.TCPRouteList
 	return mapEndpointSliceToL4Route(
@@ -1164,6 +1300,72 @@ func udpRouteReferencesGateway(route gatewayv1.UDPRoute, gateway gatewayv1.Gatew
 	return false
 }
 
+func routeRefsTargetListenerSet(
+	parentRefs []gatewayv1.ParentReference,
+	routeNamespace string,
+	listenerSet gatewayv1.ListenerSet,
+) bool {
+	listenerSetName := client.ObjectKeyFromObject(&listenerSet)
+	for _, parentRef := range parentRefs {
+		if !parentRefTargetsListenerSet(parentRef) {
+			continue
+		}
+		if parentRefTargetName(parentRef, routeNamespace) == listenerSetName {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *WatchesModel) MapListenerSetToTCPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	var routeList gatewayv1.TCPRouteList
+	return mapListenerSetToL4Route(ctx, m.logger, m.k8sClient, obj, &routeList, "TCPRoutes",
+		func(routeList *gatewayv1.TCPRouteList, listenerSet *gatewayv1.ListenerSet) []reconcile.Request {
+			requests := make([]reconcile.Request, 0)
+			for _, route := range routeList.Items {
+				if route.DeletionTimestamp == nil &&
+					routeRefsTargetListenerSet(route.Spec.ParentRefs, route.Namespace, *listenerSet) {
+					requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&route)})
+				}
+			}
+			return requests
+		},
+	)
+}
+
+func (m *WatchesModel) MapListenerSetToUDPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	var routeList gatewayv1.UDPRouteList
+	return mapListenerSetToL4Route(ctx, m.logger, m.k8sClient, obj, &routeList, "UDPRoutes",
+		func(routeList *gatewayv1.UDPRouteList, listenerSet *gatewayv1.ListenerSet) []reconcile.Request {
+			requests := make([]reconcile.Request, 0)
+			for _, route := range routeList.Items {
+				if route.DeletionTimestamp == nil &&
+					routeRefsTargetListenerSet(route.Spec.ParentRefs, route.Namespace, *listenerSet) {
+					requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&route)})
+				}
+			}
+			return requests
+		},
+	)
+}
+
+func (m *WatchesModel) MapListenerSetToTLSRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return mapListenerSetToIndexedRoutes(ctx, m.logger, m.k8sClient, obj, &gatewayv1.TLSRouteList{},
+		tlsRouteParentGatewayIndexKey,
+		"TLSRoutes",
+		func(routeList *gatewayv1.TLSRouteList) []reconcile.Request {
+			requests := make([]reconcile.Request, 0, len(routeList.Items))
+			for _, route := range routeList.Items {
+				if route.DeletionTimestamp != nil {
+					continue
+				}
+				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&route)})
+			}
+			return requests
+		},
+	)
+}
+
 func (m *WatchesModel) MapGatewayToTCPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
 	var routeList gatewayv1.TCPRouteList
 	return mapGatewayToL4Route(ctx, m.logger, m.k8sClient, obj, &routeList, "TCPRoutes",
@@ -1223,6 +1425,235 @@ func (m *WatchesModel) MapGatewayToTLSRoute(ctx context.Context, obj client.Obje
 	return requests
 }
 
+func (m *WatchesModel) MapListenerSetToGateway(ctx context.Context, obj client.Object) []reconcile.Request {
+	listenerSet, ok := obj.(*gatewayv1.ListenerSet)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ListenerSet object", slog.Any("object", obj))
+		return nil
+	}
+	requestsByKey := map[client.ObjectKey]reconcile.Request{}
+	if parentName, targetsGateway := listenerSetParentGatewayName(*listenerSet); targetsGateway {
+		addListenerSetParentGatewayRequest(requestsByKey, parentName)
+	}
+	if listenerSet.Annotations != nil {
+		addListenerSetParentGatewayRequest(
+			requestsByKey,
+			listenerSet.Annotations[ListenerSetParentGatewayAnnotation],
+		)
+	}
+	if len(requestsByKey) == 0 {
+		return nil
+	}
+	return lo.Values(requestsByKey)
+}
+
+func addListenerSetParentGatewayRequest(requestsByKey map[client.ObjectKey]reconcile.Request, parentName string) {
+	namespace, name, ok := strings.Cut(parentName, "/")
+	if !ok {
+		return
+	}
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+	requestsByKey[key] = reconcile.Request{NamespacedName: key}
+}
+
+func (m *WatchesModel) MapGatewayToListenerSet(ctx context.Context, obj client.Object) []reconcile.Request {
+	gateway, ok := obj.(*gatewayv1.Gateway)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-Gateway object", slog.Any("object", obj))
+		return nil
+	}
+	var listenerSetList gatewayv1.ListenerSetList
+	if err := m.k8sClient.List(ctx, &listenerSetList, client.MatchingFields{
+		listenerSetParentGatewayIndexKey: client.ObjectKeyFromObject(gateway).String(),
+	}); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list ListenerSets for Gateway change",
+			slog.String("gateway", client.ObjectKeyFromObject(gateway).String()),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(listenerSetList.Items))
+	for _, listenerSet := range listenerSetList.Items {
+		if listenerSet.DeletionTimestamp != nil {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&listenerSet)})
+	}
+	return requests
+}
+
+func (m *WatchesModel) MapNamespaceToListenerSet(ctx context.Context, obj client.Object) []reconcile.Request {
+	namespace, ok := obj.(*corev1.Namespace)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-Namespace object", slog.Any("object", obj))
+		return nil
+	}
+	var listenerSetList gatewayv1.ListenerSetList
+	if err := m.k8sClient.List(ctx, &listenerSetList, client.InNamespace(namespace.Name)); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list ListenerSets for Namespace change",
+			slog.String("namespace", namespace.Name),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(listenerSetList.Items))
+	for _, listenerSet := range listenerSetList.Items {
+		if listenerSet.DeletionTimestamp != nil {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&listenerSet)})
+	}
+	return requests
+}
+
+func (m *WatchesModel) MapReferenceGrantToGatewayWithListenerSets(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	grant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ReferenceGrant object", slog.Any("object", obj))
+		return nil
+	}
+	if !referenceGrantMayAllowListenerSetSecret(*grant) {
+		return nil
+	}
+
+	var listenerSetList gatewayv1.ListenerSetList
+	if err := m.k8sClient.List(ctx, &listenerSetList); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list ListenerSets for ReferenceGrant change",
+			slog.String("referenceGrant", client.ObjectKeyFromObject(grant).String()),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+
+	requestsByKey := make(map[client.ObjectKey]reconcile.Request)
+	for _, listenerSet := range listenerSetList.Items {
+		if listenerSet.DeletionTimestamp != nil || !listenerSetReferencesGrantedSecret(listenerSet, *grant) {
+			continue
+		}
+		for _, request := range m.MapListenerSetToGateway(ctx, &listenerSet) {
+			requestsByKey[request.NamespacedName] = request
+		}
+	}
+	return lo.Values(requestsByKey)
+}
+
+func (m *WatchesModel) MapReferenceGrantToListenerSet(ctx context.Context, obj client.Object) []reconcile.Request {
+	grant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ReferenceGrant object", slog.Any("object", obj))
+		return nil
+	}
+	if !referenceGrantMayAllowListenerSetSecret(*grant) {
+		return nil
+	}
+
+	var listenerSetList gatewayv1.ListenerSetList
+	if err := m.k8sClient.List(ctx, &listenerSetList); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list ListenerSets for ReferenceGrant change",
+			slog.String("referenceGrant", client.ObjectKeyFromObject(grant).String()),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(listenerSetList.Items))
+	for _, listenerSet := range listenerSetList.Items {
+		if listenerSet.DeletionTimestamp != nil || !listenerSetReferencesGrantedSecret(listenerSet, *grant) {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&listenerSet)})
+	}
+	return requests
+}
+
+func referenceGrantMayAllowListenerSetSecret(grant gatewayv1beta1.ReferenceGrant) bool {
+	return referenceGrantHasMatchingFromKind(grant, gatewayv1.Kind("ListenerSet")) &&
+		referenceGrantHasSecretTo(grant)
+}
+
+func referenceGrantHasMatchingFromKind(grant gatewayv1beta1.ReferenceGrant, kind gatewayv1.Kind) bool {
+	for _, from := range grant.Spec.From {
+		if string(from.Group) == gatewayAPIGroup && from.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func referenceGrantHasSecretTo(grant gatewayv1beta1.ReferenceGrant) bool {
+	for _, to := range grant.Spec.To {
+		if string(to.Group) == "" && to.Kind == gatewayv1.Kind("Secret") {
+			return true
+		}
+	}
+	return false
+}
+
+func listenerSetReferencesGrantedSecret(
+	listenerSet gatewayv1.ListenerSet,
+	grant gatewayv1beta1.ReferenceGrant,
+) bool {
+	if !referenceGrantHasMatchingFrom(grant, gatewayv1.Kind("ListenerSet"), listenerSet.Namespace) {
+		return false
+	}
+	for _, listener := range listenerSet.Spec.Listeners {
+		if listener.TLS == nil {
+			continue
+		}
+		for _, ref := range listener.TLS.CertificateRefs {
+			certNamespace := listenerSet.Namespace
+			if ref.Namespace != nil {
+				certNamespace = string(*ref.Namespace)
+			}
+			if certNamespace == listenerSet.Namespace || certNamespace != grant.Namespace {
+				continue
+			}
+			if referenceGrantHasMatchingSecretTo(grant, string(ref.Name)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *WatchesModel) MapNamespaceToGateway(ctx context.Context, obj client.Object) []reconcile.Request {
+	if _, ok := obj.(*corev1.Namespace); !ok {
+		m.logger.WarnContext(ctx, "Received non-Namespace object", slog.Any("object", obj))
+		return nil
+	}
+
+	var gatewayList gatewayv1.GatewayList
+	if err := m.k8sClient.List(ctx, &gatewayList); err != nil {
+		m.logger.ErrorContext(ctx, "Failed to list Gateways for Namespace change", diag.ErrAttr(err))
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for _, gateway := range gatewayList.Items {
+		if gateway.DeletionTimestamp != nil || !gatewayAllowedListenersUsesNamespaceSelector(gateway) {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&gateway)})
+	}
+	return requests
+}
+
+func gatewayAllowedListenersUsesNamespaceSelector(gateway gatewayv1.Gateway) bool {
+	if gateway.Spec.AllowedListeners == nil ||
+		gateway.Spec.AllowedListeners.Namespaces == nil ||
+		gateway.Spec.AllowedListeners.Namespaces.From == nil {
+		return false
+	}
+	return *gateway.Spec.AllowedListeners.Namespaces.From == gatewayv1.NamespacesFromSelector
+}
+
 func mapGatewayToL4Route[T client.ObjectList](
 	ctx context.Context,
 	logger *slog.Logger,
@@ -1247,6 +1678,31 @@ func mapGatewayToL4Route[T client.ObjectList](
 	}
 
 	return requestsFromList(routeList, gateway)
+}
+
+func mapListenerSetToL4Route[T client.ObjectList](
+	ctx context.Context,
+	logger *slog.Logger,
+	k8sClient k8sClient,
+	obj client.Object,
+	routeList T,
+	routeKind string,
+	requestsFromList func(T, *gatewayv1.ListenerSet) []reconcile.Request,
+) []reconcile.Request {
+	listenerSet, ok := obj.(*gatewayv1.ListenerSet)
+	if !ok {
+		logger.WarnContext(ctx, "Received non-ListenerSet object", slog.Any("object", obj))
+		return nil
+	}
+
+	if err := k8sClient.List(ctx, routeList); err != nil {
+		logger.ErrorContext(ctx, fmt.Sprintf("Failed to list %s for ListenerSet change", routeKind),
+			slog.String("listenerSet", client.ObjectKeyFromObject(listenerSet).String()),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+	return requestsFromList(routeList, listenerSet)
 }
 
 // MapGatewayConfigToGateway maps GatewayConfig events to Gateway reconcile requests.
@@ -1371,9 +1827,8 @@ func (m *WatchesModel) MapSecretToGateway(ctx context.Context, obj client.Object
 			)
 			continue
 		}
-		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKeyFromObject(&gateway),
-		})
+		gatewayKey := client.ObjectKeyFromObject(&gateway)
+		requests = append(requests, reconcile.Request{NamespacedName: gatewayKey})
 		m.logger.InfoContext(ctx,
 			"Queueing Gateway for reconciliation due to Secret change",
 			slog.String("gateway", client.ObjectKeyFromObject(&gateway).String()),
@@ -1385,6 +1840,86 @@ func (m *WatchesModel) MapSecretToGateway(ctx context.Context, obj client.Object
 		)
 	}
 
+	return requests
+}
+
+func (m *WatchesModel) MapSecretToGatewayWithListenerSets(ctx context.Context, obj client.Object) []reconcile.Request {
+	directRequests := m.MapSecretToGateway(ctx, obj)
+	secret, ok := obj.(*corev1.Secret)
+	if !ok || secret.Type != corev1.SecretTypeTLS {
+		return directRequests
+	}
+	if _, hasCert := secret.Data[corev1.TLSCertKey]; !hasCert {
+		return directRequests
+	}
+	if _, hasKey := secret.Data[corev1.TLSPrivateKeyKey]; !hasKey {
+		return directRequests
+	}
+
+	indexKey := path.Join(secret.Namespace, secret.Name)
+	var listenerSetList gatewayv1.ListenerSetList
+	if err := m.k8sClient.List(
+		ctx,
+		&listenerSetList,
+		client.MatchingFields{listenerSetCertificateIndexKey: indexKey},
+	); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list ListenerSets for certificate",
+			slog.String("indexKey", indexKey),
+			diag.ErrAttr(err),
+		)
+		return directRequests
+	}
+
+	requestsByKey := make(map[client.ObjectKey]reconcile.Request)
+	for _, request := range directRequests {
+		requestsByKey[request.NamespacedName] = request
+	}
+	for _, listenerSet := range listenerSetList.Items {
+		if listenerSet.DeletionTimestamp != nil {
+			continue
+		}
+		for _, request := range m.MapListenerSetToGateway(ctx, &listenerSet) {
+			requestsByKey[request.NamespacedName] = request
+		}
+	}
+	return lo.Values(requestsByKey)
+}
+
+func (m *WatchesModel) MapSecretToListenerSet(ctx context.Context, obj client.Object) []reconcile.Request {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok || secret.Type != corev1.SecretTypeTLS {
+		return nil
+	}
+	if _, hasCert := secret.Data[corev1.TLSCertKey]; !hasCert {
+		return nil
+	}
+	if _, hasKey := secret.Data[corev1.TLSPrivateKeyKey]; !hasKey {
+		return nil
+	}
+
+	indexKey := path.Join(secret.Namespace, secret.Name)
+	var listenerSetList gatewayv1.ListenerSetList
+	if err := m.k8sClient.List(
+		ctx,
+		&listenerSetList,
+		client.MatchingFields{listenerSetCertificateIndexKey: indexKey},
+	); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list ListenerSets for certificate",
+			slog.String("indexKey", indexKey),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(listenerSetList.Items))
+	for _, listenerSet := range listenerSetList.Items {
+		if listenerSet.DeletionTimestamp != nil {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&listenerSet)})
+	}
 	return requests
 }
 

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -199,6 +199,152 @@ func TestWatchesModel(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("registers ListenerSet indexers when enabled", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mockIndexer := k8sapi.NewMockFieldIndexer(t)
+
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.HTTPRoute{},
+				httpRouteBackendServiceIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.GRPCRoute{},
+				grpcRouteBackendServiceIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.HTTPRoute{},
+				httpRouteParentGatewayIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.GRPCRoute{},
+				grpcRouteParentGatewayIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.Gateway{},
+				gatewayCertificateIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.ListenerSet{},
+				listenerSetParentGatewayIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.ListenerSet{},
+				listenerSetCertificateIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+
+			err := model.RegisterFieldIndexers(t.Context(), mockIndexer, RegisterFieldIndexersOptions{
+				EnableListenerSet: true,
+			})
+			require.NoError(t, err)
+		})
+
+		t.Run("registered ListenerSet-enabled index callbacks handle their resource types", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mockIndexer := k8sapi.NewMockFieldIndexer(t)
+
+			expectCallback := func(obj client.Object, field string, sample client.Object) {
+				mockIndexer.EXPECT().
+					IndexField(t.Context(), obj, field, mock.AnythingOfType("client.IndexerFunc")).
+					Run(func(_ context.Context, _ client.Object, _ string, extractValue client.IndexerFunc) {
+						_ = extractValue(sample)
+					}).
+					Return(nil)
+			}
+
+			expectCallback(&gatewayv1.HTTPRoute{}, httpRouteBackendServiceIndexKey, &gatewayv1.HTTPRoute{})
+			expectCallback(&gatewayv1.GRPCRoute{}, grpcRouteBackendServiceIndexKey, &gatewayv1.GRPCRoute{})
+			expectCallback(&gatewayv1.HTTPRoute{}, httpRouteParentGatewayIndexKey, &gatewayv1.HTTPRoute{})
+			expectCallback(&gatewayv1.GRPCRoute{}, grpcRouteParentGatewayIndexKey, &gatewayv1.GRPCRoute{})
+			expectCallback(&gatewayv1.TCPRoute{}, tcpRouteBackendServiceIndexKey, &gatewayv1.TCPRoute{})
+			expectCallback(&gatewayv1.UDPRoute{}, udpRouteBackendServiceIndexKey, &gatewayv1.UDPRoute{})
+			expectCallback(&gatewayv1.TLSRoute{}, tlsRouteBackendServiceIndexKey, &gatewayv1.TLSRoute{})
+			expectCallback(&gatewayv1.TLSRoute{}, tlsRouteParentGatewayIndexKey, &gatewayv1.TLSRoute{})
+			expectCallback(&gatewayv1.Gateway{}, gatewayCertificateIndexKey, &gatewayv1.Gateway{})
+			expectCallback(&gatewayv1.ListenerSet{}, listenerSetParentGatewayIndexKey, &gatewayv1.ListenerSet{})
+			expectCallback(&gatewayv1.ListenerSet{}, listenerSetCertificateIndexKey, &gatewayv1.ListenerSet{})
+
+			err := model.RegisterFieldIndexers(t.Context(), mockIndexer, RegisterFieldIndexersOptions{
+				EnableTCPRoute:    true,
+				EnableUDPRoute:    true,
+				EnableTLSRoute:    true,
+				EnableListenerSet: true,
+			})
+
+			require.NoError(t, err)
+		})
+
+		t.Run("returns error if ListenerSet parent Gateway indexer registration fails", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mockIndexer := k8sapi.NewMockFieldIndexer(t)
+
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.HTTPRoute{},
+				httpRouteBackendServiceIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.GRPCRoute{},
+				grpcRouteBackendServiceIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.HTTPRoute{},
+				httpRouteParentGatewayIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.GRPCRoute{},
+				grpcRouteParentGatewayIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.Gateway{},
+				gatewayCertificateIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			wantErr := errors.New(faker.New().Lorem().Sentence(10))
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.ListenerSet{},
+				listenerSetParentGatewayIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(wantErr)
+
+			err := model.RegisterFieldIndexers(t.Context(), mockIndexer, RegisterFieldIndexersOptions{
+				EnableListenerSet: true,
+			})
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to index ListenerSet by parent Gateway")
+		})
+
+		t.Run("returns error if ListenerSet certificate indexer registration fails", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mockIndexer := k8sapi.NewMockFieldIndexer(t)
+
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.HTTPRoute{},
+				httpRouteBackendServiceIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.GRPCRoute{},
+				grpcRouteBackendServiceIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.HTTPRoute{},
+				httpRouteParentGatewayIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.GRPCRoute{},
+				grpcRouteParentGatewayIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.Gateway{},
+				gatewayCertificateIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.ListenerSet{},
+				listenerSetParentGatewayIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(nil)
+			wantErr := errors.New(faker.New().Lorem().Sentence(10))
+			mockIndexer.EXPECT().IndexField(t.Context(), &gatewayv1.ListenerSet{},
+				listenerSetCertificateIndexKey, mock.AnythingOfType("client.IndexerFunc")).Return(wantErr)
+
+			err := model.RegisterFieldIndexers(t.Context(), mockIndexer, RegisterFieldIndexersOptions{
+				EnableListenerSet: true,
+			})
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to index ListenerSet by certificate")
+		})
+
 		t.Run("returns error if HTTPRoute indexer registration fails", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := NewWatchesModel(deps)
@@ -834,6 +980,8 @@ func TestWatchesModel(t *testing.T) {
 			gatewayName := gatewayv1.ObjectName(faker.New().Internet().Domain())
 			otherNamespace := gatewayv1.Namespace(faker.New().Internet().Slug())
 			otherGatewayName := gatewayv1.ObjectName(faker.New().Internet().Domain())
+			listenerSetKind := gatewayv1.Kind("ListenerSet")
+			listenerSetName := gatewayv1.ObjectName("listeners-" + faker.New().Internet().Slug())
 			unsupportedKind := gatewayv1.Kind("Service")
 			unsupportedGroup := gatewayv1.Group("other.example.com")
 			route := makeRandomHTTPRoute(
@@ -842,6 +990,7 @@ func TestWatchesModel(t *testing.T) {
 					gatewayv1.ParentReference{Name: gatewayName},
 					gatewayv1.ParentReference{Name: gatewayName},
 					gatewayv1.ParentReference{Namespace: &otherNamespace, Name: otherGatewayName},
+					gatewayv1.ParentReference{Name: listenerSetName, Kind: &listenerSetKind},
 					gatewayv1.ParentReference{Name: gatewayName, Kind: &unsupportedKind},
 					gatewayv1.ParentReference{Name: gatewayName, Group: &unsupportedGroup},
 				),
@@ -852,6 +1001,7 @@ func TestWatchesModel(t *testing.T) {
 			require.ElementsMatch(t, []string{
 				fmt.Sprintf("%s/%s", routeNamespace, gatewayName),
 				fmt.Sprintf("%s/%s", otherNamespace, otherGatewayName),
+				fmt.Sprintf("%s/%s", routeNamespace, listenerSetName),
 			}, result)
 		})
 
@@ -1389,6 +1539,106 @@ func TestWatchesModel(t *testing.T) {
 		})
 	})
 
+	t.Run("indexListenerSet", func(t *testing.T) {
+		t.Run("indexes parent Gateway", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			parentNamespace := gatewayv1.Namespace("infra-" + faker.New().Lorem().Word())
+			parentName := gatewayv1.ObjectName("edge-" + faker.New().Lorem().Word())
+			listenerSet := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps-" + faker.New().Lorem().Word(),
+					Name:      "listeners-" + faker.New().Lorem().Word(),
+				},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+					Namespace: &parentNamespace,
+					Name:      parentName,
+				}},
+			}
+
+			result := model.indexListenerSetByParentGateway(t.Context(), listenerSet)
+
+			require.ElementsMatch(t, []string{fmt.Sprintf("%s/%s", parentNamespace, parentName)}, result)
+		})
+
+		t.Run("indexes certificate refs from HTTPS and TLS listeners", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			certNamespace := gatewayv1.Namespace("certs-" + faker.New().Lorem().Word())
+			listenerSet := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps-" + faker.New().Lorem().Word(),
+					Name:      "listeners-" + faker.New().Lorem().Word(),
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"},
+					Listeners: []gatewayv1.ListenerEntry{
+						{
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{CertificateRefs: []gatewayv1.SecretObjectReference{
+								{Name: gatewayv1.ObjectName("same-ns-" + faker.New().Lorem().Word())},
+							}},
+						},
+						{
+							Name:     "tls",
+							Protocol: gatewayv1.TLSProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{CertificateRefs: []gatewayv1.SecretObjectReference{
+								{
+									Name:      gatewayv1.ObjectName("shared-" + faker.New().Lorem().Word()),
+									Namespace: &certNamespace,
+								},
+							}},
+						},
+						{
+							Name:     "tcp",
+							Protocol: gatewayv1.TCPProtocolType,
+							TLS: &gatewayv1.ListenerTLSConfig{CertificateRefs: []gatewayv1.SecretObjectReference{
+								{Name: gatewayv1.ObjectName("ignored-" + faker.New().Lorem().Word())},
+							}},
+						},
+					},
+				},
+			}
+
+			result := model.indexListenerSetByCertificateSecrets(t.Context(), listenerSet)
+
+			require.ElementsMatch(t, []string{
+				fmt.Sprintf("%s/%s", listenerSet.Namespace, listenerSet.Spec.Listeners[0].TLS.CertificateRefs[0].Name),
+				fmt.Sprintf("%s/%s", certNamespace, listenerSet.Spec.Listeners[1].TLS.CertificateRefs[0].Name),
+			}, result)
+		})
+
+		t.Run("ignores invalid or deleting ListenerSets", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			deletionTimestamp := metav1.Now()
+			deletingListenerSet := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "apps",
+					Name:              "deleting",
+					DeletionTimestamp: &deletionTimestamp,
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{Name: "edge"}},
+			}
+			invalidKind := gatewayv1.Kind("Service")
+			invalidParentRefListenerSet := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "invalid"},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+					Kind: &invalidKind,
+					Name: "edge",
+				}},
+			}
+
+			require.Nil(t, model.indexListenerSetByParentGateway(t.Context(), &corev1.Service{}))
+			require.Nil(t, model.indexListenerSetByParentGateway(t.Context(), deletingListenerSet))
+			require.Nil(t, model.indexListenerSetByParentGateway(t.Context(), invalidParentRefListenerSet))
+			require.Nil(t, model.indexListenerSetByCertificateSecrets(t.Context(), &corev1.Service{}))
+			require.Nil(t, model.indexListenerSetByCertificateSecrets(t.Context(), deletingListenerSet))
+		})
+	})
+
 	t.Run("MapSecretToGateway", func(t *testing.T) {
 		t.Run("finds matching Gateways based on certificate index", func(t *testing.T) {
 			deps := makeMockDeps(t)
@@ -1553,6 +1803,689 @@ func TestWatchesModel(t *testing.T) {
 
 			result := model.MapSecretToGateway(t.Context(), &corev1.Service{})
 			require.Nil(t, result)
+		})
+	})
+
+	t.Run("MapSecretToGatewayWithListenerSets", func(t *testing.T) {
+		t.Run("queues parent Gateways for ListenerSets referencing the Secret", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			secret := makeRandomSecret(randomSecretWithTLSDataOpt())
+			indexKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+			parentNamespace := gatewayv1.Namespace("infra-" + faker.New().Lorem().Word())
+			parentName := gatewayv1.ObjectName("edge-" + faker.New().Lorem().Word())
+			listenerSets := []gatewayv1.ListenerSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps-" + faker.New().Lorem().Word(),
+					Name:      "listeners-" + faker.New().Lorem().Word(),
+				},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+					Namespace: &parentNamespace,
+					Name:      parentName,
+				}},
+			}}
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().List(
+				t.Context(),
+				&gatewayv1.GatewayList{},
+				client.MatchingFields{gatewayCertificateIndexKey: indexKey},
+			).RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.Gateway{}))
+				return nil
+			})
+			mockK8sClient.EXPECT().List(
+				t.Context(),
+				&gatewayv1.ListenerSetList{},
+				client.MatchingFields{listenerSetCertificateIndexKey: indexKey},
+			).RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf(listenerSets))
+				return nil
+			})
+
+			result := model.MapSecretToGatewayWithListenerSets(t.Context(), &secret)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: apitypes.NamespacedName{
+					Namespace: string(parentNamespace),
+					Name:      string(parentName),
+				},
+			}}, result)
+		})
+
+		t.Run("returns direct requests for invalid Secret inputs", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			opaqueSecret := makeRandomSecret(func(secret *corev1.Secret) {
+				secret.Type = corev1.SecretTypeOpaque
+			})
+			certOnlySecret := makeRandomSecret(func(secret *corev1.Secret) {
+				secret.Type = corev1.SecretTypeTLS
+				secret.Data = map[string][]byte{corev1.TLSCertKey: []byte("certificate")}
+			})
+			keyOnlySecret := makeRandomSecret(func(secret *corev1.Secret) {
+				secret.Type = corev1.SecretTypeTLS
+				secret.Data = map[string][]byte{corev1.TLSPrivateKeyKey: []byte("key")}
+			})
+
+			require.Nil(t, model.MapSecretToGatewayWithListenerSets(t.Context(), &corev1.Service{}))
+			require.Nil(t, model.MapSecretToGatewayWithListenerSets(t.Context(), &opaqueSecret))
+			require.Nil(t, model.MapSecretToGatewayWithListenerSets(t.Context(), &certOnlySecret))
+			require.Nil(t, model.MapSecretToGatewayWithListenerSets(t.Context(), &keyOnlySecret))
+		})
+
+		t.Run("keeps direct Gateway requests when ListenerSet lookup fails", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			secret := makeRandomSecret(randomSecretWithTLSDataOpt())
+			indexKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+			gateway := *newRandomGateway()
+			wantErr := errors.New("listenerset list failed")
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().List(
+				t.Context(),
+				&gatewayv1.GatewayList{},
+				client.MatchingFields{gatewayCertificateIndexKey: indexKey},
+			).RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.Gateway{gateway}))
+				return nil
+			})
+			mockK8sClient.EXPECT().List(
+				t.Context(),
+				&gatewayv1.ListenerSetList{},
+				client.MatchingFields{listenerSetCertificateIndexKey: indexKey},
+			).Return(wantErr)
+
+			result := model.MapSecretToGatewayWithListenerSets(t.Context(), &secret)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: client.ObjectKeyFromObject(&gateway),
+			}}, result)
+		})
+	})
+
+	t.Run("MapSecretToListenerSet", func(t *testing.T) {
+		t.Run("queues ListenerSets referencing the Secret", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			secret := makeRandomSecret(randomSecretWithTLSDataOpt())
+			indexKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+			}
+			deletedAt := metav1.Now()
+			deletingListenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "apps",
+					Name:              "deleting",
+					DeletionTimestamp: &deletedAt,
+				},
+			}
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().List(
+				t.Context(),
+				&gatewayv1.ListenerSetList{},
+				client.MatchingFields{listenerSetCertificateIndexKey: indexKey},
+			).RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.ListenerSet{
+					listenerSet,
+					deletingListenerSet,
+				}))
+				return nil
+			})
+
+			result := model.MapSecretToListenerSet(t.Context(), &secret)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: client.ObjectKeyFromObject(&listenerSet),
+			}}, result)
+		})
+
+		t.Run("ignores invalid Secret inputs", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			opaqueSecret := makeRandomSecret(func(secret *corev1.Secret) {
+				secret.Type = corev1.SecretTypeOpaque
+			})
+			certOnlySecret := makeRandomSecret(func(secret *corev1.Secret) {
+				secret.Type = corev1.SecretTypeTLS
+				secret.Data = map[string][]byte{corev1.TLSCertKey: []byte("certificate")}
+			})
+			keyOnlySecret := makeRandomSecret(func(secret *corev1.Secret) {
+				secret.Type = corev1.SecretTypeTLS
+				secret.Data = map[string][]byte{corev1.TLSPrivateKeyKey: []byte("key")}
+			})
+
+			require.Nil(t, model.MapSecretToListenerSet(t.Context(), &corev1.Service{}))
+			require.Nil(t, model.MapSecretToListenerSet(t.Context(), &opaqueSecret))
+			require.Nil(t, model.MapSecretToListenerSet(t.Context(), &certOnlySecret))
+			require.Nil(t, model.MapSecretToListenerSet(t.Context(), &keyOnlySecret))
+		})
+
+		t.Run("handles list errors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			secret := makeRandomSecret(randomSecretWithTLSDataOpt())
+			indexKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().List(
+				t.Context(),
+				&gatewayv1.ListenerSetList{},
+				client.MatchingFields{listenerSetCertificateIndexKey: indexKey},
+			).Return(errors.New("listenerset list failed"))
+
+			require.Nil(t, model.MapSecretToListenerSet(t.Context(), &secret))
+		})
+	})
+
+	t.Run("MapListenerSetToGateway", func(t *testing.T) {
+		t.Run("queues parent Gateway", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			parentNamespace := gatewayv1.Namespace("infra-" + faker.New().Lorem().Word())
+			parentName := gatewayv1.ObjectName("edge-" + faker.New().Lorem().Word())
+			listenerSet := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+					Namespace: &parentNamespace,
+					Name:      parentName,
+				}},
+			}
+
+			result := model.MapListenerSetToGateway(t.Context(), listenerSet)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: apitypes.NamespacedName{Namespace: string(parentNamespace), Name: string(parentName)},
+			}}, result)
+		})
+
+		t.Run("queues current and previous parent Gateways", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			parentNamespace := gatewayv1.Namespace("infra-" + faker.New().Lorem().Word())
+			parentName := gatewayv1.ObjectName("edge-" + faker.New().Lorem().Word())
+			previousParent := "old-infra/old-edge"
+			listenerSet := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps",
+					Name:      "extra",
+					Annotations: map[string]string{
+						ListenerSetParentGatewayAnnotation: previousParent,
+					},
+				},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+					Namespace: &parentNamespace,
+					Name:      parentName,
+				}},
+			}
+
+			result := model.MapListenerSetToGateway(t.Context(), listenerSet)
+
+			require.ElementsMatch(t, []reconcile.Request{
+				{NamespacedName: apitypes.NamespacedName{Namespace: string(parentNamespace), Name: string(parentName)}},
+				{NamespacedName: apitypes.NamespacedName{Namespace: "old-infra", Name: "old-edge"}},
+			}, result)
+		})
+
+		t.Run("ignores invalid inputs and parent refs", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			invalidKind := gatewayv1.Kind("Service")
+			listenerSet := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{ParentRef: gatewayv1.ParentGatewayReference{
+					Kind: &invalidKind,
+					Name: "edge",
+				}},
+			}
+
+			require.Nil(t, model.MapListenerSetToGateway(t.Context(), listenerSet))
+			require.Nil(t, model.MapListenerSetToGateway(t.Context(), &corev1.Service{}))
+		})
+	})
+
+	t.Run("MapGatewayToListenerSet", func(t *testing.T) {
+		t.Run("queues attached ListenerSets", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			gateway := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}}
+			listenerSet := gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"}}
+			deletedAt := metav1.Now()
+			deletingListenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "apps",
+					Name:              "deleting",
+					DeletionTimestamp: &deletedAt,
+				},
+			}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}, client.MatchingFields{
+					listenerSetParentGatewayIndexKey: client.ObjectKeyFromObject(gateway).String(),
+				}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.ListenerSet{
+						listenerSet,
+						deletingListenerSet,
+					}))
+					return nil
+				})
+
+			result := model.MapGatewayToListenerSet(t.Context(), gateway)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: client.ObjectKeyFromObject(&listenerSet),
+			}}, result)
+			require.Nil(t, model.MapGatewayToListenerSet(t.Context(), &corev1.Service{}))
+		})
+
+		t.Run("handles list errors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			gateway := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "edge"}}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}, mock.Anything).
+				Return(errors.New("listenerset list failed"))
+
+			require.Nil(t, model.MapGatewayToListenerSet(t.Context(), gateway))
+		})
+	})
+
+	t.Run("MapNamespaceToListenerSet", func(t *testing.T) {
+		t.Run("queues ListenerSets in changed namespace", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}}
+			listenerSet := gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"}}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}, client.InNamespace("apps")).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.ListenerSet{
+						listenerSet,
+					}))
+					return nil
+				})
+
+			result := model.MapNamespaceToListenerSet(t.Context(), namespace)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: client.ObjectKeyFromObject(&listenerSet),
+			}}, result)
+			require.Nil(t, model.MapNamespaceToListenerSet(t.Context(), &gatewayv1.Gateway{}))
+		})
+
+		t.Run("handles list errors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}, client.InNamespace("apps")).
+				Return(errors.New("listenerset list failed"))
+
+			require.Nil(t, model.MapNamespaceToListenerSet(t.Context(), namespace))
+		})
+	})
+
+	t.Run("MapReferenceGrantToGatewayWithListenerSets", func(t *testing.T) {
+		t.Run("queues parent Gateways for matching ListenerSet certificateRefs", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			certNamespace := gatewayv1.Namespace("certs")
+			parentNamespace := gatewayv1.Namespace("infra")
+			parentName := gatewayv1.ObjectName("edge")
+			grant := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Namespace: string(certNamespace), Name: "allow"},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{{
+						Group:     gatewayv1.Group(gatewayAPIGroup),
+						Kind:      gatewayv1.Kind("ListenerSet"),
+						Namespace: gatewayv1.Namespace("apps"),
+					}},
+					To: []gatewayv1beta1.ReferenceGrantTo{{
+						Group: gatewayv1.Group(""),
+						Kind:  gatewayv1.Kind("Secret"),
+						Name:  lo.ToPtr(gatewayv1.ObjectName("tls-cert")),
+					}},
+				},
+			}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Namespace: &parentNamespace,
+						Name:      parentName,
+					},
+					Listeners: []gatewayv1.ListenerEntry{{
+						Name:     "https",
+						Protocol: gatewayv1.HTTPSProtocolType,
+						Port:     443,
+						TLS: &gatewayv1.ListenerTLSConfig{CertificateRefs: []gatewayv1.SecretObjectReference{{
+							Namespace: &certNamespace,
+							Name:      "tls-cert",
+						}}},
+					}},
+				},
+			}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.ListenerSet{
+						listenerSet,
+					}))
+					return nil
+				})
+
+			result := model.MapReferenceGrantToGatewayWithListenerSets(t.Context(), grant)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: apitypes.NamespacedName{Namespace: string(parentNamespace), Name: string(parentName)},
+			}}, result)
+		})
+
+		t.Run("ignores non matching grants and handles list errors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			serviceGrant := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "certs", Name: "allow"},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{{
+						Group:     gatewayv1.Group(gatewayAPIGroup),
+						Kind:      gatewayv1.Kind("ListenerSet"),
+						Namespace: gatewayv1.Namespace("apps"),
+					}},
+					To: []gatewayv1beta1.ReferenceGrantTo{{
+						Group: gatewayv1.Group(""),
+						Kind:  gatewayv1.Kind(serviceKind),
+					}},
+				},
+			}
+			require.Nil(t, model.MapReferenceGrantToGatewayWithListenerSets(t.Context(), serviceGrant))
+			require.Nil(t, model.MapReferenceGrantToGatewayWithListenerSets(t.Context(), &corev1.Service{}))
+
+			secretGrant := serviceGrant.DeepCopy()
+			secretGrant.Spec.To[0].Kind = gatewayv1.Kind("Secret")
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				Return(errors.New("listenerset list failed"))
+
+			require.Nil(t, model.MapReferenceGrantToGatewayWithListenerSets(t.Context(), secretGrant))
+		})
+	})
+
+	t.Run("MapReferenceGrantToListenerSet", func(t *testing.T) {
+		t.Run("queues ListenerSets for matching certificateRefs", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			certNamespace := gatewayv1.Namespace("certs")
+			grant := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Namespace: string(certNamespace), Name: "allow"},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{{
+						Group:     gatewayv1.Group(gatewayAPIGroup),
+						Kind:      gatewayv1.Kind("ListenerSet"),
+						Namespace: gatewayv1.Namespace("apps"),
+					}},
+					To: []gatewayv1beta1.ReferenceGrantTo{{
+						Group: gatewayv1.Group(""),
+						Kind:  gatewayv1.Kind("Secret"),
+						Name:  lo.ToPtr(gatewayv1.ObjectName("tls-cert")),
+					}},
+				},
+			}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "extra"},
+				Spec: gatewayv1.ListenerSetSpec{
+					Listeners: []gatewayv1.ListenerEntry{{
+						Name:     "https",
+						Protocol: gatewayv1.HTTPSProtocolType,
+						Port:     443,
+						TLS: &gatewayv1.ListenerTLSConfig{CertificateRefs: []gatewayv1.SecretObjectReference{{
+							Namespace: &certNamespace,
+							Name:      "tls-cert",
+						}}},
+					}},
+				},
+			}
+			deletedAt := metav1.Now()
+			deletingListenerSet := listenerSet
+			deletingListenerSet.Name = "deleting"
+			deletingListenerSet.DeletionTimestamp = &deletedAt
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.ListenerSet{
+						listenerSet,
+						deletingListenerSet,
+					}))
+					return nil
+				})
+
+			result := model.MapReferenceGrantToListenerSet(t.Context(), grant)
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: client.ObjectKeyFromObject(&listenerSet),
+			}}, result)
+		})
+
+		t.Run("ignores non matching grants and handles list errors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			serviceGrant := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "certs", Name: "allow"},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{{
+						Group:     gatewayv1.Group(gatewayAPIGroup),
+						Kind:      gatewayv1.Kind("ListenerSet"),
+						Namespace: gatewayv1.Namespace("apps"),
+					}},
+					To: []gatewayv1beta1.ReferenceGrantTo{{
+						Group: gatewayv1.Group(""),
+						Kind:  gatewayv1.Kind(serviceKind),
+					}},
+				},
+			}
+			require.Nil(t, model.MapReferenceGrantToListenerSet(t.Context(), serviceGrant))
+			require.Nil(t, model.MapReferenceGrantToListenerSet(t.Context(), &corev1.Service{}))
+
+			secretGrant := serviceGrant.DeepCopy()
+			secretGrant.Spec.To[0].Kind = gatewayv1.Kind("Secret")
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.ListenerSetList{}).
+				Return(errors.New("listenerset list failed"))
+
+			require.Nil(t, model.MapReferenceGrantToListenerSet(t.Context(), secretGrant))
+		})
+	})
+
+	t.Run("MapListenerSetToRoutes", func(t *testing.T) {
+		makeListenerSet := func() *gatewayv1.ListenerSet {
+			return &gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "apps-" + faker.New().Lorem().Word(),
+				Name:      "listeners-" + faker.New().Lorem().Word(),
+			}}
+		}
+		listenerSetKind := gatewayv1.Kind("ListenerSet")
+
+		t.Run("queues indexed L7 and TLS routes", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			listenerSet := makeListenerSet()
+			listenerSetKey := client.ObjectKeyFromObject(listenerSet).String()
+			httpRoute := makeRandomHTTPRoute()
+			grpcRoute := makeRandomGRPCRoute()
+			tlsRoute := gatewayv1.TLSRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "routes", Name: "tls"}}
+			deletedAt := metav1.Now()
+			deletedHTTPRoute := makeRandomHTTPRoute(func(route *gatewayv1.HTTPRoute) {
+				route.DeletionTimestamp = &deletedAt
+			})
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.HTTPRouteList{},
+					client.MatchingFields{httpRouteParentGatewayIndexKey: listenerSetKey}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.HTTPRoute{
+						httpRoute,
+						deletedHTTPRoute,
+					}))
+					return nil
+				})
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.GRPCRouteList{},
+					client.MatchingFields{grpcRouteParentGatewayIndexKey: listenerSetKey}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).
+						Elem().
+						FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.GRPCRoute{grpcRoute}))
+					return nil
+				})
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.TLSRouteList{},
+					client.MatchingFields{tlsRouteParentGatewayIndexKey: listenerSetKey}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).
+						Elem().
+						FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.TLSRoute{tlsRoute}))
+					return nil
+				})
+
+			require.ElementsMatch(t,
+				[]reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(&httpRoute)}},
+				model.MapListenerSetToHTTPRoute(t.Context(), listenerSet),
+			)
+			require.ElementsMatch(t,
+				[]reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(&grpcRoute)}},
+				model.MapListenerSetToGRPCRoute(t.Context(), listenerSet),
+			)
+			require.ElementsMatch(t,
+				[]reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(&tlsRoute)}},
+				model.MapListenerSetToTLSRoute(t.Context(), listenerSet),
+			)
+			require.Nil(t, model.MapListenerSetToHTTPRoute(t.Context(), &corev1.Service{}))
+		})
+
+		t.Run("queues L4 routes with ListenerSet parent refs", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			listenerSet := makeListenerSet()
+			otherName := gatewayv1.ObjectName("other-" + faker.New().Lorem().Word())
+			tcpRoute := gatewayv1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: listenerSet.Namespace, Name: "tcp"},
+				Spec: gatewayv1.TCPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Kind: &listenerSetKind,
+						Name: gatewayv1.ObjectName(listenerSet.Name),
+					}},
+				}},
+			}
+			udpRoute := gatewayv1.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: listenerSet.Namespace, Name: "udp"},
+				Spec: gatewayv1.UDPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Kind: &listenerSetKind,
+						Name: gatewayv1.ObjectName(listenerSet.Name),
+					}},
+				}},
+			}
+			otherTCPRoute := gatewayv1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: listenerSet.Namespace, Name: "other"},
+				Spec: gatewayv1.TCPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{Kind: &listenerSetKind, Name: otherName}},
+				}},
+			}
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().List(t.Context(), &gatewayv1.TCPRouteList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf([]gatewayv1.TCPRoute{
+						tcpRoute,
+						otherTCPRoute,
+					}))
+					return nil
+				})
+			mockK8sClient.EXPECT().List(t.Context(), &gatewayv1.UDPRouteList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).
+						Elem().
+						FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.UDPRoute{udpRoute}))
+					return nil
+				})
+
+			require.ElementsMatch(t,
+				[]reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(&tcpRoute)}},
+				model.MapListenerSetToTCPRoute(t.Context(), listenerSet),
+			)
+			require.ElementsMatch(t,
+				[]reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(&udpRoute)}},
+				model.MapListenerSetToUDPRoute(t.Context(), listenerSet),
+			)
+			require.Nil(t, model.MapListenerSetToTCPRoute(t.Context(), &corev1.Service{}))
+		})
+
+		t.Run("returns nil when route list fails", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			listenerSet := makeListenerSet()
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.HTTPRouteList{},
+					client.MatchingFields{
+						httpRouteParentGatewayIndexKey: client.ObjectKeyFromObject(listenerSet).String(),
+					}).
+				Return(errors.New(faker.New().Lorem().Sentence(10)))
+
+			require.Nil(t, model.MapListenerSetToHTTPRoute(t.Context(), listenerSet))
+		})
+	})
+
+	t.Run("MapNamespaceToGateway", func(t *testing.T) {
+		t.Run("queues Gateways using allowedListeners namespace selectors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			selectedFrom := gatewayv1.NamespacesFromSelector
+			sameFrom := gatewayv1.NamespacesFromSame
+			wantGateway := *newRandomGateway(func(gateway *gatewayv1.Gateway) {
+				gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+					Namespaces: &gatewayv1.ListenerNamespaces{
+						From:     &selectedFrom,
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "media"}},
+					},
+				}
+			})
+			otherGateway := *newRandomGateway(func(gateway *gatewayv1.Gateway) {
+				gateway.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+					Namespaces: &gatewayv1.ListenerNamespaces{From: &sameFrom},
+				}
+			})
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().List(t.Context(), &gatewayv1.GatewayList{}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").
+						Set(reflect.ValueOf([]gatewayv1.Gateway{wantGateway, otherGateway}))
+					return nil
+				})
+
+			result := model.MapNamespaceToGateway(t.Context(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "apps", Labels: map[string]string{"team": "media"}},
+			})
+
+			require.ElementsMatch(t, []reconcile.Request{{
+				NamespacedName: client.ObjectKeyFromObject(&wantGateway),
+			}}, result)
 		})
 	})
 

--- a/internal/diag/slog_test.go
+++ b/internal/diag/slog_test.go
@@ -110,6 +110,11 @@ func TestDiagSlogHandler(t *testing.T) {
 			require.NoError(t, err)
 			assert.Contains(t, string(output), message)
 		})
+		t.Run("should panic when optional output file cannot be opened", func(t *testing.T) {
+			require.Panics(t, func() {
+				NewRootLoggerOpts().WithOptionalOutputFile(t.TempDir())
+			})
+		})
 	})
 }
 

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -36,6 +36,7 @@ type StartManagerDeps struct {
 	GatewayClassCtrl *app.GatewayClassController
 	GatewayCtrl      *app.GatewayController
 	NLBGatewayCtrl   *app.NetworkLoadBalancerGatewayController
+	ListenerSetCtrl  *app.ListenerSetController
 	HTTPRouteCtrl    *app.HTTPRouteController
 	GRPCRouteCtrl    *app.GRPCRouteController
 	TCPRouteCtrl     *app.TCPRouteController
@@ -61,6 +62,7 @@ type experimentalRouteCapabilities struct {
 	TCPRoute         bool
 	UDPRoute         bool
 	BackendTLSPolicy bool
+	ListenerSet      bool
 }
 
 type resolvedExperimentalRouteCapabilities struct {
@@ -68,6 +70,7 @@ type resolvedExperimentalRouteCapabilities struct {
 	reconcileUDPRoute         bool
 	reconcileBackendTLSPolicy bool
 	backendTLSPolicyAvailable bool
+	listenerSetAvailable      bool
 }
 
 type setupL4RouteControllerParams struct {
@@ -76,6 +79,7 @@ type setupL4RouteControllerParams struct {
 	mapEndpoint         handler.MapFunc
 	mapGrant            handler.MapFunc
 	mapGateway          handler.MapFunc
+	mapListenerSet      handler.MapFunc
 	mapSecret           handler.MapFunc
 	mapBackendTLSPolicy handler.MapFunc
 	mapConfigMap        handler.MapFunc
@@ -89,6 +93,7 @@ type setupL7RouteControllerParams struct {
 	mapEndpoint                handler.MapFunc
 	pairedRoute                client.Object
 	mapPairedRoute             handler.MapFunc
+	mapListenerSetToRoute      handler.MapFunc
 	mapBackendTLSPolicyToRoute handler.MapFunc
 	mapConfigMapToRoute        handler.MapFunc
 	mapServiceToRoute          handler.MapFunc
@@ -119,7 +124,6 @@ func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRo
 	tcpRouteAvailable, err := resourceKindAvailable(
 		mapper,
 		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "TCPRoute"},
-		"v1",
 	)
 	if err != nil {
 		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect TCPRoute availability: %w", err)
@@ -128,7 +132,6 @@ func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRo
 	udpRouteAvailable, err := resourceKindAvailable(
 		mapper,
 		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "UDPRoute"},
-		"v1",
 	)
 	if err != nil {
 		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect UDPRoute availability: %w", err)
@@ -136,21 +139,28 @@ func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRo
 	backendTLSPolicyAvailable, err := resourceKindAvailable(
 		mapper,
 		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "BackendTLSPolicy"},
-		"v1",
 	)
 	if err != nil {
 		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect BackendTLSPolicy availability: %w", err)
+	}
+	listenerSetAvailable, err := resourceKindAvailable(
+		mapper,
+		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "ListenerSet"},
+	)
+	if err != nil {
+		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect ListenerSet availability: %w", err)
 	}
 
 	return experimentalRouteCapabilities{
 		TCPRoute:         tcpRouteAvailable,
 		UDPRoute:         udpRouteAvailable,
 		BackendTLSPolicy: backendTLSPolicyAvailable,
+		ListenerSet:      listenerSetAvailable,
 	}, nil
 }
 
-func resourceKindAvailable(mapper meta.RESTMapper, groupKind schema.GroupKind, version string) (bool, error) {
-	if _, err := mapper.RESTMapping(groupKind, version); err != nil {
+func resourceKindAvailable(mapper meta.RESTMapper, groupKind schema.GroupKind) (bool, error) {
+	if _, err := mapper.RESTMapping(groupKind, "v1"); err != nil {
 		if meta.IsNoMatchError(err) {
 			return false, nil
 		}
@@ -191,12 +201,16 @@ func resolveExperimentalRouteCapabilities(
 	if deps.ReconcileBackendTLSPolicy && !experimentalRouteCRDs.BackendTLSPolicy {
 		logger.InfoContext(ctx, "BackendTLSPolicy CRD is not installed; BackendTLSPolicy support is disabled")
 	}
+	if !experimentalRouteCRDs.ListenerSet {
+		logger.InfoContext(ctx, "ListenerSet CRD is not installed; ListenerSet support is disabled")
+	}
 
 	return resolvedExperimentalRouteCapabilities{
 		reconcileTCPRoute:         deps.ReconcileTCPRoute && experimentalRouteCRDs.TCPRoute,
 		reconcileUDPRoute:         deps.ReconcileUDPRoute && experimentalRouteCRDs.UDPRoute,
 		reconcileBackendTLSPolicy: deps.ReconcileBackendTLSPolicy && experimentalRouteCRDs.BackendTLSPolicy,
 		backendTLSPolicyAvailable: experimentalRouteCRDs.BackendTLSPolicy,
+		listenerSetAvailable:      experimentalRouteCRDs.ListenerSet,
 	}, nil
 }
 
@@ -234,6 +248,13 @@ func setupL4RouteController(
 			builder.WithPredicates(gatewaySecretPredicate()),
 		)
 	}
+	if params.mapListenerSet != nil {
+		controllerBuilder = controllerBuilder.Watches(
+			&gatewayv1.ListenerSet{},
+			handler.EnqueueRequestsFromMapFunc(params.mapListenerSet),
+			builder.WithPredicates(l4RouteObjectPredicate()),
+		)
+	}
 	if enableBackendTLSPolicy && params.name == "tlsroute" {
 		controllerBuilder = controllerBuilder.
 			Watches(
@@ -258,6 +279,7 @@ func setupL4RouteController(
 func coreControllerSetupTasks(
 	mgr manager.Manager,
 	deps StartManagerDeps,
+	experimentalRoutes resolvedExperimentalRouteCapabilities,
 	middlewares []controllerMiddleware[reconcile.Request],
 ) []controllerSetupTask {
 	return []controllerSetupTask{
@@ -278,26 +300,7 @@ func coreControllerSetupTasks(
 			disabledLog: "Gateway controller is disabled",
 			setupErr:    "failed to setup Gateway controller: %w",
 			setup: func() error {
-				return builder.ControllerManagedBy(mgr).
-					Named("gateway").
-					For(
-						&gatewayv1.Gateway{},
-
-						// Applying predicates just on the gateway level. Secrets do not have generation incremented
-						// so secret updates will not trigger a reconciliation.
-						builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
-					).
-					Watches(
-						&corev1.Secret{},
-						handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapSecretToGateway),
-						builder.WithPredicates(gatewaySecretPredicate()),
-					).
-					Watches(
-						&configtypes.GatewayConfig{},
-						handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGatewayConfigToGateway),
-						builder.WithPredicates(predicate.GenerationChangedPredicate{}),
-					).
-					Complete(wireupReconciler(deps.GatewayCtrl, middlewares...))
+				return setupGatewayController(mgr, deps, experimentalRoutes.listenerSetAvailable, middlewares)
 			},
 		},
 		{
@@ -305,21 +308,136 @@ func coreControllerSetupTasks(
 			disabledLog: "Network Load Balancer Gateway controller is disabled",
 			setupErr:    "failed to setup Network Load Balancer Gateway controller: %w",
 			setup: func() error {
-				return builder.ControllerManagedBy(mgr).
-					Named("networkloadbalancer-gateway").
-					For(
-						&gatewayv1.Gateway{},
-						builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
-					).
-					Watches(
-						&configtypes.GatewayConfig{},
-						handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGatewayConfigToGateway),
-						builder.WithPredicates(predicate.GenerationChangedPredicate{}),
-					).
-					Complete(wireupReconciler(deps.NLBGatewayCtrl, middlewares...))
+				return setupNetworkLoadBalancerGatewayController(
+					mgr,
+					deps,
+					experimentalRoutes.listenerSetAvailable,
+					middlewares,
+				)
 			},
 		},
 	}
+}
+
+func listenerSetControllerSetupTasks(
+	mgr manager.Manager,
+	deps StartManagerDeps,
+	experimentalRoutes resolvedExperimentalRouteCapabilities,
+	middlewares []controllerMiddleware[reconcile.Request],
+) []controllerSetupTask {
+	return []controllerSetupTask{{
+		enabled:     experimentalRoutes.listenerSetAvailable,
+		disabledLog: "ListenerSet controller is disabled because the ListenerSet CRD is not installed",
+		setupErr:    "failed to setup ListenerSet controller: %w",
+		setup: func() error {
+			return builder.ControllerManagedBy(mgr).
+				Named("listenerset").
+				For(
+					&gatewayv1.ListenerSet{},
+					builder.WithPredicates(l4RouteObjectPredicate()),
+				).
+				Watches(
+					&gatewayv1.Gateway{},
+					handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGatewayToListenerSet),
+					builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
+				).
+				Watches(
+					&corev1.Namespace{},
+					handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapNamespaceToListenerSet),
+					builder.WithPredicates(predicate.LabelChangedPredicate{}),
+				).
+				Watches(
+					&corev1.Secret{},
+					handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapSecretToListenerSet),
+					builder.WithPredicates(gatewaySecretPredicate()),
+				).
+				Watches(
+					&gatewayv1beta1.ReferenceGrant{},
+					handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapReferenceGrantToListenerSet),
+					builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+				).
+				Complete(wireupReconciler(deps.ListenerSetCtrl, middlewares...))
+		},
+	}}
+}
+
+func setupGatewayController(
+	mgr manager.Manager,
+	deps StartManagerDeps,
+	listenerSetAvailable bool,
+	middlewares []controllerMiddleware[reconcile.Request],
+) error {
+	deps.GatewayCtrl.SetListenerSetEnabled(listenerSetAvailable)
+	secretMapper := deps.WatchesModel.MapSecretToGateway
+	if listenerSetAvailable {
+		secretMapper = deps.WatchesModel.MapSecretToGatewayWithListenerSets
+	}
+	controllerBuilder := builder.ControllerManagedBy(mgr).
+		Named("gateway").
+		For(
+			&gatewayv1.Gateway{},
+			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
+		).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(secretMapper),
+			builder.WithPredicates(gatewaySecretPredicate()),
+		).
+		Watches(
+			&configtypes.GatewayConfig{},
+			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGatewayConfigToGateway),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
+	controllerBuilder = watchListenerSetGatewayObjects(controllerBuilder, deps, listenerSetAvailable)
+	return controllerBuilder.Complete(wireupReconciler(deps.GatewayCtrl, middlewares...))
+}
+
+func setupNetworkLoadBalancerGatewayController(
+	mgr manager.Manager,
+	deps StartManagerDeps,
+	listenerSetAvailable bool,
+	middlewares []controllerMiddleware[reconcile.Request],
+) error {
+	deps.NLBGatewayCtrl.SetListenerSetEnabled(listenerSetAvailable)
+	controllerBuilder := builder.ControllerManagedBy(mgr).
+		Named("networkloadbalancer-gateway").
+		For(
+			&gatewayv1.Gateway{},
+			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
+		).
+		Watches(
+			&configtypes.GatewayConfig{},
+			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGatewayConfigToGateway),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
+	controllerBuilder = watchListenerSetGatewayObjects(controllerBuilder, deps, listenerSetAvailable)
+	return controllerBuilder.Complete(wireupReconciler(deps.NLBGatewayCtrl, middlewares...))
+}
+
+func watchListenerSetGatewayObjects(
+	controllerBuilder *builder.Builder,
+	deps StartManagerDeps,
+	listenerSetAvailable bool,
+) *builder.Builder {
+	if !listenerSetAvailable {
+		return controllerBuilder
+	}
+	return controllerBuilder.
+		Watches(
+			&gatewayv1.ListenerSet{},
+			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapListenerSetToGateway),
+			builder.WithPredicates(l4RouteObjectPredicate()),
+		).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapNamespaceToGateway),
+			builder.WithPredicates(predicate.LabelChangedPredicate{}),
+		).
+		Watches(
+			&gatewayv1beta1.ReferenceGrant{},
+			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapReferenceGrantToGatewayWithListenerSets),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
 }
 
 func l7AndTLSControllerSetupTasks(
@@ -335,7 +453,13 @@ func l7AndTLSControllerSetupTasks(
 			setupErr:    "failed to setup HTTPRoute controller: %w",
 			setup: func() error {
 				deps.HTTPRouteCtrl.SetBackendTLSPolicyEnabled(experimentalRoutes.reconcileBackendTLSPolicy)
-				return setupHTTPRouteController(mgr, deps, experimentalRoutes.reconcileBackendTLSPolicy, middlewares)
+				return setupHTTPRouteController(
+					mgr,
+					deps,
+					experimentalRoutes.reconcileBackendTLSPolicy,
+					experimentalRoutes.listenerSetAvailable,
+					middlewares,
+				)
 			},
 		},
 		{
@@ -344,7 +468,13 @@ func l7AndTLSControllerSetupTasks(
 			setupErr:    "failed to setup GRPCRoute controller: %w",
 			setup: func() error {
 				deps.GRPCRouteCtrl.SetBackendTLSPolicyEnabled(experimentalRoutes.reconcileBackendTLSPolicy)
-				return setupGRPCRouteController(mgr, deps, experimentalRoutes.reconcileBackendTLSPolicy, middlewares)
+				return setupGRPCRouteController(
+					mgr,
+					deps,
+					experimentalRoutes.reconcileBackendTLSPolicy,
+					experimentalRoutes.listenerSetAvailable,
+					middlewares,
+				)
 			},
 		},
 		{
@@ -354,12 +484,16 @@ func l7AndTLSControllerSetupTasks(
 			setup: func() error {
 				deps.TLSRouteCtrl.SetBackendTLSPolicyEnabled(experimentalRoutes.reconcileBackendTLSPolicy)
 				return setupL4RouteController(mgr, setupL4RouteControllerParams{
-					name:                "tlsroute",
-					route:               &gatewayv1.TLSRoute{},
-					mapEndpoint:         deps.WatchesModel.MapEndpointSliceToTLSRoute,
-					mapGrant:            deps.WatchesModel.MapReferenceGrantToTLSRoute,
-					mapGateway:          deps.WatchesModel.MapGatewayToTLSRoute,
-					mapSecret:           deps.WatchesModel.MapSecretToTLSRoute,
+					name:        "tlsroute",
+					route:       &gatewayv1.TLSRoute{},
+					mapEndpoint: deps.WatchesModel.MapEndpointSliceToTLSRoute,
+					mapGrant:    deps.WatchesModel.MapReferenceGrantToTLSRoute,
+					mapGateway:  deps.WatchesModel.MapGatewayToTLSRoute,
+					mapSecret:   deps.WatchesModel.MapSecretToTLSRoute,
+					mapListenerSet: listenerSetMapper(
+						experimentalRoutes.listenerSetAvailable,
+						deps.WatchesModel.MapListenerSetToTLSRoute,
+					),
 					mapBackendTLSPolicy: deps.WatchesModel.MapBackendTLSPolicyToTLSRoute,
 					mapConfigMap:        deps.WatchesModel.MapConfigMapToTLSRoute,
 					mapService:          deps.WatchesModel.MapServiceToTLSRoute,
@@ -385,6 +519,7 @@ func setupHTTPRouteController(
 	mgr manager.Manager,
 	deps StartManagerDeps,
 	enableBackendTLSPolicy bool,
+	enableListenerSet bool,
 	middlewares []controllerMiddleware[reconcile.Request],
 ) error {
 	return setupL7RouteController(mgr, setupL7RouteControllerParams{
@@ -393,6 +528,7 @@ func setupHTTPRouteController(
 		mapEndpoint:                deps.WatchesModel.MapEndpointSliceToHTTPRoute,
 		pairedRoute:                &gatewayv1.GRPCRoute{},
 		mapPairedRoute:             deps.WatchesModel.MapGRPCRouteToHTTPRoute,
+		mapListenerSetToRoute:      listenerSetMapper(enableListenerSet, deps.WatchesModel.MapListenerSetToHTTPRoute),
 		mapBackendTLSPolicyToRoute: deps.WatchesModel.MapBackendTLSPolicyToHTTPRoute,
 		mapConfigMapToRoute:        deps.WatchesModel.MapConfigMapToHTTPRoute,
 		mapServiceToRoute:          deps.WatchesModel.MapServiceToHTTPRoute,
@@ -404,6 +540,7 @@ func setupGRPCRouteController(
 	mgr manager.Manager,
 	deps StartManagerDeps,
 	enableBackendTLSPolicy bool,
+	enableListenerSet bool,
 	middlewares []controllerMiddleware[reconcile.Request],
 ) error {
 	return setupL7RouteController(mgr, setupL7RouteControllerParams{
@@ -412,6 +549,7 @@ func setupGRPCRouteController(
 		mapEndpoint:                deps.WatchesModel.MapEndpointSliceToGRPCRoute,
 		pairedRoute:                &gatewayv1.HTTPRoute{},
 		mapPairedRoute:             deps.WatchesModel.MapHTTPRouteToGRPCRoute,
+		mapListenerSetToRoute:      listenerSetMapper(enableListenerSet, deps.WatchesModel.MapListenerSetToGRPCRoute),
 		mapBackendTLSPolicyToRoute: deps.WatchesModel.MapBackendTLSPolicyToGRPCRoute,
 		mapConfigMapToRoute:        deps.WatchesModel.MapConfigMapToGRPCRoute,
 		mapServiceToRoute:          deps.WatchesModel.MapServiceToGRPCRoute,
@@ -456,7 +594,21 @@ func setupL7RouteController(
 				builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 			)
 	}
+	if params.mapListenerSetToRoute != nil {
+		controllerBuilder = controllerBuilder.Watches(
+			&gatewayv1.ListenerSet{},
+			handler.EnqueueRequestsFromMapFunc(params.mapListenerSetToRoute),
+			builder.WithPredicates(l4RouteObjectPredicate()),
+		)
+	}
 	return controllerBuilder.Complete(wireupReconciler(params.reconciler, middlewares...))
+}
+
+func listenerSetMapper(enabled bool, mapper handler.MapFunc) handler.MapFunc {
+	if !enabled {
+		return nil
+	}
+	return mapper
 }
 
 func l4RouteControllerSetupTasks(
@@ -477,7 +629,11 @@ func l4RouteControllerSetupTasks(
 					mapEndpoint: deps.WatchesModel.MapEndpointSliceToTCPRoute,
 					mapGrant:    deps.WatchesModel.MapReferenceGrantToTCPRoute,
 					mapGateway:  deps.WatchesModel.MapGatewayToTCPRoute,
-					reconciler:  deps.TCPRouteCtrl,
+					mapListenerSet: listenerSetMapper(
+						experimentalRoutes.listenerSetAvailable,
+						deps.WatchesModel.MapListenerSetToTCPRoute,
+					),
+					reconciler: deps.TCPRouteCtrl,
 				}, false, middlewares...)
 			},
 		},
@@ -492,7 +648,11 @@ func l4RouteControllerSetupTasks(
 					mapEndpoint: deps.WatchesModel.MapEndpointSliceToUDPRoute,
 					mapGrant:    deps.WatchesModel.MapReferenceGrantToUDPRoute,
 					mapGateway:  deps.WatchesModel.MapGatewayToUDPRoute,
-					reconciler:  deps.UDPRouteCtrl,
+					mapListenerSet: listenerSetMapper(
+						experimentalRoutes.listenerSetAvailable,
+						deps.WatchesModel.MapListenerSetToUDPRoute,
+					),
+					reconciler: deps.UDPRouteCtrl,
 				}, false, middlewares...)
 			},
 		},
@@ -536,9 +696,10 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error {
 	}
 
 	if err := deps.WatchesModel.RegisterFieldIndexers(ctx, mgr.GetFieldIndexer(), app.RegisterFieldIndexersOptions{
-		EnableTCPRoute: experimentalRoutes.reconcileTCPRoute,
-		EnableUDPRoute: experimentalRoutes.reconcileUDPRoute,
-		EnableTLSRoute: deps.ReconcileTLSRoute,
+		EnableTCPRoute:    experimentalRoutes.reconcileTCPRoute,
+		EnableUDPRoute:    experimentalRoutes.reconcileUDPRoute,
+		EnableTLSRoute:    deps.ReconcileTLSRoute,
+		EnableListenerSet: experimentalRoutes.listenerSetAvailable,
 	}); err != nil {
 		return fmt.Errorf("failed to register field indexers: %w", err)
 	}
@@ -547,7 +708,8 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error {
 		newTracingMiddleware(),
 		newErrorHandlingMiddleware(deps.RootLogger),
 	}
-	tasks := coreControllerSetupTasks(mgr, deps, middlewares)
+	tasks := coreControllerSetupTasks(mgr, deps, experimentalRoutes, middlewares)
+	tasks = append(tasks, listenerSetControllerSetupTasks(mgr, deps, experimentalRoutes, middlewares)...)
 	tasks = append(tasks, l7AndTLSControllerSetupTasks(mgr, deps, experimentalRoutes, middlewares)...)
 	tasks = append(tasks, l4RouteControllerSetupTasks(mgr, deps, experimentalRoutes, middlewares)...)
 	if err := runControllerSetupTasks(loggerCtx, logger, tasks); err != nil {

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -256,7 +256,7 @@ func setupL4RouteController(
 		controllerBuilder = controllerBuilder.Watches(
 			&gatewayv1.ListenerSet{},
 			handler.EnqueueRequestsFromMapFunc(params.mapListenerSet),
-			builder.WithPredicates(l4RouteObjectPredicate()),
+			builder.WithPredicates(listenerSetRouteObjectPredicate()),
 		)
 	}
 	if enableBackendTLSPolicy && params.name == "tlsroute" {

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -120,6 +120,10 @@ func l4RouteObjectPredicate() predicate.Funcs {
 	}
 }
 
+func listenerSetRouteObjectPredicate() predicate.ResourceVersionChangedPredicate {
+	return predicate.ResourceVersionChangedPredicate{}
+}
+
 func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRouteCapabilities, error) {
 	tcpRouteAvailable, err := resourceKindAvailable(
 		mapper,
@@ -598,7 +602,7 @@ func setupL7RouteController(
 		controllerBuilder = controllerBuilder.Watches(
 			&gatewayv1.ListenerSet{},
 			handler.EnqueueRequestsFromMapFunc(params.mapListenerSetToRoute),
-			builder.WithPredicates(l4RouteObjectPredicate()),
+			builder.WithPredicates(listenerSetRouteObjectPredicate()),
 		)
 	}
 	return controllerBuilder.Complete(wireupReconciler(params.reconciler, middlewares...))

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -118,29 +118,28 @@ func TestL4RouteObjectPredicate(t *testing.T) {
 }
 
 func TestDetectExperimentalRouteCapabilities(t *testing.T) {
-	t.Run("detects TCPRoute and UDPRoute", func(t *testing.T) {
+	t.Run("detects TCPRoute UDPRoute BackendTLSPolicy and ListenerSet", func(t *testing.T) {
 		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
 			{Group: gatewayv1.GroupName, Version: "v1"},
 		})
-		mapper.Add(schema.GroupVersionKind{
-			Group:   gatewayv1.GroupName,
-			Version: "v1",
-			Kind:    "TCPRoute",
-		}, meta.RESTScopeNamespace)
-		mapper.Add(schema.GroupVersionKind{
-			Group:   gatewayv1.GroupName,
-			Version: "v1",
-			Kind:    "UDPRoute",
-		}, meta.RESTScopeNamespace)
+		for _, kind := range []string{"TCPRoute", "UDPRoute", "BackendTLSPolicy", "ListenerSet"} {
+			mapper.Add(schema.GroupVersionKind{
+				Group:   gatewayv1.GroupName,
+				Version: "v1",
+				Kind:    kind,
+			}, meta.RESTScopeNamespace)
+		}
 
 		got, err := detectExperimentalRouteCapabilities(mapper)
 
 		require.NoError(t, err)
 		assert.True(t, got.TCPRoute)
 		assert.True(t, got.UDPRoute)
+		assert.True(t, got.BackendTLSPolicy)
+		assert.True(t, got.ListenerSet)
 	})
 
-	t.Run("treats missing routes as unavailable", func(t *testing.T) {
+	t.Run("treats missing optional Gateway API resources as unavailable", func(t *testing.T) {
 		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
 			{Group: gatewayv1.GroupName, Version: "v1"},
 		})
@@ -150,6 +149,8 @@ func TestDetectExperimentalRouteCapabilities(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, got.TCPRoute)
 		assert.False(t, got.UDPRoute)
+		assert.False(t, got.BackendTLSPolicy)
+		assert.False(t, got.ListenerSet)
 	})
 
 	t.Run("returns non discovery errors", func(t *testing.T) {
@@ -160,6 +161,8 @@ func TestDetectExperimentalRouteCapabilities(t *testing.T) {
 		require.ErrorIs(t, err, wantErr)
 		assert.False(t, got.TCPRoute)
 		assert.False(t, got.UDPRoute)
+		assert.False(t, got.BackendTLSPolicy)
+		assert.False(t, got.ListenerSet)
 	})
 }
 
@@ -195,6 +198,7 @@ func TestResolveExperimentalRouteCapabilities(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, got.reconcileTCPRoute)
 		assert.False(t, got.reconcileUDPRoute)
+		assert.False(t, got.listenerSetAvailable)
 	})
 
 	t.Run("keeps BackendTLSPolicy controller available for cleanup when feature is disabled", func(t *testing.T) {
@@ -219,6 +223,27 @@ func TestResolveExperimentalRouteCapabilities(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, got.reconcileBackendTLSPolicy)
 		assert.True(t, got.backendTLSPolicyAvailable)
+	})
+
+	t.Run("enables ListenerSet support when the CRD is installed", func(t *testing.T) {
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+			{Group: gatewayv1.GroupName, Version: "v1"},
+		})
+		mapper.Add(schema.GroupVersionKind{
+			Group:   gatewayv1.GroupName,
+			Version: "v1",
+			Kind:    "ListenerSet",
+		}, meta.RESTScopeNamespace)
+
+		got, err := resolveExperimentalRouteCapabilities(
+			t.Context(),
+			diag.RootTestLogger(),
+			mapper,
+			StartManagerDeps{},
+		)
+
+		require.NoError(t, err)
+		assert.True(t, got.listenerSetAvailable)
 	})
 }
 

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -42,28 +42,58 @@ func TestL7RouteObjectPredicate(t *testing.T) {
 }
 
 func TestListenerSetRouteObjectPredicate(t *testing.T) {
-	oldListenerSet := &gatewayv1.ListenerSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       "demo",
-			Name:            "extra-listeners",
-			ResourceVersion: "1",
-		},
-	}
-	newListenerSet := oldListenerSet.DeepCopy()
-	newListenerSet.ResourceVersion = "2"
-	newListenerSet.Status.Conditions = []metav1.Condition{{
-		Type:               string(gatewayv1.ListenerSetConditionAccepted),
-		Status:             metav1.ConditionTrue,
-		Reason:             string(gatewayv1.ListenerSetReasonAccepted),
-		ObservedGeneration: 1,
-	}}
+	fake := faker.New()
+	predicate := listenerSetRouteObjectPredicate()
 
-	result := listenerSetRouteObjectPredicate().Update(event.UpdateEvent{
-		ObjectOld: oldListenerSet,
-		ObjectNew: newListenerSet,
+	t.Run("accepts resource version changes", func(t *testing.T) {
+		oldListenerSet := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "demo",
+				Name:            "extra-listeners",
+				ResourceVersion: "1",
+			},
+		}
+		newListenerSet := oldListenerSet.DeepCopy()
+		newListenerSet.ResourceVersion = "2"
+		newListenerSet.Status.Conditions = []metav1.Condition{{
+			Type:               string(gatewayv1.ListenerSetConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.ListenerSetReasonAccepted),
+			ObservedGeneration: 1,
+		}}
+
+		result := predicate.Update(event.UpdateEvent{
+			ObjectOld: oldListenerSet,
+			ObjectNew: newListenerSet,
+		})
+
+		assert.True(t, result)
 	})
 
-	assert.True(t, result)
+	t.Run("accepts status only updates", func(t *testing.T) {
+		oldObj := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "listeners-" + fake.UUID().V4(),
+				Namespace:       "ns-" + fake.UUID().V4(),
+				Generation:      1,
+				ResourceVersion: fake.UUID().V4(),
+			},
+		}
+		newObj := oldObj.DeepCopy()
+		newObj.ResourceVersion = fake.UUID().V4()
+		newObj.Status.Conditions = []metav1.Condition{{
+			Type:               string(gatewayv1.ListenerSetConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerSetReasonNotAllowed),
+			ObservedGeneration: oldObj.Generation,
+			Message:            "parent gateway no longer allows this ListenerSet",
+		}}
+
+		assert.True(t, predicate.Update(event.UpdateEvent{
+			ObjectOld: oldObj,
+			ObjectNew: newObj,
+		}))
+	})
 }
 
 func TestStartManager(t *testing.T) {
@@ -139,6 +169,31 @@ func TestL4RouteObjectPredicate(t *testing.T) {
 		newObj.ResourceVersion = fake.UUID().V4()
 
 		assert.False(t, predicate.Update(updateEvent(oldObj, newObj)))
+	})
+
+	t.Run("ignores ListenerSet status only updates", func(t *testing.T) {
+		oldObj := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "listeners-" + fake.UUID().V4(),
+				Namespace:       "ns-" + fake.UUID().V4(),
+				Generation:      1,
+				ResourceVersion: fake.UUID().V4(),
+			},
+		}
+		newObj := oldObj.DeepCopy()
+		newObj.ResourceVersion = fake.UUID().V4()
+		newObj.Status.Conditions = []metav1.Condition{{
+			Type:               string(gatewayv1.ListenerSetConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.ListenerSetReasonNotAllowed),
+			ObservedGeneration: oldObj.Generation,
+			Message:            "parent gateway no longer allows this ListenerSet",
+		}}
+
+		assert.False(t, predicate.Update(event.UpdateEvent{
+			ObjectOld: oldObj,
+			ObjectNew: newObj,
+		}))
 	})
 }
 

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -41,6 +41,31 @@ func TestL7RouteObjectPredicate(t *testing.T) {
 	})
 }
 
+func TestListenerSetRouteObjectPredicate(t *testing.T) {
+	oldListenerSet := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "demo",
+			Name:            "extra-listeners",
+			ResourceVersion: "1",
+		},
+	}
+	newListenerSet := oldListenerSet.DeepCopy()
+	newListenerSet.ResourceVersion = "2"
+	newListenerSet.Status.Conditions = []metav1.Condition{{
+		Type:               string(gatewayv1.ListenerSetConditionAccepted),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gatewayv1.ListenerSetReasonAccepted),
+		ObservedGeneration: 1,
+	}}
+
+	result := listenerSetRouteObjectPredicate().Update(event.UpdateEvent{
+		ObjectOld: oldListenerSet,
+		ObjectNew: newListenerSet,
+	})
+
+	assert.True(t, result)
+}
+
 func TestStartManager(t *testing.T) {
 	t.Run("gatewaySecretPredicate", func(t *testing.T) {
 		t.Run("allows TLS Secret create events to reach Gateway mapping", func(t *testing.T) {


### PR DESCRIPTION
## Adds Gateway API `ListenerSet` support for OCI Load Balancer and OCI Network Load Balancer Gateways.

`ListenerSet` allows additional listeners to attach to an existing `Gateway` when the parent Gateway opts in with `spec.allowedListeners`. The controller now resolves Gateway and ListenerSet listeners together,
applies deterministic conflict handling, updates ListenerSet status, supports routes targeting `parentRef.kind: ListenerSet`, and reconciles ListenerSet-originated OCI listeners with stable generated OCI names.

Supported combinations:
- OCI Load Balancer: `HTTP`, `HTTPS`, and `TLS` terminate listeners
- OCI Network Load Balancer: `TCP`, `UDP`, and `TLS` passthrough listeners

This also adds:
- Optional ListenerSet CRD detection so clusters without ListenerSet do not fail startup
- RBAC for `listenersets` and `listenersets/status`
- Secret and ReferenceGrant watches for ListenerSet certificateRefs
- README updates and example manifests

Closes #73

### Example:
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: shared-nlb
  namespace: infra
spec:
  gatewayClassName: oci-nlb
  allowedListeners:
    namespaces:
      from: All
  infrastructure:
    parametersRef:
      group: oke-gateway-api.gemyago.github.io
      kind: GatewayConfig
      name: shared-nlb-config
---
apiVersion: gateway.networking.k8s.io/v1
kind: ListenerSet
metadata:
  name: iot-listeners
  namespace: apps
spec:
  parentRef:
    namespace: infra
    name: shared-nlb
  listeners:
    - name: rtmp
      protocol: TCP
      port: 1935
    - name: coap-dtls
      protocol: UDP
      port: 5684
---
apiVersion: gateway.networking.k8s.io/v1
kind: TCPRoute
metadata:
  name: rtmp
  namespace: apps
spec:
  parentRefs:
    - kind: ListenerSet
      name: iot-listeners
      sectionName: rtmp
  rules:
    - backendRefs:
        - name: rtmp-service
          port: 1935
```