### PR TITLE
Add frontend mutual TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Gateway listener TLS options can configure OCI Load Balancer frontend cipher sui
 
 OCI documents supported predefined cipher suite names in [Predefined Load Balancer Cipher Suites](https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingciphersuites_topic-Predefined_Cipher_Suites.htm). OCI SSL configuration accepts `TLSv1`, `TLSv1.1`, `TLSv1.2`, and `TLSv1.3`; see the OCI Load Balancer [`SSLConfiguration`](https://docs.oracle.com/en-us/iaas/tools/python/latest/api/load_balancer/models/oci.load_balancer.models.SSLConfiguration.html) documentation for protocol values and defaults.
 
+Gateway frontend mutual TLS is supported on OCI Load Balancer HTTPS and terminate TLS listeners through standard `Gateway.spec.tls.frontend` validation. Use `caCertificateRefs` to reference ConfigMaps containing `ca.crt`; the controller creates OCI CA bundles and programs listener peer certificate verification. Existing OCI CA bundles can be referenced with the `oci.oraclecloud.com/frontend-mtls-trusted-ca-bundle-ocids` Gateway annotation, and verify depth can be set with `oci.oraclecloud.com/frontend-mtls-verify-depth`. See [deploy/manifests/examples/gateway-https-mtls.yaml](./deploy/manifests/examples/gateway-https-mtls.yaml) and [deploy/manifests/examples/listenerset-https-mtls.yaml](./deploy/manifests/examples/listenerset-https-mtls.yaml).
+
 ## GRPCRoute With OCI Load Balancer
 
 `GRPCRoute` uses the standard Gateway API CRDs and is reconciled on OCI Load Balancer with the other layer 7 routes. It is not implemented on OCI Network Load Balancer. Use `TCPRoute` if you only need gRPC passthrough to pods.

--- a/deploy/manifests/examples/gateway-https-mtls.yaml
+++ b/deploy/manifests/examples/gateway-https-mtls.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: client-ca-bundle
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDGTCCAgGgAwIBAgIUf6q19DJQ8J7jyryakoN7w7Wx9d8wDQYJKoZIhvcNAQEL
+    BQAwHDEaMBgGA1UEAwwRZXhhbXBsZS1jbGllbnQtY2EwHhcNMjYwNzE4MjIyNjQw
+    WhcNMjcwNzE4MjIyNjQwWjAcMRowGAYDVQQDDBFleGFtcGxlLWNsaWVudC1jYTCC
+    ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKR/qFUPsVFAGm/xxU/aC50N
+    o0Yx/A0IZhnxXret+zwTz0bxPKIAZad3XJfwAgZY10SiblPNp/xokxqxzgHVn611
+    8PKPxPjy2k0/07+2RqtxJ9S4nVl2WYpIimOFDtguchsBR2xwSXKro3fsBFse6K+T
+    riyi15Dj3pZ9kIzP6JeU3hp/00AF8IrMdT5wDdW3GMeHr6Hs3gpoWtHIPoKzsZ8n
+    SaP5DmPpBjMFIfaSMic/+uqlZE0JYBzYvaXSPaXGwlM4qib0fFR0JpKBffMI8u1M
+    IysedLOXhmjXKSTe4i4+AgQAelgnEfqGXpSwhWhV399HJxlcSprm+GBV/YUIEk8C
+    AwEAAaNTMFEwHQYDVR0OBBYEFDR5qA5OLCe+BgULdkU67EWdC/kMMB8GA1UdIwQY
+    MBaAFDR5qA5OLCe+BgULdkU67EWdC/kMMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI
+    hvcNAQELBQADggEBADFLr2vhnAX9s8JgVB3M3i+iLqcBcmnJhZlFSHj9kf/ImS4n
+    SyD80LhG9RQy7ngP4LBMN56Q2+0aioxswNgHaZDSy006plGeWdy/hN1t3zlDGyGm
+    cF03pN37LgS+AX9yhETQaSnUIdgOJo1X6eaCbZK2oeZBfKFbBQEOHjfW7gt1Qa+h
+    DrrLcvhfhRUxQh7Rckz9JyzdzL5u2Bj4j/zQd3aEFW+QAvxfu+WpTWDDat4xKsA0
+    RjINXiKXdWglOotJQ4yEykadt9AqGi1PaWmodXSr8aMabuvjQ6P9UVat8NGRfMpP
+    QQ1Jy15cPzihBCxizB2Eh4pGVukaAs8el+Ps43w=
+    -----END CERTIFICATE-----
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: oke-gateway
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+            - group: ""
+              kind: ConfigMap
+              name: client-ca-bundle
+          mode: AllowValidOnly
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: oke-gw-example-https-cert
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mtls-api
+spec:
+  parentRefs:
+    - name: oke-gateway
+      sectionName: https
+  hostnames:
+    - api.example.com
+  rules:
+    - backendRefs:
+        - name: oke-gateway-example-server
+          port: 8080

--- a/deploy/manifests/examples/listenerset-https-mtls.yaml
+++ b/deploy/manifests/examples/listenerset-https-mtls.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-client-ca-bundle
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDGTCCAgGgAwIBAgIUf6q19DJQ8J7jyryakoN7w7Wx9d8wDQYJKoZIhvcNAQEL
+    BQAwHDEaMBgGA1UEAwwRZXhhbXBsZS1jbGllbnQtY2EwHhcNMjYwNzE4MjIyNjQw
+    WhcNMjcwNzE4MjIyNjQwWjAcMRowGAYDVQQDDBFleGFtcGxlLWNsaWVudC1jYTCC
+    ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKR/qFUPsVFAGm/xxU/aC50N
+    o0Yx/A0IZhnxXret+zwTz0bxPKIAZad3XJfwAgZY10SiblPNp/xokxqxzgHVn611
+    8PKPxPjy2k0/07+2RqtxJ9S4nVl2WYpIimOFDtguchsBR2xwSXKro3fsBFse6K+T
+    riyi15Dj3pZ9kIzP6JeU3hp/00AF8IrMdT5wDdW3GMeHr6Hs3gpoWtHIPoKzsZ8n
+    SaP5DmPpBjMFIfaSMic/+uqlZE0JYBzYvaXSPaXGwlM4qib0fFR0JpKBffMI8u1M
+    IysedLOXhmjXKSTe4i4+AgQAelgnEfqGXpSwhWhV399HJxlcSprm+GBV/YUIEk8C
+    AwEAAaNTMFEwHQYDVR0OBBYEFDR5qA5OLCe+BgULdkU67EWdC/kMMB8GA1UdIwQY
+    MBaAFDR5qA5OLCe+BgULdkU67EWdC/kMMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI
+    hvcNAQELBQADggEBADFLr2vhnAX9s8JgVB3M3i+iLqcBcmnJhZlFSHj9kf/ImS4n
+    SyD80LhG9RQy7ngP4LBMN56Q2+0aioxswNgHaZDSy006plGeWdy/hN1t3zlDGyGm
+    cF03pN37LgS+AX9yhETQaSnUIdgOJo1X6eaCbZK2oeZBfKFbBQEOHjfW7gt1Qa+h
+    DrrLcvhfhRUxQh7Rckz9JyzdzL5u2Bj4j/zQd3aEFW+QAvxfu+WpTWDDat4xKsA0
+    RjINXiKXdWglOotJQ4yEykadt9AqGi1PaWmodXSr8aMabuvjQ6P9UVat8NGRfMpP
+    QQ1Jy15cPzihBCxizB2Eh4pGVukaAs8el+Ps43w=
+    -----END CERTIFICATE-----
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: shared-alb
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  allowedListeners:
+    namespaces:
+      from: Same
+  tls:
+    frontend:
+      default: {}
+      perPort:
+        - port: 8443
+          tls:
+            validation:
+              caCertificateRefs:
+                - group: ""
+                  kind: ConfigMap
+                  name: api-client-ca-bundle
+              mode: AllowValidOnly
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: mtls-api
+spec:
+  parentRef:
+    name: shared-alb
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 8443
+      hostname: api.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: oke-gw-example-https-cert
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mtls-api
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: mtls-api
+      sectionName: https
+  hostnames:
+    - api.example.com
+  rules:
+    - backendRefs:
+        - name: oke-gateway-example-server
+          port: 8080

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -28,6 +28,15 @@ const (
 	// ListenerTLSOptionCipherSuiteName configures OCI listener SSL cipher suite name.
 	ListenerTLSOptionCipherSuiteName = "oci.oraclecloud.com/cipher-suite-name"
 
+	// FrontendMTLSTrustedCABundleOCIDsAnnotation adds existing OCI CA bundle OCIDs to frontend mTLS.
+	FrontendMTLSTrustedCABundleOCIDsAnnotation = "oci.oraclecloud.com/frontend-mtls-trusted-ca-bundle-ocids"
+
+	// FrontendMTLSVerifyDepthAnnotation configures OCI frontend mTLS peer certificate verification depth.
+	FrontendMTLSVerifyDepthAnnotation = "oci.oraclecloud.com/frontend-mtls-verify-depth"
+
+	// GatewayFrontendMTLSCABundleCompartmentsAnnotation stores OCI compartments with controller-managed CA bundles.
+	GatewayFrontendMTLSCABundleCompartmentsAnnotation = "oke-gateway-api.gemyago.github.io/frontend-mtls-compartments"
+
 	// BackendTLSPolicyProgrammedFinalizer is used to clean up controller-managed OCI CA bundles.
 	BackendTLSPolicyProgrammedFinalizer = "oke-gateway-api.gemyago.github.io/backend-tls-policy-programmed"
 

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -19,6 +19,12 @@ const (
 	// GatewayProgrammedCertificatesAnnotation stores OCI certificate names programmed by the controller.
 	GatewayProgrammedCertificatesAnnotation = "oke-gateway-api.gemyago.github.io/gateway-programmed-certificates"
 
+	// GatewayFrontendMTLSConfigMapsAnnotation stores frontend mTLS CA ConfigMap revisions.
+	GatewayFrontendMTLSConfigMapsAnnotation = "frontend-mtls-configmaps.oke-gateway-api.gemyago.github.io"
+
+	// GatewayFrontendMTLSReferenceGrantsAnnotation stores frontend mTLS ReferenceGrant revisions.
+	GatewayFrontendMTLSReferenceGrantsAnnotation = "frontend-mtls-referencegrants.oke-gateway-api.gemyago.github.io"
+
 	// ListenerTLSOptionOCICertificateOCID configures an existing OCI Certificates Service certificate for a listener.
 	ListenerTLSOptionOCICertificateOCID = "oci.oraclecloud.com/certificate-ocid"
 

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -1,6 +1,11 @@
 package app
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
 
 type resourceStatusError struct {
 	conditionType string
@@ -16,6 +21,15 @@ func (e resourceStatusError) Error() string {
 			e.conditionType, e.reason, e.message, e.cause)
 	}
 	return fmt.Sprintf("resourceStatusError: type=%s, reason=%s, message=%s", e.conditionType, e.reason, e.message)
+}
+
+func isParentGatewayStatusError(err error) bool {
+	var statusErr *resourceStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	return statusErr.conditionType == string(gatewayv1.GatewayConditionAccepted) ||
+		statusErr.conditionType == string(gatewayv1.GatewayConditionProgrammed)
 }
 
 type ReconcileError struct {

--- a/internal/app/frontend_mtls_model.go
+++ b/internal/app/frontend_mtls_model.go
@@ -78,14 +78,39 @@ func (m *ociLoadBalancerModelImpl) applyFrontendMTLS(
 	if validation == nil && len(optionCAIDs) == 0 {
 		return sslConfig, nil
 	}
-	if m.certsClient == nil {
-		return nil, errors.New("OCI certificates management client is required for frontend mTLS")
-	}
 	settings, err := resolveFrontendMTLSSettings(*params.gateway, params.listenerSpec.Port, validation, optionCAIDs)
 	if err != nil {
 		return nil, err
 	}
 
+	if sslConfig == nil {
+		sslConfig = &loadbalancer.SslConfigurationDetails{}
+	}
+	verifyPeer := true
+	sslConfig.VerifyPeerCertificate = &verifyPeer
+	sslConfig.VerifyDepth = &settings.verifyDepth
+	if sslConfig.CertificateName != nil {
+		if len(settings.ociCAIDs) > 0 {
+			return nil, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+				fmt.Sprintf(
+					"frontend mTLS OCI CA bundle OCID annotations require listener %s to use %s",
+					params.listenerSpec.Name,
+					ListenerTLSOptionOCICertificateOCID,
+				),
+			)
+		}
+		for _, ref := range settings.caRefs {
+			if _, err = m.resolveFrontendMTLSCARef(ctx, *params.gateway, ref); err != nil {
+				return nil, err
+			}
+		}
+		sslConfig.TrustedCertificateAuthorityIds = nil
+		return sslConfig, nil
+	}
+
+	if m.certsClient == nil {
+		return nil, errors.New("OCI certificates management client is required for frontend mTLS")
+	}
 	trustedCAIDs, err := m.resolveFrontendMTLSTrustedCAIDs(ctx, params, settings)
 	if err != nil {
 		return nil, err
@@ -93,12 +118,6 @@ func (m *ociLoadBalancerModelImpl) applyFrontendMTLS(
 
 	trustedCAIDs = lo.Uniq(trustedCAIDs)
 	sort.Strings(trustedCAIDs)
-	if sslConfig == nil {
-		sslConfig = &loadbalancer.SslConfigurationDetails{}
-	}
-	verifyPeer := true
-	sslConfig.VerifyPeerCertificate = &verifyPeer
-	sslConfig.VerifyDepth = &settings.verifyDepth
 	sslConfig.TrustedCertificateAuthorityIds = trustedCAIDs
 	return sslConfig, nil
 }

--- a/internal/app/frontend_mtls_model.go
+++ b/internal/app/frontend_mtls_model.go
@@ -1,0 +1,630 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	frontendMTLSCABundleNamePrefix = "oke-fmtls-"
+	frontendMTLSManagedByTag       = "oke-gateway-api-managed-by"
+	frontendMTLSManagedByValue     = "frontend-mtls"
+	frontendMTLSGatewayTag         = "oke-gateway-api-gateway"
+	frontendMTLSPortTag            = "oke-gateway-api-port"
+	frontendMTLSCAHashTag          = "oke-gateway-api-ca-sha256"
+	defaultFrontendMTLSVerifyDepth = 3
+)
+
+type cleanupFrontendMTLSCABundlesParams struct {
+	gateway            *gatewayv1.Gateway
+	compartmentID      string
+	desiredBundleNames map[string]struct{}
+}
+
+type frontendMTLSResolvedCARef struct {
+	ref   gatewayv1.ObjectReference
+	caPEM string
+}
+
+type frontendMTLSSettings struct {
+	caRefs      []gatewayv1.ObjectReference
+	ociCAIDs    []string
+	verifyDepth int
+}
+
+func frontendMTLSPortTrustedCABundleOCIDsAnnotation(port gatewayv1.PortNumber) string {
+	return fmt.Sprintf("oci.oraclecloud.com/frontend-mtls-%d-trusted-ca-bundle-ocids", port)
+}
+
+func frontendMTLSPortVerifyDepthAnnotation(port gatewayv1.PortNumber) string {
+	return fmt.Sprintf("oci.oraclecloud.com/frontend-mtls-%d-verify-depth", port)
+}
+
+func (m *ociLoadBalancerModelImpl) applyFrontendMTLS(
+	ctx context.Context,
+	params reconcileHTTPListenerParams,
+	sslConfig *loadbalancer.SslConfigurationDetails,
+) (*loadbalancer.SslConfigurationDetails, error) {
+	if params.listenerSpec == nil || params.listenerSpec.TLS == nil {
+		return sslConfig, nil
+	}
+	if params.gateway == nil {
+		return sslConfig, nil
+	}
+	if params.listenerSpec.Protocol != gatewayv1.HTTPSProtocolType &&
+		params.listenerSpec.Protocol != gatewayv1.TLSProtocolType {
+		return nil, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+			"frontend mTLS can only be used with HTTPS or TLS listeners",
+		)
+	}
+
+	optionCAIDs := frontendMTLSOCICABundleIDs(*params.gateway, params.listenerSpec.Port)
+	validation := effectiveFrontendTLSValidation(*params.gateway, params.listenerSpec.Port)
+	if validation == nil && len(optionCAIDs) == 0 {
+		return sslConfig, nil
+	}
+	if m.certsClient == nil {
+		return nil, errors.New("OCI certificates management client is required for frontend mTLS")
+	}
+	settings, err := resolveFrontendMTLSSettings(*params.gateway, params.listenerSpec.Port, validation, optionCAIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	trustedCAIDs, err := m.resolveFrontendMTLSTrustedCAIDs(ctx, params, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	trustedCAIDs = lo.Uniq(trustedCAIDs)
+	sort.Strings(trustedCAIDs)
+	if sslConfig == nil {
+		sslConfig = &loadbalancer.SslConfigurationDetails{}
+	}
+	verifyPeer := true
+	sslConfig.VerifyPeerCertificate = &verifyPeer
+	sslConfig.VerifyDepth = &settings.verifyDepth
+	sslConfig.TrustedCertificateAuthorityIds = trustedCAIDs
+	return sslConfig, nil
+}
+
+func resolveFrontendMTLSSettings(
+	gateway gatewayv1.Gateway,
+	port gatewayv1.PortNumber,
+	validation *gatewayv1.FrontendTLSValidation,
+	optionCAIDs []string,
+) (frontendMTLSSettings, error) {
+	mode := gatewayv1.AllowValidOnly
+	if validation != nil && validation.Mode != "" {
+		mode = validation.Mode
+	}
+	if mode == gatewayv1.AllowInsecureFallback {
+		return frontendMTLSSettings{}, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+			"frontend mTLS mode AllowInsecureFallback is not supported by OCI Load Balancer",
+		)
+	}
+	if mode != gatewayv1.AllowValidOnly {
+		return frontendMTLSSettings{}, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+			fmt.Sprintf("frontend mTLS mode %q is not supported", mode),
+		)
+	}
+
+	caRefs := []gatewayv1.ObjectReference(nil)
+	if validation != nil {
+		caRefs = validation.CACertificateRefs
+	}
+	if len(caRefs) > 0 && len(optionCAIDs) > 0 {
+		return frontendMTLSSettings{}, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+			"frontend mTLS cannot mix caCertificateRefs with OCI CA bundle OCID annotations",
+		)
+	}
+	if len(caRefs) == 0 && len(optionCAIDs) == 0 {
+		return frontendMTLSSettings{}, frontendMTLSStatusError(string(gatewayv1.ListenerReasonNoValidCACertificate),
+			"frontend mTLS requires at least one caCertificateRef or OCI CA bundle OCID annotation",
+		)
+	}
+
+	verifyDepth, err := frontendMTLSVerifyDepth(gateway, port)
+	if err != nil {
+		return frontendMTLSSettings{}, err
+	}
+	return frontendMTLSSettings{
+		caRefs:      caRefs,
+		ociCAIDs:    optionCAIDs,
+		verifyDepth: verifyDepth,
+	}, nil
+}
+
+func (m *ociLoadBalancerModelImpl) resolveFrontendMTLSTrustedCAIDs(
+	ctx context.Context,
+	params reconcileHTTPListenerParams,
+	settings frontendMTLSSettings,
+) ([]string, error) {
+	trustedCAIDs := make([]string, 0, len(settings.caRefs)+len(settings.ociCAIDs))
+	for _, caID := range settings.ociCAIDs {
+		if _, getErr := m.certsClient.GetCaBundle(ctx, certificatesmanagement.GetCaBundleRequest{
+			CaBundleId: &caID,
+		}); getErr != nil {
+			return nil, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+				fmt.Sprintf("frontend mTLS OCI CA bundle %s cannot be resolved", caID),
+			)
+		}
+		trustedCAIDs = append(trustedCAIDs, caID)
+	}
+
+	for _, ref := range settings.caRefs {
+		resolved, resolveErr := m.resolveFrontendMTLSCARef(ctx, *params.gateway, ref)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		caID, ensureErr := m.ensureFrontendMTLSCABundle(
+			ctx,
+			*params.gateway,
+			params.listenerSpec.Port,
+			resolved.ref,
+			params.loadBalancerCompartmentID,
+			resolved.caPEM,
+		)
+		if ensureErr != nil {
+			return nil, ensureErr
+		}
+		trustedCAIDs = append(trustedCAIDs, caID)
+	}
+	return trustedCAIDs, nil
+}
+
+func effectiveFrontendTLSValidation(
+	gateway gatewayv1.Gateway,
+	port gatewayv1.PortNumber,
+) *gatewayv1.FrontendTLSValidation {
+	if gateway.Spec.TLS == nil || gateway.Spec.TLS.Frontend == nil {
+		return nil
+	}
+	for i := range gateway.Spec.TLS.Frontend.PerPort {
+		portConfig := gateway.Spec.TLS.Frontend.PerPort[i]
+		if portConfig.Port == port {
+			return portConfig.TLS.Validation
+		}
+	}
+	return gateway.Spec.TLS.Frontend.Default.Validation
+}
+
+func frontendMTLSOCICABundleIDs(gateway gatewayv1.Gateway, port gatewayv1.PortNumber) []string {
+	if gateway.Annotations == nil {
+		return nil
+	}
+	value := gateway.Annotations[frontendMTLSPortTrustedCABundleOCIDsAnnotation(port)]
+	if strings.TrimSpace(value) != "" {
+		return splitCSVOption(gatewayv1.AnnotationValue(value))
+	}
+	return splitCSVOption(gatewayv1.AnnotationValue(gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation]))
+}
+
+func frontendMTLSVerifyDepth(gateway gatewayv1.Gateway, port gatewayv1.PortNumber) (int, error) {
+	if gateway.Annotations == nil {
+		return defaultFrontendMTLSVerifyDepth, nil
+	}
+	value := strings.TrimSpace(gateway.Annotations[frontendMTLSPortVerifyDepthAnnotation(port)])
+	if value == "" {
+		value = strings.TrimSpace(gateway.Annotations[FrontendMTLSVerifyDepthAnnotation])
+	}
+	if value == "" {
+		return defaultFrontendMTLSVerifyDepth, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 1 {
+		return 0, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+			fmt.Sprintf("annotation %s must be a positive integer", FrontendMTLSVerifyDepthAnnotation),
+		)
+	}
+	return parsed, nil
+}
+
+func (m *ociLoadBalancerModelImpl) resolveFrontendMTLSCARef(
+	ctx context.Context,
+	gateway gatewayv1.Gateway,
+	ref gatewayv1.ObjectReference,
+) (frontendMTLSResolvedCARef, error) {
+	if ref.Group != "" || ref.Kind != "ConfigMap" {
+		return frontendMTLSResolvedCARef{}, frontendMTLSStatusError(
+			string(gatewayv1.ListenerReasonInvalidCACertificateKind),
+			fmt.Sprintf("frontend mTLS caCertificateRef %s/%s must reference a core ConfigMap", ref.Group, ref.Kind),
+		)
+	}
+	refNamespace := gateway.Namespace
+	if ref.Namespace != nil {
+		refNamespace = string(*ref.Namespace)
+	}
+	fullName := apitypes.NamespacedName{Namespace: refNamespace, Name: string(ref.Name)}
+	allowed, err := referenceGrantAllowsCoreRef(
+		ctx,
+		m.k8sClient,
+		gatewayv1.Kind("Gateway"),
+		gateway.Namespace,
+		"ConfigMap",
+		fullName,
+	)
+	if err != nil {
+		return frontendMTLSResolvedCARef{}, err
+	}
+	if !allowed {
+		return frontendMTLSResolvedCARef{}, frontendMTLSStatusError(
+			string(gatewayv1.GatewayReasonRefNotPermitted),
+			fmt.Sprintf("frontend mTLS caCertificateRef %s is not permitted by a ReferenceGrant", fullName.String()),
+		)
+	}
+
+	var configMap corev1.ConfigMap
+	if err = m.k8sClient.Get(ctx, fullName, &configMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return frontendMTLSResolvedCARef{}, frontendMTLSStatusError(
+				string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+				fmt.Sprintf("frontend mTLS caCertificateRef ConfigMap %s was not found", fullName.String()),
+			)
+		}
+		return frontendMTLSResolvedCARef{}, fmt.Errorf(
+			"failed to get frontend mTLS ConfigMap %s: %w",
+			fullName.String(),
+			err,
+		)
+	}
+	caPEM, ok := configMap.Data["ca.crt"]
+	if !ok {
+		return frontendMTLSResolvedCARef{}, frontendMTLSStatusError(
+			string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+			fmt.Sprintf("frontend mTLS caCertificateRef ConfigMap %s is missing ca.crt", fullName.String()),
+		)
+	}
+	if err = validateCABundlePEM(caPEM); err != nil {
+		return frontendMTLSResolvedCARef{}, frontendMTLSStatusError(
+			string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+			fmt.Sprintf("frontend mTLS caCertificateRef ConfigMap %s has invalid ca.crt: %v", fullName.String(), err),
+		)
+	}
+	return frontendMTLSResolvedCARef{ref: ref, caPEM: caPEM}, nil
+}
+
+func (m *ociLoadBalancerModelImpl) ensureFrontendMTLSCABundle(
+	ctx context.Context,
+	gateway gatewayv1.Gateway,
+	port gatewayv1.PortNumber,
+	ref gatewayv1.ObjectReference,
+	compartmentID string,
+	caPEM string,
+) (string, error) {
+	if err := m.ensureFrontendMTLSCompartment(ctx, gateway, compartmentID); err != nil {
+		return "", err
+	}
+	name := frontendMTLSCABundleName(gateway, port, ref)
+	caHash := sha256Hex(caPEM)
+	tags := frontendMTLSCABundleTags(gateway, port, caHash)
+	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
+		CompartmentId: &compartmentID,
+		Name:          &name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list OCI CA bundles for frontend mTLS Gateway %s/%s: %w",
+			gateway.Namespace,
+			gateway.Name,
+			err,
+		)
+	}
+	for _, bundle := range listResp.Items {
+		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted {
+			continue
+		}
+		if !isOwnedFrontendMTLSCABundle(bundle.FreeformTags, gateway) {
+			return "", fmt.Errorf("OCI CA bundle %s already exists and is not owned by frontend mTLS Gateway %s/%s",
+				name,
+				gateway.Namespace,
+				gateway.Name,
+			)
+		}
+		if usableErr := ensureFrontendMTLSCABundleUsable(bundle); usableErr != nil {
+			return "", usableErr
+		}
+		if bundle.FreeformTags[frontendMTLSCAHashTag] != caHash {
+			m.logger.InfoContext(ctx, "Updating OCI CA bundle for frontend mTLS",
+				slog.String("gateway", fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name)),
+				slog.String("caBundleName", name),
+			)
+			_, err = m.certsClient.UpdateCaBundle(ctx, certificatesmanagement.UpdateCaBundleRequest{
+				CaBundleId: bundle.Id,
+				UpdateCaBundleDetails: certificatesmanagement.UpdateCaBundleDetails{
+					CaBundlePem:  &caPEM,
+					FreeformTags: tags,
+				},
+			})
+			if err != nil {
+				return "", fmt.Errorf("failed to update OCI CA bundle %s: %w", name, err)
+			}
+		}
+		return lo.FromPtr(bundle.Id), nil
+	}
+
+	m.logger.InfoContext(ctx, "Creating OCI CA bundle for frontend mTLS",
+		slog.String("gateway", fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name)),
+		slog.String("caBundleName", name),
+	)
+	createResp, err := m.certsClient.CreateCaBundle(ctx, certificatesmanagement.CreateCaBundleRequest{
+		CreateCaBundleDetails: certificatesmanagement.CreateCaBundleDetails{
+			Name:          &name,
+			CompartmentId: &compartmentID,
+			CaBundlePem:   &caPEM,
+			FreeformTags:  tags,
+		},
+	})
+	if err != nil {
+		if isFrontendMTLSCABundleAlreadyExists(err) {
+			return m.resolveExistingFrontendMTLSCABundle(ctx, gateway, compartmentID, name, caHash)
+		}
+		return "", fmt.Errorf("failed to create OCI CA bundle %s: %w", name, err)
+	}
+	if createResp.CaBundle.LifecycleState != certificatesmanagement.CaBundleLifecycleStateActive {
+		return "", fmt.Errorf("OCI CA bundle %s is %s and is not ready for frontend mTLS",
+			name,
+			createResp.CaBundle.LifecycleState,
+		)
+	}
+	return lo.FromPtr(createResp.CaBundle.Id), nil
+}
+
+func (m *ociLoadBalancerModelImpl) ensureFrontendMTLSCompartment(
+	ctx context.Context,
+	gateway gatewayv1.Gateway,
+	compartmentID string,
+) error {
+	if compartmentID == "" || lo.Contains(frontendMTLSCompartmentIDs(gateway), compartmentID) {
+		return nil
+	}
+	gatewayToUpdate := gateway.DeepCopy()
+	if gatewayToUpdate.Annotations == nil {
+		gatewayToUpdate.Annotations = map[string]string{}
+	}
+	compartments := append(frontendMTLSCompartmentIDs(gateway), compartmentID)
+	sort.Strings(compartments)
+	gatewayToUpdate.Annotations[GatewayFrontendMTLSCABundleCompartmentsAnnotation] = strings.Join(compartments, ",")
+	if err := m.k8sClient.Update(ctx, gatewayToUpdate); err != nil {
+		return fmt.Errorf("failed to record frontend mTLS CA bundle compartment on Gateway %s/%s: %w",
+			gateway.Namespace,
+			gateway.Name,
+			err,
+		)
+	}
+	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) resolveExistingFrontendMTLSCABundle(
+	ctx context.Context,
+	gateway gatewayv1.Gateway,
+	compartmentID string,
+	name string,
+	caHash string,
+) (string, error) {
+	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
+		CompartmentId: &compartmentID,
+		Name:          &name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to re-list OCI CA bundle %s after create conflict: %w", name, err)
+	}
+	for _, bundle := range listResp.Items {
+		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted {
+			continue
+		}
+		if !isOwnedFrontendMTLSCABundle(bundle.FreeformTags, gateway) {
+			return "", fmt.Errorf("OCI CA bundle %s already exists and is not owned by frontend mTLS Gateway %s/%s",
+				name,
+				gateway.Namespace,
+				gateway.Name,
+			)
+		}
+		if usableErr := ensureFrontendMTLSCABundleUsable(bundle); usableErr != nil {
+			return "", usableErr
+		}
+		if bundle.FreeformTags[frontendMTLSCAHashTag] != caHash {
+			return "", fmt.Errorf(
+				"OCI CA bundle %s already exists with stale CA data and is not ready for update",
+				name,
+			)
+		}
+		return lo.FromPtr(bundle.Id), nil
+	}
+	return "", fmt.Errorf("OCI CA bundle %s already exists but was not visible in list response", name)
+}
+
+func (m *ociLoadBalancerModelImpl) cleanupFrontendMTLSCABundles(
+	ctx context.Context,
+	params cleanupFrontendMTLSCABundlesParams,
+) error {
+	if params.gateway == nil || params.compartmentID == "" || m.certsClient == nil {
+		return nil
+	}
+	compartments := frontendMTLSCompartmentIDs(*params.gateway)
+	if len(compartments) == 0 {
+		compartments = []string{params.compartmentID}
+	}
+	for _, compartmentID := range compartments {
+		if err := m.cleanupFrontendMTLSCABundlesInCompartment(ctx, params, compartmentID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) cleanupFrontendMTLSCABundlesInCompartment(
+	ctx context.Context,
+	params cleanupFrontendMTLSCABundlesParams,
+	compartmentID string,
+) error {
+	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
+		CompartmentId: &compartmentID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list OCI CA bundles for frontend mTLS cleanup: %w", err)
+	}
+	for _, bundle := range listResp.Items {
+		if !isOwnedFrontendMTLSCABundle(bundle.FreeformTags, *params.gateway) {
+			continue
+		}
+		if _, desired := params.desiredBundleNames[lo.FromPtr(bundle.Name)]; desired {
+			continue
+		}
+		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted ||
+			bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleting {
+			continue
+		}
+		if err = m.deleteFrontendMTLSCABundle(ctx, *params.gateway, bundle); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) deleteFrontendMTLSCABundle(
+	ctx context.Context,
+	gateway gatewayv1.Gateway,
+	bundle certificatesmanagement.CaBundleSummary,
+) error {
+	m.logger.InfoContext(ctx, "Deleting OCI CA bundle for frontend mTLS",
+		slog.String("gateway", fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name)),
+		slog.String("caBundleName", lo.FromPtr(bundle.Name)),
+	)
+	_, err := m.certsClient.DeleteCaBundle(ctx, certificatesmanagement.DeleteCaBundleRequest{
+		CaBundleId: bundle.Id,
+	})
+	if err == nil || isFrontendMTLSCABundleAlreadyDeleted(err) {
+		return nil
+	}
+	return fmt.Errorf("failed to delete OCI CA bundle %s: %w", lo.FromPtr(bundle.Name), err)
+}
+
+func frontendMTLSCompartmentIDs(gateway gatewayv1.Gateway) []string {
+	compartmentAnnotation := gateway.Annotations[GatewayFrontendMTLSCABundleCompartmentsAnnotation]
+	if compartmentAnnotation == "" {
+		return nil
+	}
+	compartments := strings.Split(compartmentAnnotation, ",")
+	uniqueCompartments := make(map[string]struct{}, len(compartments))
+	for _, compartment := range compartments {
+		compartment = strings.TrimSpace(compartment)
+		if compartment == "" {
+			continue
+		}
+		uniqueCompartments[compartment] = struct{}{}
+	}
+	result := lo.Keys(uniqueCompartments)
+	sort.Strings(result)
+	return result
+}
+
+func frontendMTLSCABundleName(
+	gateway gatewayv1.Gateway,
+	port gatewayv1.PortNumber,
+	ref gatewayv1.ObjectReference,
+) string {
+	refNamespace := gateway.Namespace
+	if ref.Namespace != nil {
+		refNamespace = string(*ref.Namespace)
+	}
+	hashInput := fmt.Sprintf("%s/%s/%s/%d/%s/%s/%s/%s",
+		gateway.Namespace,
+		gateway.Name,
+		frontendMTLSGatewayIdentity(gateway),
+		port,
+		ref.Group,
+		ref.Kind,
+		refNamespace,
+		ref.Name,
+	)
+	return frontendMTLSCABundleNamePrefix + sha256Hex(hashInput)[:24]
+}
+
+func frontendMTLSGatewayIdentity(gateway gatewayv1.Gateway) string {
+	if gateway.UID != "" {
+		return string(gateway.UID)
+	}
+	if !gateway.CreationTimestamp.IsZero() {
+		return gateway.CreationTimestamp.UTC().Format("2006-01-02T15:04:05.999999999Z07:00")
+	}
+	return strconv.FormatInt(gateway.Generation, 10)
+}
+
+func frontendMTLSCABundleTags(
+	gateway gatewayv1.Gateway,
+	port gatewayv1.PortNumber,
+	caHash string,
+) map[string]string {
+	return map[string]string{
+		frontendMTLSManagedByTag: frontendMTLSManagedByValue,
+		frontendMTLSGatewayTag:   fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name),
+		frontendMTLSPortTag:      strconv.Itoa(int(port)),
+		frontendMTLSCAHashTag:    caHash,
+	}
+}
+
+func isOwnedFrontendMTLSCABundle(tags map[string]string, gateway gatewayv1.Gateway) bool {
+	return tags[frontendMTLSManagedByTag] == frontendMTLSManagedByValue &&
+		tags[frontendMTLSGatewayTag] == fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name)
+}
+
+func ensureFrontendMTLSCABundleUsable(bundle certificatesmanagement.CaBundleSummary) error {
+	switch bundle.LifecycleState {
+	case "", certificatesmanagement.CaBundleLifecycleStateActive:
+		return nil
+	case certificatesmanagement.CaBundleLifecycleStateDeleting:
+		return fmt.Errorf("OCI CA bundle %s is %s and cannot be reused for frontend mTLS",
+			lo.FromPtr(bundle.Name),
+			bundle.LifecycleState,
+		)
+	case certificatesmanagement.CaBundleLifecycleStateCreating,
+		certificatesmanagement.CaBundleLifecycleStateUpdating,
+		certificatesmanagement.CaBundleLifecycleStateDeleted,
+		certificatesmanagement.CaBundleLifecycleStateFailed:
+		return fmt.Errorf("OCI CA bundle %s is %s and is not ready for frontend mTLS",
+			lo.FromPtr(bundle.Name),
+			bundle.LifecycleState,
+		)
+	default:
+		return fmt.Errorf("OCI CA bundle %s is %s and is not ready for frontend mTLS",
+			lo.FromPtr(bundle.Name),
+			bundle.LifecycleState,
+		)
+	}
+}
+
+func isFrontendMTLSCABundleAlreadyExists(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok &&
+		serviceErr.GetHTTPStatusCode() == http.StatusBadRequest &&
+		serviceErr.GetCode() == "InvalidParameter" &&
+		strings.Contains(serviceErr.GetMessage(), "already exists")
+}
+
+func isFrontendMTLSCABundleAlreadyDeleted(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound
+}
+
+func frontendMTLSStatusError(reason string, message string) *resourceStatusError {
+	return &resourceStatusError{
+		conditionType: string(gatewayv1.GatewayConditionAccepted),
+		reason:        reason,
+		message:       message,
+	}
+}

--- a/internal/app/frontend_mtls_model.go
+++ b/internal/app/frontend_mtls_model.go
@@ -238,8 +238,10 @@ func frontendMTLSVerifyDepth(gateway gatewayv1.Gateway, port gatewayv1.PortNumbe
 	if gateway.Annotations == nil {
 		return defaultFrontendMTLSVerifyDepth, nil
 	}
-	value := strings.TrimSpace(gateway.Annotations[frontendMTLSPortVerifyDepthAnnotation(port)])
+	annotationKey := frontendMTLSPortVerifyDepthAnnotation(port)
+	value := strings.TrimSpace(gateway.Annotations[annotationKey])
 	if value == "" {
+		annotationKey = FrontendMTLSVerifyDepthAnnotation
 		value = strings.TrimSpace(gateway.Annotations[FrontendMTLSVerifyDepthAnnotation])
 	}
 	if value == "" {
@@ -248,7 +250,7 @@ func frontendMTLSVerifyDepth(gateway gatewayv1.Gateway, port gatewayv1.PortNumbe
 	parsed, err := strconv.Atoi(value)
 	if err != nil || parsed < 1 {
 		return 0, frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
-			fmt.Sprintf("annotation %s must be a positive integer", FrontendMTLSVerifyDepthAnnotation),
+			fmt.Sprintf("annotation %s must be a positive integer", annotationKey),
 		)
 	}
 	return parsed, nil

--- a/internal/app/frontend_mtls_model.go
+++ b/internal/app/frontend_mtls_model.go
@@ -649,3 +649,10 @@ func frontendMTLSStatusError(reason string, message string) *resourceStatusError
 		message:       message,
 	}
 }
+
+func isFrontendMTLSStatusError(err error) bool {
+	var statusErr *resourceStatusError
+	return errors.As(err, &statusErr) &&
+		statusErr.conditionType == string(gatewayv1.GatewayConditionAccepted) &&
+		strings.HasPrefix(statusErr.message, "frontend mTLS ")
+}

--- a/internal/app/frontend_mtls_model_test.go
+++ b/internal/app/frontend_mtls_model_test.go
@@ -1,0 +1,975 @@
+package app
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaswdr/faker/v2"
+	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
+	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
+)
+
+func TestFrontendMTLSModel(t *testing.T) {
+	makeGateway := func(t *testing.T, port gatewayv1.PortNumber, validation *gatewayv1.FrontendTLSValidation) gatewayv1.Gateway {
+		t.Helper()
+		fakeData := faker.New()
+		mode := gatewayv1.TLSModeTerminate
+		return gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fakeData.Lorem().Word(),
+				Name:       "gw-" + fakeData.Lorem().Word(),
+				Generation: 1,
+				Annotations: map[string]string{
+					ControllerClassName: "true",
+				},
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     port,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						Mode: &mode,
+					},
+				}},
+				TLS: &gatewayv1.GatewayTLSConfig{
+					Frontend: &gatewayv1.FrontendTLSConfig{
+						Default: gatewayv1.TLSConfig{Validation: validation},
+					},
+				},
+			},
+		}
+	}
+	makeConfigMap := func(t *testing.T, namespace string, name gatewayv1.ObjectName) corev1.ConfigMap {
+		t.Helper()
+		return corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: string(name)},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+	}
+	makeModel := func(t *testing.T, objects ...client.Object) (*ociLoadBalancerModelImpl, *stubCertificatesManagementClient) {
+		t.Helper()
+		k8sObjects := make([]client.Object, 0, len(objects))
+		k8sObjects = append(k8sObjects, objects...)
+		certsClient := newStubCertificatesManagementClient()
+		model := newOciLoadBalancerModel(ociLoadBalancerModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient: fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(k8sObjects...).
+				Build(),
+			OciClient:                 NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: certsClient,
+			WorkRequestsWatcher:       NewMockworkRequestsWatcher(t),
+			RoutingRulesMapper:        NewMockociLoadBalancerRoutingRulesMapper(t),
+		})
+		return model, certsClient
+	}
+	defaultCABundleName := func(gateway gatewayv1.Gateway) string {
+		return frontendMTLSCABundleName(
+			gateway,
+			443,
+			gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs[0],
+		)
+	}
+
+	t.Run("applies standard ConfigMap CA refs to listener SSL configuration", func(t *testing.T) {
+		refName := gatewayv1.ObjectName("ca-" + faker.New().Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  refName,
+			}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		sslConfig := &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")}
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + faker.New().Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, sslConfig)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, lo.FromPtr(got.VerifyPeerCertificate))
+		assert.Equal(t, defaultFrontendMTLSVerifyDepth, lo.FromPtr(got.VerifyDepth))
+		require.Len(t, got.TrustedCertificateAuthorityIds, 1)
+		assert.Len(t, certsClient.createCalls, 1)
+		assert.Equal(t,
+			defaultCABundleName(gateway),
+			lo.FromPtr(certsClient.createCalls[0].CreateCaBundleDetails.Name),
+		)
+		assert.Contains(t, got.TrustedCertificateAuthorityIds[0], "ocid1.cabundle.oc1..created")
+	})
+
+	t.Run("per-port validation and annotations override defaults", func(t *testing.T) {
+		fakeData := faker.New()
+		defaultRef := gatewayv1.ObjectName("default-" + fakeData.Lorem().Word())
+		portRef := gatewayv1.ObjectName("port-" + fakeData.Lorem().Word())
+		port := gatewayv1.PortNumber(8443)
+		gateway := makeGateway(t, port, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: defaultRef}},
+		})
+		gateway.Spec.TLS.Frontend.PerPort = []gatewayv1.TLSPortConfig{{
+			Port: port,
+			TLS: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+				CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: portRef}},
+			}},
+		}}
+		gateway.Annotations[frontendMTLSPortVerifyDepthAnnotation(port)] = "5"
+		configMap := makeConfigMap(t, gateway.Namespace, portRef)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")})
+
+		require.NoError(t, err)
+		assert.Equal(t, 5, lo.FromPtr(got.VerifyDepth))
+		assert.Len(t, got.TrustedCertificateAuthorityIds, 1)
+		require.Len(t, certsClient.createCalls, 1)
+		assert.Equal(t,
+			frontendMTLSCABundleName(
+				gateway,
+				port,
+				gateway.Spec.TLS.Frontend.PerPort[0].TLS.Validation.CACertificateRefs[0],
+			),
+			lo.FromPtr(certsClient.createCalls[0].CreateCaBundleDetails.Name),
+		)
+	})
+
+	t.Run("uses existing OCI CA bundle OCIDs without creating bundles", func(t *testing.T) {
+		fakeData := faker.New()
+		ociCAID := "ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		gateway := makeGateway(t, 443, nil)
+		gateway.Spec.TLS = nil
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] = ociCAID
+		gateway.Annotations[FrontendMTLSVerifyDepthAnnotation] = "4"
+		model, certsClient := makeModel(t, &gateway)
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{ociCAID}, got.TrustedCertificateAuthorityIds)
+		assert.Equal(t, 4, lo.FromPtr(got.VerifyDepth))
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("per-port OCI CA bundle OCID annotations override defaults", func(t *testing.T) {
+		fakeData := faker.New()
+		defaultCAID := "ocid1.cabundle.oc1..default" + fakeData.UUID().V4()
+		portCAID := "ocid1.cabundle.oc1..port" + fakeData.UUID().V4()
+		gateway := makeGateway(t, 8443, nil)
+		gateway.Spec.TLS = nil
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] = defaultCAID
+		gateway.Annotations[frontendMTLSPortTrustedCABundleOCIDsAnnotation(8443)] = portCAID
+		model, certsClient := makeModel(t, &gateway)
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{portCAID}, got.TrustedCertificateAuthorityIds)
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("returns existing config when frontend mTLS is not configured", func(t *testing.T) {
+		gateway := makeGateway(t, 443, nil)
+		sslConfig := &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")}
+		model, certsClient := makeModel(t, &gateway)
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, sslConfig)
+
+		require.NoError(t, err)
+		assert.Same(t, sslConfig, got)
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("returns existing config without listener TLS or Gateway context", func(t *testing.T) {
+		gateway := makeGateway(t, 443, nil)
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] =
+			"ocid1.cabundle.oc1.." + faker.New().UUID().V4()
+		listenerWithoutTLS := gateway.Spec.Listeners[0]
+		listenerWithoutTLS.TLS = nil
+		sslConfig := &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")}
+		model, certsClient := makeModel(t, &gateway)
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &listenerWithoutTLS,
+			gateway:      &gateway,
+		}, sslConfig)
+
+		require.NoError(t, err)
+		assert.Same(t, sslConfig, got)
+
+		got, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+		}, sslConfig)
+
+		require.NoError(t, err)
+		assert.Same(t, sslConfig, got)
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("rejects frontend mTLS on non TLS listener protocols", func(t *testing.T) {
+		gateway := makeGateway(t, 443, nil)
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] =
+			"ocid1.cabundle.oc1.." + faker.New().UUID().V4()
+		gateway.Spec.Listeners[0].Protocol = gatewayv1.HTTPProtocolType
+		model, _ := makeModel(t, &gateway)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "HTTPS or TLS listeners")
+	})
+
+	t.Run("requires certificates management client when configured", func(t *testing.T) {
+		gateway := makeGateway(t, 443, nil)
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] =
+			"ocid1.cabundle.oc1.." + faker.New().UUID().V4()
+		model, _ := makeModel(t, &gateway)
+		model.certsClient = nil
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "certificates management client")
+	})
+
+	t.Run("rejects unsupported and invalid frontend mTLS settings", func(t *testing.T) {
+		fakeData := faker.New()
+		mode := gatewayv1.AllowInsecureFallback
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			Mode: mode,
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word()),
+			}},
+		})
+		model, _ := makeModel(t, &gateway)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")})
+
+		require.ErrorContains(t, err, "AllowInsecureFallback")
+		var statusErr *resourceStatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, string(gatewayv1.GatewayReasonInvalidParameters), statusErr.reason)
+	})
+
+	t.Run("rejects unknown frontend mTLS mode", func(t *testing.T) {
+		mode := gatewayv1.FrontendValidationModeType("AuditOnly")
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			Mode: mode,
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  "ca-" + gatewayv1.ObjectName(faker.New().Lorem().Word()),
+			}},
+		})
+		model, _ := makeModel(t, &gateway)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "AuditOnly")
+	})
+
+	t.Run("rejects mixed standard refs and OCI CA bundle OCIDs", func(t *testing.T) {
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  "ca-" + gatewayv1.ObjectName(faker.New().Lorem().Word()),
+			}},
+		})
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] =
+			"ocid1.cabundle.oc1.." + faker.New().UUID().V4()
+		model, _ := makeModel(t, &gateway)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "cannot mix")
+	})
+
+	t.Run("rejects validation without any trust anchor", func(t *testing.T) {
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{})
+		model, _ := makeModel(t, &gateway)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "requires at least one")
+	})
+
+	t.Run("rejects invalid verify depth annotation", func(t *testing.T) {
+		gateway := makeGateway(t, 443, nil)
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] =
+			"ocid1.cabundle.oc1.." + faker.New().UUID().V4()
+		gateway.Annotations[FrontendMTLSVerifyDepthAnnotation] = "zero"
+		model, _ := makeModel(t, &gateway)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "positive integer")
+	})
+
+	t.Run("rejects unresolved OCI CA bundle OCID", func(t *testing.T) {
+		fakeData := faker.New()
+		ociCAID := "ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		gateway := makeGateway(t, 443, nil)
+		gateway.Spec.TLS = nil
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] = ociCAID
+		model, certsClient := makeModel(t, &gateway)
+		certsClient.getErrByID[ociCAID] = errors.New("missing")
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "cannot be resolved")
+	})
+
+	t.Run("rejects invalid ConfigMap refs and CA data", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: gatewayv1.Group("example.com"),
+				Kind:  "Secret",
+				Name:  gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word()),
+			}},
+		})
+		model, _ := makeModel(t, &gateway)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+
+		require.ErrorContains(t, err, "core ConfigMap")
+
+		gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs[0] = gatewayv1.ObjectReference{
+			Group: "", Kind: "ConfigMap", Name: gatewayv1.ObjectName("missing-" + fakeData.Lorem().Word()),
+		}
+		model, _ = makeModel(t, &gateway)
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+		require.ErrorContains(t, err, "was not found")
+
+		refName := gatewayv1.ObjectName("empty-" + fakeData.Lorem().Word())
+		gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs[0].Name = refName
+		emptyConfigMap := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gateway.Namespace, Name: string(refName)},
+		}
+		model, _ = makeModel(t, &gateway, &emptyConfigMap)
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+		require.ErrorContains(t, err, "missing ca.crt")
+
+		invalidConfigMap := emptyConfigMap
+		invalidConfigMap.Data = map[string]string{"ca.crt": "not pem"}
+		model, _ = makeModel(t, &gateway, &invalidConfigMap)
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			listenerSpec: &gateway.Spec.Listeners[0],
+			gateway:      &gateway,
+		}, &loadbalancer.SslConfigurationDetails{})
+		require.ErrorContains(t, err, "invalid ca.crt")
+	})
+
+	t.Run("enforces ReferenceGrant for cross namespace ConfigMap refs", func(t *testing.T) {
+		fakeData := faker.New()
+		refNamespace := "ca-" + fakeData.Lorem().Word()
+		refName := gatewayv1.ObjectName("bundle-" + fakeData.Lorem().Word())
+		refNamespaceTyped := gatewayv1.Namespace(refNamespace)
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group:     "",
+				Kind:      "ConfigMap",
+				Name:      refName,
+				Namespace: &refNamespaceTyped,
+			}},
+		})
+		configMap := makeConfigMap(t, refNamespace, refName)
+		model, _ := makeModel(t, &gateway, &configMap)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")})
+
+		require.ErrorContains(t, err, "ReferenceGrant")
+		var statusErr *resourceStatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, string(gatewayv1.GatewayReasonRefNotPermitted), statusErr.reason)
+
+		grant := gatewayv1beta1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Namespace: refNamespace, Name: "grant-" + fakeData.Lorem().Word()},
+			Spec: gatewayv1beta1.ReferenceGrantSpec{
+				From: []gatewayv1beta1.ReferenceGrantFrom{{
+					Group:     gatewayv1.Group(gatewayAPIGroup),
+					Kind:      gatewayv1.Kind("Gateway"),
+					Namespace: gatewayv1.Namespace(gateway.Namespace),
+				}},
+				To: []gatewayv1beta1.ReferenceGrantTo{{
+					Group: "",
+					Kind:  gatewayv1.Kind("ConfigMap"),
+				}},
+			},
+		}
+		model, _ = makeModel(t, &gateway, &configMap, &grant)
+
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("cleans up stale controller owned bundles but keeps desired and unowned bundles", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 443, nil)
+		compartmentID := "compartment-" + fakeData.Lorem().Word()
+		desiredName := "desired-" + fakeData.Lorem().Word()
+		staleName := "stale-" + fakeData.Lorem().Word()
+		unownedName := "unowned-" + fakeData.Lorem().Word()
+		model, certsClient := makeModel(t, &gateway)
+		certsClient.bundles[desiredName] = certificatesmanagement.CaBundleSummary{
+			Id:             new("desired-id"),
+			Name:           new(desiredName),
+			CompartmentId:  new(compartmentID),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "hash"),
+		}
+		certsClient.bundles[staleName] = certificatesmanagement.CaBundleSummary{
+			Id:             new("stale-id"),
+			Name:           new(staleName),
+			CompartmentId:  new(compartmentID),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "hash"),
+		}
+		certsClient.bundles[unownedName] = certificatesmanagement.CaBundleSummary{
+			Id:             new("unowned-id"),
+			Name:           new(unownedName),
+			CompartmentId:  new(compartmentID),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		}
+
+		err := model.cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
+			gateway:       &gateway,
+			compartmentID: compartmentID,
+			desiredBundleNames: map[string]struct{}{
+				desiredName: {},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, certsClient.deleteCalls, 1)
+		assert.Equal(t, "stale-id", lo.FromPtr(certsClient.deleteCalls[0].CaBundleId))
+	})
+
+	t.Run("reuses and updates owned OCI CA bundles", func(t *testing.T) {
+		fakeData := faker.New()
+		refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: refName}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		name := defaultCABundleName(gateway)
+		id := "ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             &id,
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "stale-hash"),
+		}
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{id}, got.TrustedCertificateAuthorityIds)
+		require.Len(t, certsClient.updateCalls, 1)
+		assert.Equal(t, id, lo.FromPtr(certsClient.updateCalls[0].CaBundleId))
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("rejects existing unowned or unusable OCI CA bundle", func(t *testing.T) {
+		fakeData := faker.New()
+		refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: refName}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		name := defaultCABundleName(gateway)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             new("ocid1.cabundle.oc1.." + fakeData.UUID().V4()),
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		}
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+
+		require.ErrorContains(t, err, "not owned")
+
+		model, certsClient = makeModel(t, &gateway, &configMap)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             new("ocid1.cabundle.oc1.." + fakeData.UUID().V4()),
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleting,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, sha256Hex(configMap.Data["ca.crt"])),
+		}
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+		require.ErrorContains(t, err, "cannot be reused")
+	})
+
+	t.Run("resolves create conflict by reusing existing matching bundle", func(t *testing.T) {
+		fakeData := faker.New()
+		refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+		compartmentID := "compartment-" + fakeData.Lorem().Word()
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: refName}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		name := defaultCABundleName(gateway)
+		id := "ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		certsClient.listEmptyResponses = 1
+		certsClient.createErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusBadRequest),
+			ociapi.RandomServiceErrorWithCode("InvalidParameter"),
+			ociapi.RandomServiceErrorWithMessage("A CA bundle with the name '"+name+"' already exists."),
+		)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             &id,
+			Name:           &name,
+			CompartmentId:  &compartmentID,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, sha256Hex(configMap.Data["ca.crt"])),
+		}
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: compartmentID,
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{id}, got.TrustedCertificateAuthorityIds)
+	})
+
+	t.Run("surfaces create conflict lookup failures", func(t *testing.T) {
+		fakeData := faker.New()
+		refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: refName}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		name := defaultCABundleName(gateway)
+		certsClient.listEmptyResponses = 2
+		certsClient.createErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusBadRequest),
+			ociapi.RandomServiceErrorWithCode("InvalidParameter"),
+			ociapi.RandomServiceErrorWithMessage("A CA bundle with the name '"+name+"' already exists."),
+		)
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+
+		require.ErrorContains(t, err, "was not visible")
+
+		model, certsClient = makeModel(t, &gateway, &configMap)
+		certsClient.listEmptyResponses = 1
+		certsClient.createErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusBadRequest),
+			ociapi.RandomServiceErrorWithCode("InvalidParameter"),
+			ociapi.RandomServiceErrorWithMessage("A CA bundle with the name '"+name+"' already exists."),
+		)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             new("ocid1.cabundle.oc1.." + fakeData.UUID().V4()),
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+		}
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+		require.ErrorContains(t, err, "not owned")
+
+		model, certsClient = makeModel(t, &gateway, &configMap)
+		certsClient.listEmptyResponses = 1
+		certsClient.createErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusBadRequest),
+			ociapi.RandomServiceErrorWithCode("InvalidParameter"),
+			ociapi.RandomServiceErrorWithMessage("A CA bundle with the name '"+name+"' already exists."),
+		)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             new("ocid1.cabundle.oc1.." + fakeData.UUID().V4()),
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "stale-hash"),
+		}
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+		require.ErrorContains(t, err, "stale CA data")
+	})
+
+	t.Run("surfaces CA bundle create and lookup failures", func(t *testing.T) {
+		fakeData := faker.New()
+		refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: refName}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		certsClient.listErr = errors.New("list failed")
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+		require.ErrorContains(t, err, "failed to list OCI CA bundles")
+
+		model, certsClient = makeModel(t, &gateway, &configMap)
+		certsClient.createState = certificatesmanagement.CaBundleLifecycleStateCreating
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+		require.ErrorContains(t, err, "is CREATING")
+
+		model, certsClient = makeModel(t, &gateway, &configMap)
+		certsClient.createErr = errors.New("create failed")
+		_, err = model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+		require.ErrorContains(t, err, "failed to create OCI CA bundle")
+	})
+
+	t.Run("ignores deleted named bundle before creating replacement", func(t *testing.T) {
+		fakeData := faker.New()
+		refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: refName}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		name := defaultCABundleName(gateway)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             new("deleted-id"),
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleted,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, sha256Hex(configMap.Data["ca.crt"])),
+		}
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Contains(t, got.TrustedCertificateAuthorityIds[0], "ocid1.cabundle.oc1..created")
+		require.Len(t, certsClient.createCalls, 1)
+	})
+
+	t.Run("surfaces CA bundle update failures", func(t *testing.T) {
+		fakeData := faker.New()
+		refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{Group: "", Kind: "ConfigMap", Name: refName}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		name := defaultCABundleName(gateway)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             new("ocid1.cabundle.oc1.." + fakeData.UUID().V4()),
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "stale-hash"),
+		}
+		certsClient.updateErr = errors.New("update failed")
+
+		_, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, nil)
+
+		require.ErrorContains(t, err, "failed to update OCI CA bundle")
+	})
+
+	t.Run("cleans up across recorded compartments and ignores deleted bundle states", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 443, nil)
+		gateway.Annotations[GatewayFrontendMTLSCABundleCompartmentsAnnotation] = "comp-a, ,comp-b,comp-a"
+		model, certsClient := makeModel(t, &gateway)
+		certsClient.bundles["deleting-"+fakeData.Lorem().Word()] = certificatesmanagement.CaBundleSummary{
+			Id:             new("deleting-id"),
+			Name:           new("deleting"),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleting,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "hash"),
+		}
+		certsClient.bundles["deleted-"+fakeData.Lorem().Word()] = certificatesmanagement.CaBundleSummary{
+			Id:             new("deleted-id"),
+			Name:           new("deleted"),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleted,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "hash"),
+		}
+
+		err := model.cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
+			gateway:            &gateway,
+			compartmentID:      "compartment-" + fakeData.Lorem().Word(),
+			desiredBundleNames: map[string]struct{}{},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, certsClient.deleteCalls)
+		assert.Equal(t, []string{"comp-a", "comp-b"}, frontendMTLSCompartmentIDs(gateway))
+	})
+
+	t.Run("cleanup handles no-op and error cases", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 443, nil)
+		var certsClient *stubCertificatesManagementClient
+		model, _ := makeModel(t, &gateway)
+
+		require.NoError(t, model.cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{}))
+		model.certsClient = nil
+		require.NoError(t, model.cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
+			gateway:       &gateway,
+			compartmentID: "compartment-" + fakeData.Lorem().Word(),
+		}))
+
+		model, certsClient = makeModel(t, &gateway)
+		certsClient.listErr = errors.New("list failed")
+		err := model.cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
+			gateway:       &gateway,
+			compartmentID: "compartment-" + fakeData.Lorem().Word(),
+		})
+		require.ErrorContains(t, err, "failed to list OCI CA bundles")
+
+		model, certsClient = makeModel(t, &gateway)
+		staleName := "stale-" + fakeData.Lorem().Word()
+		certsClient.bundles[staleName] = certificatesmanagement.CaBundleSummary{
+			Id:             new("stale-id"),
+			Name:           new(staleName),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "hash"),
+		}
+		certsClient.deleteErr = ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+		)
+		require.NoError(t, model.cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
+			gateway:       &gateway,
+			compartmentID: "compartment-" + fakeData.Lorem().Word(),
+		}))
+
+		model, certsClient = makeModel(t, &gateway)
+		certsClient.bundles[staleName] = certificatesmanagement.CaBundleSummary{
+			Id:             new("stale-id"),
+			Name:           new(staleName),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateActive,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "hash"),
+		}
+		certsClient.deleteErr = errors.New("delete failed")
+		err = model.cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
+			gateway:       &gateway,
+			compartmentID: "compartment-" + fakeData.Lorem().Word(),
+		})
+		require.ErrorContains(t, err, "failed to delete OCI CA bundle")
+	})
+
+	t.Run("direct CA bundle helpers cover fallback and error paths", func(t *testing.T) {
+		fakeData := faker.New()
+		port := gatewayv1.PortNumber(8443)
+		defaultValidation := &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  "ca-" + gatewayv1.ObjectName(fakeData.Lorem().Word()),
+			}},
+		}
+		gateway := makeGateway(t, port, defaultValidation)
+		gateway.Spec.TLS.Frontend.PerPort = []gatewayv1.TLSPortConfig{{
+			Port: port + 1,
+			TLS:  gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{}},
+		}}
+		assert.Same(t, defaultValidation, effectiveFrontendTLSValidation(gateway, port))
+		assert.Nil(t, frontendMTLSOCICABundleIDs(gatewayv1.Gateway{}, port))
+
+		model, _ := makeModel(t)
+		err := model.ensureFrontendMTLSCompartment(
+			t.Context(),
+			gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: gateway.Namespace, Name: gateway.Name}},
+			"compartment-"+fakeData.Lorem().Word(),
+		)
+		require.ErrorContains(t, err, "failed to record frontend mTLS CA bundle compartment")
+
+		gateway.Annotations[GatewayFrontendMTLSCABundleCompartmentsAnnotation] = "existing"
+		require.NoError(t, model.ensureFrontendMTLSCompartment(t.Context(), gateway, "existing"))
+		require.NoError(t, model.ensureFrontendMTLSCompartment(t.Context(), gateway, ""))
+
+		pendingName := "pending-" + fakeData.Lorem().Word()
+		err = ensureFrontendMTLSCABundleUsable(certificatesmanagement.CaBundleSummary{
+			Name:           &pendingName,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateFailed,
+		})
+		require.ErrorContains(t, err, "not ready")
+	})
+
+	t.Run("direct existing CA bundle resolver handles list and deleted-only failures", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 443, nil)
+		model, certsClient := makeModel(t, &gateway)
+		name := "ca-" + fakeData.Lorem().Word()
+		compartmentID := "compartment-" + fakeData.Lorem().Word()
+		certsClient.listErr = errors.New("list failed")
+
+		_, err := model.resolveExistingFrontendMTLSCABundle(t.Context(), gateway, compartmentID, name, "hash")
+
+		require.ErrorContains(t, err, "failed to re-list OCI CA bundle")
+
+		model, certsClient = makeModel(t, &gateway)
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:             new("deleted-id"),
+			Name:           &name,
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateDeleted,
+			FreeformTags:   frontendMTLSCABundleTags(gateway, 443, "hash"),
+		}
+		_, err = model.resolveExistingFrontendMTLSCABundle(t.Context(), gateway, compartmentID, name, "hash")
+		require.ErrorContains(t, err, "was not visible")
+	})
+
+	t.Run("helper functions are deterministic", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 8443, nil)
+		gateway.UID = apitypes.UID("uid-" + fakeData.UUID().V4())
+		ref := gatewayv1.ObjectReference{
+			Group: "",
+			Kind:  "ConfigMap",
+			Name:  "ca-" + gatewayv1.ObjectName(fakeData.Lorem().Word()),
+		}
+
+		name := frontendMTLSCABundleName(gateway, 8443, ref)
+
+		assert.True(t, strings.HasPrefix(name, frontendMTLSCABundleNamePrefix))
+		assert.Len(t, name, len(frontendMTLSCABundleNamePrefix)+24)
+		assert.Equal(t, string(gateway.UID), frontendMTLSGatewayIdentity(gateway))
+		assert.True(t, isOwnedFrontendMTLSCABundle(frontendMTLSCABundleTags(gateway, 8443, "hash"), gateway))
+		assert.False(t, isOwnedFrontendMTLSCABundle(nil, gateway))
+		assert.False(t, isFrontendMTLSCABundleAlreadyExists(errors.New("plain")))
+		assert.False(t, isFrontendMTLSCABundleAlreadyDeleted(errors.New("plain")))
+
+		noUIDGateway := gateway
+		noUIDGateway.UID = ""
+		noUIDGateway.CreationTimestamp = metav1.NewTime(time.Now())
+		assert.NotEmpty(t, frontendMTLSGatewayIdentity(noUIDGateway))
+
+		noTimestampGateway := noUIDGateway
+		noTimestampGateway.CreationTimestamp = metav1.Time{}
+		noTimestampGateway.Generation = 17
+		assert.Equal(t, "17", frontendMTLSGatewayIdentity(noTimestampGateway))
+		assert.Equal(t, defaultFrontendMTLSVerifyDepth, lo.Must(frontendMTLSVerifyDepth(gatewayv1.Gateway{}, 8443)))
+	})
+
+	t.Run("Gateway frontend mTLS configured helper handles spec and annotations", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 443, nil)
+		assert.True(t, gatewayFrontendMTLSConfigured(gateway))
+
+		gateway.Spec.TLS = nil
+		gateway.Annotations = nil
+		assert.False(t, gatewayFrontendMTLSConfigured(gateway))
+
+		gateway.Annotations = map[string]string{
+			FrontendMTLSVerifyDepthAnnotation: " ",
+		}
+		assert.False(t, gatewayFrontendMTLSConfigured(gateway))
+
+		gateway.Annotations[frontendMTLSPortTrustedCABundleOCIDsAnnotation(443)] =
+			"ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		assert.True(t, gatewayFrontendMTLSConfigured(gateway))
+	})
+}

--- a/internal/app/frontend_mtls_model_test.go
+++ b/internal/app/frontend_mtls_model_test.go
@@ -987,12 +987,36 @@ func TestFrontendMTLSModel(t *testing.T) {
 
 	t.Run("Gateway frontend mTLS configured helper handles spec and annotations", func(t *testing.T) {
 		fakeData := faker.New()
-		gateway := makeGateway(t, 443, nil)
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word()),
+			}},
+		})
 		assert.True(t, gatewayFrontendMTLSConfigured(gateway))
 
 		gateway.Spec.TLS = nil
 		gateway.Annotations = nil
 		assert.False(t, gatewayFrontendMTLSConfigured(gateway))
+
+		gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+			Frontend: &gatewayv1.FrontendTLSConfig{Default: gatewayv1.TLSConfig{}},
+		}
+		assert.False(t, gatewayFrontendMTLSConfigured(gateway))
+
+		gateway.Spec.TLS.Frontend.PerPort = []gatewayv1.TLSPortConfig{{
+			Port: 443,
+			TLS: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+				CACertificateRefs: []gatewayv1.ObjectReference{{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word()),
+				}},
+			}},
+		}}
+		assert.True(t, gatewayFrontendMTLSConfigured(gateway))
+		gateway.Spec.TLS = nil
 
 		gateway.Annotations = map[string]string{
 			FrontendMTLSVerifyDepthAnnotation: " ",

--- a/internal/app/frontend_mtls_model_test.go
+++ b/internal/app/frontend_mtls_model_test.go
@@ -89,7 +89,7 @@ func TestFrontendMTLSModel(t *testing.T) {
 		)
 	}
 
-	t.Run("applies standard ConfigMap CA refs to listener SSL configuration", func(t *testing.T) {
+	t.Run("uses listener certificate alias CA bundle for standard ConfigMap CA refs", func(t *testing.T) {
 		refName := gatewayv1.ObjectName("ca-" + faker.New().Lorem().Word())
 		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
 			CACertificateRefs: []gatewayv1.ObjectReference{{
@@ -112,8 +112,37 @@ func TestFrontendMTLSModel(t *testing.T) {
 		require.NotNil(t, got)
 		assert.True(t, lo.FromPtr(got.VerifyPeerCertificate))
 		assert.Equal(t, defaultFrontendMTLSVerifyDepth, lo.FromPtr(got.VerifyDepth))
+		assert.Empty(t, got.TrustedCertificateAuthorityIds)
+		assert.Empty(t, certsClient.createCalls)
+	})
+
+	t.Run("creates OCI CA bundles for standard ConfigMap CA refs with OCI certificate IDs", func(t *testing.T) {
+		refName := gatewayv1.ObjectName("ca-" + faker.New().Lorem().Word())
+		gateway := makeGateway(t, 443, &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  refName,
+			}},
+		})
+		configMap := makeConfigMap(t, gateway.Namespace, refName)
+		model, certsClient := makeModel(t, &gateway, &configMap)
+		sslConfig := &loadbalancer.SslConfigurationDetails{
+			CertificateIds: []string{"ocid1.certificate.oc1.." + faker.New().UUID().V4()},
+		}
+
+		got, err := model.applyFrontendMTLS(t.Context(), reconcileHTTPListenerParams{
+			loadBalancerCompartmentID: "compartment-" + faker.New().Lorem().Word(),
+			listenerSpec:              &gateway.Spec.Listeners[0],
+			gateway:                   &gateway,
+		}, sslConfig)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, lo.FromPtr(got.VerifyPeerCertificate))
+		assert.Equal(t, defaultFrontendMTLSVerifyDepth, lo.FromPtr(got.VerifyDepth))
 		require.Len(t, got.TrustedCertificateAuthorityIds, 1)
-		assert.Len(t, certsClient.createCalls, 1)
+		require.Len(t, certsClient.createCalls, 1)
 		assert.Equal(t,
 			defaultCABundleName(gateway),
 			lo.FromPtr(certsClient.createCalls[0].CreateCaBundleDetails.Name),
@@ -147,16 +176,8 @@ func TestFrontendMTLSModel(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, 5, lo.FromPtr(got.VerifyDepth))
-		assert.Len(t, got.TrustedCertificateAuthorityIds, 1)
-		require.Len(t, certsClient.createCalls, 1)
-		assert.Equal(t,
-			frontendMTLSCABundleName(
-				gateway,
-				port,
-				gateway.Spec.TLS.Frontend.PerPort[0].TLS.Validation.CACertificateRefs[0],
-			),
-			lo.FromPtr(certsClient.createCalls[0].CreateCaBundleDetails.Name),
-		)
+		assert.Empty(t, got.TrustedCertificateAuthorityIds)
+		assert.Empty(t, certsClient.createCalls)
 	})
 
 	t.Run("uses existing OCI CA bundle OCIDs without creating bundles", func(t *testing.T) {
@@ -172,7 +193,9 @@ func TestFrontendMTLSModel(t *testing.T) {
 			loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
 			listenerSpec:              &gateway.Spec.Listeners[0],
 			gateway:                   &gateway,
-		}, &loadbalancer.SslConfigurationDetails{CertificateName: new("cert")})
+		}, &loadbalancer.SslConfigurationDetails{
+			CertificateIds: []string{"ocid1.certificate.oc1.." + fakeData.UUID().V4()},
+		})
 
 		require.NoError(t, err)
 		assert.Equal(t, []string{ociCAID}, got.TrustedCertificateAuthorityIds)
@@ -936,11 +959,19 @@ func TestFrontendMTLSModel(t *testing.T) {
 
 		assert.True(t, strings.HasPrefix(name, frontendMTLSCABundleNamePrefix))
 		assert.Len(t, name, len(frontendMTLSCABundleNamePrefix)+24)
+		refNamespace := gatewayv1.Namespace("ca-ns-" + fakeData.Lorem().Word())
+		namespacedRef := ref
+		namespacedRef.Namespace = &refNamespace
+		assert.NotEqual(t, name, frontendMTLSCABundleName(gateway, 8443, namespacedRef))
 		assert.Equal(t, string(gateway.UID), frontendMTLSGatewayIdentity(gateway))
 		assert.True(t, isOwnedFrontendMTLSCABundle(frontendMTLSCABundleTags(gateway, 8443, "hash"), gateway))
 		assert.False(t, isOwnedFrontendMTLSCABundle(nil, gateway))
 		assert.False(t, isFrontendMTLSCABundleAlreadyExists(errors.New("plain")))
 		assert.False(t, isFrontendMTLSCABundleAlreadyDeleted(errors.New("plain")))
+		require.ErrorContains(t, ensureFrontendMTLSCABundleUsable(certificatesmanagement.CaBundleSummary{
+			Name:           new("bundle-" + fakeData.Lorem().Word()),
+			LifecycleState: certificatesmanagement.CaBundleLifecycleStateFailed,
+		}), "not ready")
 
 		noUIDGateway := gateway
 		noUIDGateway.UID = ""
@@ -971,5 +1002,82 @@ func TestFrontendMTLSModel(t *testing.T) {
 		gateway.Annotations[frontendMTLSPortTrustedCABundleOCIDsAnnotation(443)] =
 			"ocid1.cabundle.oc1.." + fakeData.UUID().V4()
 		assert.True(t, gatewayFrontendMTLSConfigured(gateway))
+	})
+
+	t.Run("desired CA bundle names only include OCI certificate ID listeners", func(t *testing.T) {
+		fakeData := faker.New()
+		validation := &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: []gatewayv1.ObjectReference{{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word()),
+			}},
+		}
+		gateway := makeGateway(t, 443, validation)
+		secretBackedListener := gateway.Spec.Listeners[0]
+
+		assert.Empty(t, desiredFrontendMTLSCABundleNames(gateway, []gatewayv1.Listener{secretBackedListener}))
+
+		ociIDListener := secretBackedListener
+		ociIDListener.TLS.Options = map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+			ListenerTLSOptionOCICertificateOCID: gatewayv1.AnnotationValue(
+				"ocid1.certificate.oc1.." + fakeData.UUID().V4(),
+			),
+		}
+		got := desiredFrontendMTLSCABundleNames(gateway, []gatewayv1.Listener{ociIDListener})
+
+		assert.Contains(t, got, frontendMTLSCABundleName(gateway, 443, validation.CACertificateRefs[0]))
+
+		gateway.Spec.TLS = nil
+		assert.Empty(t, desiredFrontendMTLSCABundleNames(gateway, []gatewayv1.Listener{ociIDListener}))
+	})
+
+	t.Run("listener certificate CA helper covers empty and invalid OCI CA option paths", func(t *testing.T) {
+		fakeData := faker.New()
+		gateway := makeGateway(t, 443, nil)
+		gateway.Spec.TLS = nil
+		model, _ := makeModel(t, &gateway)
+
+		got, err := model.frontendMTLSCAForListenerCertificate(t.Context(), listenerSecretCertificatesParams{
+			gatewayNamespace: gateway.Namespace,
+			gateway:          &gateway,
+			listenerSpec:     gateway.Spec.Listeners[0],
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, got)
+
+		gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] =
+			"ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		got, err = model.frontendMTLSCAForListenerCertificate(t.Context(), listenerSecretCertificatesParams{
+			gatewayNamespace: gateway.Namespace,
+			gateway:          &gateway,
+			listenerSpec:     gateway.Spec.Listeners[0],
+		})
+
+		require.ErrorContains(t, err, "OCI CA bundle OCID annotations require listener")
+		assert.Empty(t, got)
+
+		gateway.Annotations = map[string]string{}
+		gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+			Frontend: &gatewayv1.FrontendTLSConfig{
+				Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+					Mode: gatewayv1.FrontendValidationModeType("InvalidMode"),
+					CACertificateRefs: []gatewayv1.ObjectReference{{
+						Group: "",
+						Kind:  "ConfigMap",
+						Name:  gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word()),
+					}},
+				}},
+			},
+		}
+		got, err = model.frontendMTLSCAForListenerCertificate(t.Context(), listenerSecretCertificatesParams{
+			gatewayNamespace: gateway.Namespace,
+			gateway:          &gateway,
+			listenerSpec:     gateway.Spec.Listeners[0],
+		})
+
+		require.ErrorContains(t, err, "InvalidMode")
+		assert.Empty(t, got)
 	})
 }

--- a/internal/app/frontend_mtls_model_test.go
+++ b/internal/app/frontend_mtls_model_test.go
@@ -983,6 +983,16 @@ func TestFrontendMTLSModel(t *testing.T) {
 		noTimestampGateway.Generation = 17
 		assert.Equal(t, "17", frontendMTLSGatewayIdentity(noTimestampGateway))
 		assert.Equal(t, defaultFrontendMTLSVerifyDepth, lo.Must(frontendMTLSVerifyDepth(gatewayv1.Gateway{}, 8443)))
+
+		port := gatewayv1.PortNumber(8443)
+		portAnnotation := frontendMTLSPortVerifyDepthAnnotation(port)
+		gateway.Annotations = map[string]string{
+			FrontendMTLSVerifyDepthAnnotation: "4",
+			portAnnotation:                    "invalid",
+		}
+		_, err := frontendMTLSVerifyDepth(gateway, port)
+		require.ErrorContains(t, err, portAnnotation)
+		require.NotContains(t, err.Error(), FrontendMTLSVerifyDepthAnnotation)
 	})
 
 	t.Run("Gateway frontend mTLS configured helper handles spec and annotations", func(t *testing.T) {

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -536,9 +536,10 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 	}
 
 	if err = m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
-		loadBalancerID:   loadBalancerID,
-		knownListeners:   response.LoadBalancer.Listeners,
-		gatewayListeners: gatewayListeners,
+		loadBalancerID:       loadBalancerID,
+		knownListeners:       response.LoadBalancer.Listeners,
+		knownRoutingPolicies: response.LoadBalancer.RoutingPolicies,
+		gatewayListeners:     gatewayListeners,
 	}); err != nil {
 		return fmt.Errorf("failed to remove missing listeners: %w", err)
 	}

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/samber/lo"
 	"go.uber.org/dig"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -512,18 +513,26 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 		listenerName := string(listener.Name)
 
 		params := reconcileHTTPListenerParams{
-			loadBalancerID:        loadBalancerID,
-			knownListeners:        response.LoadBalancer.Listeners,
-			knownRoutingPolicies:  response.LoadBalancer.RoutingPolicies,
-			listenerCertificates:  reconcileListenersCertificatesResult.certificatesByListener[listenerName],
-			listenerCertificateID: reconcileListenersCertificatesResult.certificateIDsByListener[listenerName],
-			defaultBackendSetName: *defaultBackendSet.Name,
-			listenerSpec:          &listener,
+			loadBalancerID:            loadBalancerID,
+			loadBalancerCompartmentID: lo.FromPtr(response.LoadBalancer.CompartmentId),
+			knownListeners:            response.LoadBalancer.Listeners,
+			knownRoutingPolicies:      response.LoadBalancer.RoutingPolicies,
+			listenerCertificates:      reconcileListenersCertificatesResult.certificatesByListener[listenerName],
+			listenerCertificateID:     reconcileListenersCertificatesResult.certificateIDsByListener[listenerName],
+			defaultBackendSetName:     *defaultBackendSet.Name,
+			listenerSpec:              &listener,
+		}
+		if gatewayFrontendMTLSConfigured(data.gateway) {
+			params.gateway = &data.gateway
 		}
 
 		if err = m.ociLoadBalancerModel.reconcileHTTPListener(ctx, params); err != nil {
 			return fmt.Errorf("failed to reconcile listener %s: %w", listener.Name, err)
 		}
+	}
+
+	if err = m.cleanupFrontendMTLSCABundles(ctx, data, gatewayManagedListeners, response.LoadBalancer); err != nil {
+		return err
 	}
 
 	if err = m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
@@ -548,6 +557,67 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 	}
 
 	return nil
+}
+
+func (m *gatewayModelImpl) cleanupFrontendMTLSCABundles(
+	ctx context.Context,
+	data *resolvedGatewayDetails,
+	gatewayManagedListeners []gatewayv1.Listener,
+	loadBalancer loadbalancer.LoadBalancer,
+) error {
+	desiredBundleNames := desiredFrontendMTLSCABundleNames(data.gateway, gatewayManagedListeners)
+	if len(desiredBundleNames) == 0 &&
+		data.gateway.Annotations[GatewayFrontendMTLSCABundleCompartmentsAnnotation] == "" {
+		return nil
+	}
+	if err := m.ociLoadBalancerModel.cleanupFrontendMTLSCABundles(ctx, cleanupFrontendMTLSCABundlesParams{
+		gateway:            &data.gateway,
+		compartmentID:      lo.FromPtr(loadBalancer.CompartmentId),
+		desiredBundleNames: desiredBundleNames,
+	}); err != nil {
+		return fmt.Errorf("failed to clean up frontend mTLS CA bundles: %w", err)
+	}
+	return nil
+}
+
+func desiredFrontendMTLSCABundleNames(
+	gateway gatewayv1.Gateway,
+	gatewayManagedListeners []gatewayv1.Listener,
+) map[string]struct{} {
+	desiredBundleNames := make(map[string]struct{})
+	for _, listener := range gatewayManagedListeners {
+		if !gatewayFrontendMTLSConfigured(gateway) || listener.TLS == nil {
+			continue
+		}
+		validation := effectiveFrontendTLSValidation(gateway, listener.Port)
+		if validation == nil || len(validation.CACertificateRefs) == 0 {
+			continue
+		}
+		for _, ref := range validation.CACertificateRefs {
+			desiredBundleNames[frontendMTLSCABundleName(gateway, listener.Port, ref)] = struct{}{}
+		}
+	}
+	return desiredBundleNames
+}
+
+func gatewayFrontendMTLSConfigured(gateway gatewayv1.Gateway) bool {
+	if gateway.Spec.TLS != nil && gateway.Spec.TLS.Frontend != nil {
+		return true
+	}
+	if gateway.Annotations == nil {
+		return false
+	}
+	for key, value := range gateway.Annotations {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		if key == FrontendMTLSTrustedCABundleOCIDsAnnotation ||
+			key == FrontendMTLSVerifyDepthAnnotation ||
+			strings.HasPrefix(key, "oci.oraclecloud.com/frontend-mtls-") {
+			return true
+		}
+	}
+	return false
 }
 
 func gatewayStatusAddressesFromLoadBalancer(lb *loadbalancer.LoadBalancer) []gatewayv1.GatewayStatusAddress {

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/gemyago/oke-gateway-api/internal/types"
 )
@@ -98,6 +99,9 @@ type resolvedGatewayDetails struct {
 	// Map of secret full name to the secret object
 	// holds all secrets that are used by the gateway (mostly listeners certificates)
 	gatewaySecrets map[string]corev1.Secret
+
+	gatewayFrontendMTLSConfigMaps      map[string]corev1.ConfigMap
+	gatewayFrontendMTLSReferenceGrants map[string]gatewayv1beta1.ReferenceGrant
 
 	config types.GatewayConfig
 
@@ -205,10 +209,146 @@ func (m *gatewayModelImpl) resolveReconcileRequest(
 	if err := m.populateGatewaySecrets(ctx, receiver); err != nil {
 		return false, err
 	}
+	if err := m.populateGatewayFrontendMTLSDependencies(ctx, receiver); err != nil {
+		return false, err
+	}
 
 	// TODO: Make sure config is complete
 
 	return true, nil
+}
+
+func (m *gatewayModelImpl) populateGatewayFrontendMTLSDependencies(
+	ctx context.Context,
+	receiver *resolvedGatewayDetails,
+) error {
+	receiver.gatewayFrontendMTLSConfigMaps = make(map[string]corev1.ConfigMap)
+	receiver.gatewayFrontendMTLSReferenceGrants = make(map[string]gatewayv1beta1.ReferenceGrant)
+	refs := frontendMTLSConfigMapRefs(receiver.gateway)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	listedGrantNamespaces := make(map[string]struct{})
+	for _, fullName := range refs {
+		if err := m.populateGatewayFrontendMTLSConfigMapDependency(ctx, receiver, fullName); err != nil {
+			return err
+		}
+		if frontendMTLSReferenceGrantsAlreadyListed(receiver.gateway, fullName, listedGrantNamespaces) {
+			continue
+		}
+		listedGrantNamespaces[fullName.Namespace] = struct{}{}
+		if err := m.populateGatewayFrontendMTLSReferenceGrantDependencies(
+			ctx,
+			receiver,
+			refs,
+			fullName.Namespace,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *gatewayModelImpl) populateGatewayFrontendMTLSConfigMapDependency(
+	ctx context.Context,
+	receiver *resolvedGatewayDetails,
+	fullName apitypes.NamespacedName,
+) error {
+	var configMap corev1.ConfigMap
+	if err := m.client.Get(ctx, fullName, &configMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get frontend mTLS ConfigMap %s: %w", fullName.String(), err)
+	}
+	receiver.gatewayFrontendMTLSConfigMaps[fullName.String()] = configMap
+	return nil
+}
+
+func frontendMTLSReferenceGrantsAlreadyListed(
+	gateway gatewayv1.Gateway,
+	fullName apitypes.NamespacedName,
+	listedGrantNamespaces map[string]struct{},
+) bool {
+	if fullName.Namespace == gateway.Namespace {
+		return true
+	}
+	_, listed := listedGrantNamespaces[fullName.Namespace]
+	return listed
+}
+
+func (m *gatewayModelImpl) populateGatewayFrontendMTLSReferenceGrantDependencies(
+	ctx context.Context,
+	receiver *resolvedGatewayDetails,
+	refs []apitypes.NamespacedName,
+	namespace string,
+) error {
+	var grants gatewayv1beta1.ReferenceGrantList
+	if err := m.client.List(ctx, &grants, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf(
+			"failed to list frontend mTLS ReferenceGrants in namespace %s: %w",
+			namespace,
+			err,
+		)
+	}
+	for _, grant := range grants.Items {
+		m.addGatewayFrontendMTLSReferenceGrantDependency(receiver, refs, grant)
+	}
+	return nil
+}
+
+func (m *gatewayModelImpl) addGatewayFrontendMTLSReferenceGrantDependency(
+	receiver *resolvedGatewayDetails,
+	refs []apitypes.NamespacedName,
+	grant gatewayv1beta1.ReferenceGrant,
+) {
+	if !referenceGrantHasMatchingFrom(grant, gatewayv1.Kind("Gateway"), receiver.gateway.Namespace) {
+		return
+	}
+	for _, ref := range refs {
+		if ref.Namespace != grant.Namespace {
+			continue
+		}
+		if referenceGrantHasMatchingCoreTo(grant, "ConfigMap", ref.Name) {
+			receiver.gatewayFrontendMTLSReferenceGrants[client.ObjectKeyFromObject(&grant).String()] = grant
+			return
+		}
+	}
+}
+
+func frontendMTLSConfigMapRefs(gateway gatewayv1.Gateway) []apitypes.NamespacedName {
+	if gateway.Spec.TLS == nil || gateway.Spec.TLS.Frontend == nil {
+		return nil
+	}
+	refsByKey := make(map[apitypes.NamespacedName]struct{})
+	addRefs := func(validation *gatewayv1.FrontendTLSValidation) {
+		if validation == nil {
+			return
+		}
+		for _, ref := range validation.CACertificateRefs {
+			if ref.Group != "" || ref.Kind != "ConfigMap" {
+				continue
+			}
+			refNamespace := gateway.Namespace
+			if ref.Namespace != nil {
+				refNamespace = string(*ref.Namespace)
+			}
+			refsByKey[apitypes.NamespacedName{
+				Namespace: refNamespace,
+				Name:      string(ref.Name),
+			}] = struct{}{}
+		}
+	}
+	addRefs(gateway.Spec.TLS.Frontend.Default.Validation)
+	for _, portConfig := range gateway.Spec.TLS.Frontend.PerPort {
+		addRefs(portConfig.TLS.Validation)
+	}
+	refs := lo.Keys(refsByKey)
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].String() < refs[j].String()
+	})
+	return refs
 }
 
 func (m *gatewayModelImpl) populateGatewaySecrets(
@@ -531,10 +671,6 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 		}
 	}
 
-	if err = m.cleanupFrontendMTLSCABundles(ctx, data, gatewayManagedListeners, response.LoadBalancer); err != nil {
-		return err
-	}
-
 	if err = m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
 		loadBalancerID:       loadBalancerID,
 		knownListeners:       response.LoadBalancer.Listeners,
@@ -542,6 +678,10 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 		gatewayListeners:     gatewayListeners,
 	}); err != nil {
 		return fmt.Errorf("failed to remove missing listeners: %w", err)
+	}
+
+	if err = m.cleanupFrontendMTLSCABundles(ctx, data, gatewayManagedListeners, response.LoadBalancer); err != nil {
+		return err
 	}
 
 	if err = m.ociLoadBalancerModel.removeUnusedCertificates(ctx, removeUnusedCertificatesParams{
@@ -648,45 +788,16 @@ func gatewayStatusAddressesFromLoadBalancer(lb *loadbalancer.LoadBalancer) []gat
 }
 
 func (m *gatewayModelImpl) isProgrammed(_ context.Context, data *resolvedGatewayDetails) bool {
-	annotations := map[string]string{
-		GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
-		GatewayProgrammedCertificatesAnnotation: programmedGatewayCertificatesAnnotation(
-			programmedCertificateNamesFromSecrets(data.gatewaySecrets),
-		),
-	}
-
-	// Include secrets annotations in the check
-	if len(data.gatewaySecrets) > 0 {
-		for _, secret := range data.gatewaySecrets {
-			secretUID := string(secret.UID)
-			annotationKey := GatewayUsedSecretsAnnotationPrefix + "/" + secretUID
-			annotations[annotationKey] = secret.ResourceVersion
-		}
-	}
-
 	return m.resourcesModel.isConditionSet(isConditionSetParams{
 		resource:      &data.gateway,
 		conditions:    data.gateway.Status.Conditions,
 		conditionType: string(gatewayv1.GatewayConditionProgrammed),
-		annotations:   annotations,
+		annotations:   programmedGatewayAnnotations(data),
 	})
 }
 
 func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGatewayDetails) error {
-	annotations := map[string]string{
-		GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
-		GatewayProgrammedCertificatesAnnotation: programmedGatewayCertificatesAnnotation(
-			programmedCertificateNamesFromSecrets(data.gatewaySecrets),
-		),
-	}
-
-	if len(data.gatewaySecrets) > 0 {
-		for _, secret := range data.gatewaySecrets {
-			secretUID := string(secret.UID)
-			annotationKey := GatewayUsedSecretsAnnotationPrefix + "/" + secretUID
-			annotations[annotationKey] = secret.ResourceVersion
-		}
-	}
+	annotations := programmedGatewayAnnotations(data)
 
 	data.gateway.Status.Addresses = gatewayStatusAddressesFromLoadBalancer(data.loadBalancer)
 	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets, data.effectiveListeners)
@@ -710,6 +821,67 @@ func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGate
 		return err
 	}
 	return nil
+}
+
+func programmedGatewayAnnotations(data *resolvedGatewayDetails) map[string]string {
+	annotations := map[string]string{
+		GatewayProgrammingRevisionAnnotation: GatewayProgrammingRevisionValue,
+		GatewayProgrammedCertificatesAnnotation: programmedGatewayCertificatesAnnotation(
+			programmedCertificateNamesFromSecrets(data.gatewaySecrets),
+		),
+	}
+
+	if len(data.gatewaySecrets) > 0 {
+		for _, secret := range data.gatewaySecrets {
+			secretUID := string(secret.UID)
+			annotationKey := GatewayUsedSecretsAnnotationPrefix + "/" + secretUID
+			annotations[annotationKey] = secret.ResourceVersion
+		}
+	}
+
+	if len(frontendMTLSConfigMapRefs(data.gateway)) > 0 {
+		annotations[GatewayFrontendMTLSConfigMapsAnnotation] = configMapRevisionsAnnotation(
+			data.gatewayFrontendMTLSConfigMaps,
+		)
+	}
+	if len(data.gatewayFrontendMTLSReferenceGrants) > 0 ||
+		gatewayHasCrossNamespaceFrontendMTLSConfigMapRefs(data.gateway) {
+		annotations[GatewayFrontendMTLSReferenceGrantsAnnotation] = referenceGrantRevisionsAnnotation(
+			data.gatewayFrontendMTLSReferenceGrants,
+		)
+	}
+	return annotations
+}
+
+func gatewayHasCrossNamespaceFrontendMTLSConfigMapRefs(gateway gatewayv1.Gateway) bool {
+	for _, ref := range frontendMTLSConfigMapRefs(gateway) {
+		if ref.Namespace != gateway.Namespace {
+			return true
+		}
+	}
+	return false
+}
+
+func configMapRevisionsAnnotation(objects map[string]corev1.ConfigMap) string {
+	keys := lo.Keys(objects)
+	sort.Strings(keys)
+	revisions := make([]string, 0, len(keys))
+	for _, key := range keys {
+		object := objects[key]
+		revisions = append(revisions, fmt.Sprintf("%s=%s/%s", key, object.UID, object.ResourceVersion))
+	}
+	return strings.Join(revisions, ",")
+}
+
+func referenceGrantRevisionsAnnotation(objects map[string]gatewayv1beta1.ReferenceGrant) string {
+	keys := lo.Keys(objects)
+	sort.Strings(keys)
+	revisions := make([]string, 0, len(keys))
+	for _, key := range keys {
+		object := objects[key]
+		revisions = append(revisions, fmt.Sprintf("%s=%s/%s", key, object.UID, object.ResourceVersion))
+	}
+	return strings.Join(revisions, ",")
 }
 
 func setListenerSetsProgrammed(

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -802,13 +802,14 @@ func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGate
 	data.gateway.Status.Addresses = gatewayStatusAddressesFromLoadBalancer(data.loadBalancer)
 	data.gateway.Status.AttachedListenerSets = attachedListenerSetCount(data.listenerSets, data.effectiveListeners)
 	if err := m.resourcesModel.setCondition(ctx, setConditionParams{
-		resource:      &data.gateway,
-		conditions:    &data.gateway.Status.Conditions,
-		conditionType: string(gatewayv1.GatewayConditionProgrammed),
-		status:        metav1.ConditionTrue,
-		reason:        string(gatewayv1.GatewayReasonProgrammed),
-		message:       fmt.Sprintf("Gateway %s programmed by %s", data.gateway.Name, ControllerClassName),
-		annotations:   annotations,
+		resource:          &data.gateway,
+		conditions:        &data.gateway.Status.Conditions,
+		conditionType:     string(gatewayv1.GatewayConditionProgrammed),
+		status:            metav1.ConditionTrue,
+		reason:            string(gatewayv1.GatewayReasonProgrammed),
+		message:           fmt.Sprintf("Gateway %s programmed by %s", data.gateway.Name, ControllerClassName),
+		annotations:       annotations,
+		removeAnnotations: staleProgrammedGatewayAnnotations(annotations),
 	}); err != nil {
 		return fmt.Errorf("failed to set programmed condition for Gateway %s: %w", data.gateway.Name, err)
 	}
@@ -851,6 +852,20 @@ func programmedGatewayAnnotations(data *resolvedGatewayDetails) map[string]strin
 		)
 	}
 	return annotations
+}
+
+func staleProgrammedGatewayAnnotations(annotations map[string]string) []string {
+	keys := []string{
+		GatewayFrontendMTLSConfigMapsAnnotation,
+		GatewayFrontendMTLSReferenceGrantsAnnotation,
+	}
+	stale := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if _, found := annotations[key]; !found {
+			stale = append(stale, key)
+		}
+	}
+	return stale
 }
 
 func gatewayHasCrossNamespaceFrontendMTLSConfigMapRefs(gateway gatewayv1.Gateway) bool {

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -638,15 +638,14 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 
 	gatewayListeners := effectiveOCIListenersForGateway(data)
 	gatewayManagedListeners := gatewayManagedOCIListenersForLoadBalancer(data)
-	reconcileListenersCertificatesResult, err := m.ociLoadBalancerModel.reconcileListenersCertificates(ctx,
-		reconcileListenersCertificatesParams{
-			loadBalancerID:    loadBalancerID,
-			gateway:           &data.gateway,
-			gatewayListeners:  gatewayListeners,
-			knownCertificates: response.LoadBalancer.Certificates,
-		})
+	reconcileListenersCertificatesResult, err := m.reconcileGatewayListenerCertificates(
+		ctx,
+		data,
+		gatewayListeners,
+		response.LoadBalancer,
+	)
 	if err != nil {
-		return fmt.Errorf("failed to reconcile listeners certificates: %w", err)
+		return err
 	}
 
 	for _, listener := range gatewayManagedListeners {
@@ -671,13 +670,8 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 		}
 	}
 
-	if err = m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
-		loadBalancerID:       loadBalancerID,
-		knownListeners:       response.LoadBalancer.Listeners,
-		knownRoutingPolicies: response.LoadBalancer.RoutingPolicies,
-		gatewayListeners:     gatewayListeners,
-	}); err != nil {
-		return fmt.Errorf("failed to remove missing listeners: %w", err)
+	if err = m.removeMissingGatewayListeners(ctx, loadBalancerID, response.LoadBalancer, gatewayListeners); err != nil {
+		return err
 	}
 
 	if err = m.cleanupFrontendMTLSCABundles(ctx, data, gatewayManagedListeners, response.LoadBalancer); err != nil {
@@ -698,6 +692,82 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 	}
 
 	return nil
+}
+
+func (m *gatewayModelImpl) reconcileGatewayListenerCertificates(
+	ctx context.Context,
+	data *resolvedGatewayDetails,
+	gatewayListeners []gatewayv1.Listener,
+	loadBalancer loadbalancer.LoadBalancer,
+) (reconcileListenersCertificatesResult, error) {
+	result, err := m.ociLoadBalancerModel.reconcileListenersCertificates(ctx, reconcileListenersCertificatesParams{
+		loadBalancerID:    data.config.Spec.LoadBalancerID,
+		gateway:           &data.gateway,
+		gatewayListeners:  gatewayListeners,
+		knownCertificates: loadBalancer.Certificates,
+	})
+	if err != nil {
+		if isFrontendMTLSStatusError(err) {
+			if removeErr := m.failClosedFrontendMTLSListeners(
+				ctx,
+				data,
+				gatewayListeners,
+				loadBalancer,
+			); removeErr != nil {
+				return reconcileListenersCertificatesResult{}, removeErr
+			}
+		}
+		return reconcileListenersCertificatesResult{}, fmt.Errorf("failed to reconcile listeners certificates: %w", err)
+	}
+	return result, nil
+}
+
+func (m *gatewayModelImpl) removeMissingGatewayListeners(
+	ctx context.Context,
+	loadBalancerID string,
+	loadBalancer loadbalancer.LoadBalancer,
+	gatewayListeners []gatewayv1.Listener,
+) error {
+	if err := m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
+		loadBalancerID:       loadBalancerID,
+		knownListeners:       loadBalancer.Listeners,
+		knownRoutingPolicies: loadBalancer.RoutingPolicies,
+		gatewayListeners:     gatewayListeners,
+	}); err != nil {
+		return fmt.Errorf("failed to remove missing listeners: %w", err)
+	}
+	return nil
+}
+
+func (m *gatewayModelImpl) failClosedFrontendMTLSListeners(
+	ctx context.Context,
+	data *resolvedGatewayDetails,
+	gatewayListeners []gatewayv1.Listener,
+	loadBalancer loadbalancer.LoadBalancer,
+) error {
+	if err := m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
+		loadBalancerID:       data.config.Spec.LoadBalancerID,
+		knownListeners:       loadBalancer.Listeners,
+		knownRoutingPolicies: loadBalancer.RoutingPolicies,
+		gatewayListeners:     gatewayListenersWithoutFrontendMTLS(data.gateway, gatewayListeners),
+	}); err != nil {
+		return fmt.Errorf("failed to fail closed frontend mTLS listeners: %w", err)
+	}
+	return nil
+}
+
+func gatewayListenersWithoutFrontendMTLS(
+	gateway gatewayv1.Gateway,
+	gatewayListeners []gatewayv1.Listener,
+) []gatewayv1.Listener {
+	keptListeners := []gatewayv1.Listener(nil)
+	for _, listener := range gatewayListeners {
+		if listenerUsesFrontendMTLS(gateway, listener) {
+			continue
+		}
+		keptListeners = append(keptListeners, listener)
+	}
+	return keptListeners
 }
 
 func (m *gatewayModelImpl) cleanupFrontendMTLSCABundles(
@@ -742,6 +812,16 @@ func desiredFrontendMTLSCABundleNames(
 		}
 	}
 	return desiredBundleNames
+}
+
+func listenerUsesFrontendMTLS(gateway gatewayv1.Gateway, listener gatewayv1.Listener) bool {
+	if listener.TLS == nil {
+		return false
+	}
+	if validation := effectiveFrontendTLSValidation(gateway, listener.Port); validation != nil {
+		return true
+	}
+	return len(frontendMTLSOCICABundleIDs(gateway, listener.Port)) > 0
 }
 
 func gatewayFrontendMTLSConfigured(gateway gatewayv1.Gateway) bool {

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -606,7 +606,15 @@ func desiredFrontendMTLSCABundleNames(
 
 func gatewayFrontendMTLSConfigured(gateway gatewayv1.Gateway) bool {
 	if gateway.Spec.TLS != nil && gateway.Spec.TLS.Frontend != nil {
-		return true
+		frontend := gateway.Spec.TLS.Frontend
+		if frontend.Default.Validation != nil {
+			return true
+		}
+		for _, portConfig := range frontend.PerPort {
+			if portConfig.TLS.Validation != nil {
+				return true
+			}
+		}
 	}
 	if gateway.Annotations == nil {
 		return false

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -589,6 +589,9 @@ func desiredFrontendMTLSCABundleNames(
 		if !gatewayFrontendMTLSConfigured(gateway) || listener.TLS == nil {
 			continue
 		}
+		if listenerOCICertificateOCID(listener) == "" {
+			continue
+		}
 		validation := effectiveFrontendTLSValidation(gateway, listener.Port)
 		if validation == nil || len(validation.CACertificateRefs) == 0 {
 			continue

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1134,6 +1134,138 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			require.NoError(t, err)
 		})
+		t.Run("programs frontend mTLS listener params and cleanup", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			fakeData := faker.New()
+
+			config := makeRandomGatewayConfig()
+			httpsListener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway()
+			gateway.Spec.Listeners = []gatewayv1.Listener{httpsListener}
+			ref := gatewayv1.ObjectReference{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word()),
+			}
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+						CACertificateRefs: []gatewayv1.ObjectReference{ref},
+					}},
+				},
+			}
+			compartmentID := "ocid1.compartment.oc1.." + fakeData.UUID().V4()
+			loadBalancer := makeRandomOCILoadBalancer(
+				randomOCILoadBalancerWithRandomBackendSetsOpt(),
+				randomOCILoadBalancerWithRandomPoliciesOpt(),
+				randomOCILoadBalancerWithRandomCertificatesOpt(),
+			)
+			loadBalancer.CompartmentId = &compartmentID
+			defaultBackendSet := makeRandomOCIBackendSet()
+			certificatesByListener := map[string][]loadbalancer.Certificate{
+				string(httpsListener.Name): {makeRandomOCICertificate()},
+			}
+			desiredBundleName := frontendMTLSCABundleName(*gateway, httpsListener.Port, ref)
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadBalancer}, nil)
+			loadBalancerModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			loadBalancerModel.EXPECT().
+				reconcileDefaultBackendSet(t.Context(), mock.Anything).
+				Return(defaultBackendSet, nil)
+			reconcileCertificatesCall := loadBalancerModel.EXPECT().
+				reconcileListenersCertificates(t.Context(), mock.Anything).
+				Return(reconcileListenersCertificatesResult{certificatesByListener: certificatesByListener}, nil)
+			loadBalancerModel.EXPECT().
+				reconcileHTTPListener(t.Context(), mock.MatchedBy(func(params reconcileHTTPListenerParams) bool {
+					return params.gateway != nil &&
+						params.gateway.Name == gateway.Name &&
+						params.loadBalancerCompartmentID == compartmentID &&
+						params.listenerSpec != nil &&
+						params.listenerSpec.Name == httpsListener.Name
+				})).
+				Return(nil).
+				Once().
+				NotBefore(reconcileCertificatesCall.Call)
+			cleanupCall := loadBalancerModel.EXPECT().
+				cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
+					gateway:       gateway,
+					compartmentID: compartmentID,
+					desiredBundleNames: map[string]struct{}{
+						desiredBundleName: {},
+					},
+				}).
+				Return(nil)
+			removeCall := loadBalancerModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.Anything).
+				Return(nil).
+				NotBefore(cleanupCall.Call)
+			loadBalancerModel.EXPECT().
+				removeUnusedCertificates(t.Context(), mock.Anything).
+				Return(nil).
+				NotBefore(removeCall)
+
+			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  config,
+			})
+
+			require.NoError(t, err)
+		})
+		t.Run("wraps frontend mTLS cleanup errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			fakeData := faker.New()
+
+			config := makeRandomGatewayConfig()
+			httpsListener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway()
+			gateway.Spec.Listeners = []gatewayv1.Listener{httpsListener}
+			gateway.Annotations = map[string]string{}
+			gateway.Annotations[GatewayFrontendMTLSCABundleCompartmentsAnnotation] =
+				"ocid1.compartment.oc1.." + fakeData.UUID().V4()
+			compartmentID := "ocid1.compartment.oc1.." + fakeData.UUID().V4()
+			loadBalancer := makeRandomOCILoadBalancer(
+				randomOCILoadBalancerWithRandomBackendSetsOpt(),
+				randomOCILoadBalancerWithRandomPoliciesOpt(),
+				randomOCILoadBalancerWithRandomCertificatesOpt(),
+			)
+			loadBalancer.CompartmentId = &compartmentID
+			defaultBackendSet := makeRandomOCIBackendSet()
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadBalancer}, nil)
+			loadBalancerModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			loadBalancerModel.EXPECT().
+				reconcileDefaultBackendSet(t.Context(), mock.Anything).
+				Return(defaultBackendSet, nil)
+			reconcileCertificatesCall := loadBalancerModel.EXPECT().
+				reconcileListenersCertificates(t.Context(), mock.Anything).
+				Return(reconcileListenersCertificatesResult{}, nil)
+			loadBalancerModel.EXPECT().
+				reconcileHTTPListener(t.Context(), mock.Anything).
+				Return(nil).
+				NotBefore(reconcileCertificatesCall.Call)
+			loadBalancerModel.EXPECT().
+				cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).
+				Return(errors.New("cleanup failed"))
+
+			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  config,
+			})
+
+			require.ErrorContains(t, err, "failed to clean up frontend mTLS CA bundles")
+		})
 		t.Run("programs ListenerSet listeners with derived OCI listener names", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newGatewayModel(deps)

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1767,6 +1767,10 @@ func TestGatewayModelImpl(t *testing.T) {
 						GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
 						GatewayProgrammedCertificatesAnnotation: "",
 					},
+					removeAnnotations: []string{
+						GatewayFrontendMTLSConfigMapsAnnotation,
+						GatewayFrontendMTLSReferenceGrantsAnnotation,
+					},
 				},
 			).Return(nil)
 
@@ -1818,6 +1822,10 @@ func TestGatewayModelImpl(t *testing.T) {
 					reason:        string(gatewayv1.GatewayReasonProgrammed),
 					message:       fmt.Sprintf("Gateway %s programmed by %s", data.gateway.Name, ControllerClassName),
 					annotations:   expectedAnnotations,
+					removeAnnotations: []string{
+						GatewayFrontendMTLSConfigMapsAnnotation,
+						GatewayFrontendMTLSReferenceGrantsAnnotation,
+					},
 				},
 			).Return(nil)
 

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1111,9 +1111,10 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			removeCall := loadBalancerModel.EXPECT().
 				removeMissingListeners(t.Context(), removeMissingListenersParams{
-					loadBalancerID:   config.Spec.LoadBalancerID,
-					knownListeners:   loadBalancer.Listeners,
-					gatewayListeners: gateway.Spec.Listeners,
+					loadBalancerID:       config.Spec.LoadBalancerID,
+					knownListeners:       loadBalancer.Listeners,
+					knownRoutingPolicies: loadBalancer.RoutingPolicies,
+					gatewayListeners:     gateway.Spec.Listeners,
 				}).
 				Return(nil)
 
@@ -1334,9 +1335,10 @@ func TestGatewayModelImpl(t *testing.T) {
 			}
 			removeCall := loadBalancerModel.EXPECT().
 				removeMissingListeners(t.Context(), removeMissingListenersParams{
-					loadBalancerID:   config.Spec.LoadBalancerID,
-					knownListeners:   loadBalancer.Listeners,
-					gatewayListeners: gatewayListeners,
+					loadBalancerID:       config.Spec.LoadBalancerID,
+					knownListeners:       loadBalancer.Listeners,
+					knownRoutingPolicies: loadBalancer.RoutingPolicies,
+					gatewayListeners:     gatewayListeners,
 				}).
 				Return(nil)
 			loadBalancerModel.EXPECT().

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1474,6 +1474,137 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			require.NoError(t, err)
 		})
+		t.Run("removes frontend mTLS listener when CA ReferenceGrant is revoked", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			config := makeRandomGatewayConfig()
+			listener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway()
+			caNamespace := gatewayv1.Namespace("security-" + fake.Lorem().Word())
+			gateway.Spec.Listeners = []gatewayv1.Listener{listener}
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					PerPort: []gatewayv1.TLSPortConfig{{
+						Port: listener.Port,
+						TLS: gatewayv1.TLSConfig{
+							Validation: &gatewayv1.FrontendTLSValidation{
+								CACertificateRefs: []gatewayv1.ObjectReference{{
+									Name:      gatewayv1.ObjectName("ca-bundle-" + fake.Lorem().Word()),
+									Namespace: &caNamespace,
+								}},
+							},
+						},
+					}},
+				},
+			}
+			knownListener := makeRandomOCIListener()
+			loadBalancer := makeRandomOCILoadBalancer(
+				randomOCILoadBalancerWithRandomBackendSetsOpt(),
+				randomOCILoadBalancerWithRandomPoliciesOpt(),
+				randomOCILoadBalancerWithRandomCertificatesOpt(),
+			)
+			loadBalancer.Listeners = map[string]loadbalancer.Listener{
+				string(listener.Name): knownListener,
+			}
+			defaultBackendSet := makeRandomOCIBackendSet()
+			statusErr := frontendMTLSStatusError(
+				string(gatewayv1.GatewayReasonInvalidParameters),
+				"frontend mTLS caCertificateRef is not permitted by a ReferenceGrant",
+			)
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadBalancer}, nil)
+			loadBalancerModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			loadBalancerModel.EXPECT().
+				reconcileDefaultBackendSet(t.Context(), mock.Anything).
+				Return(defaultBackendSet, nil)
+			reconcileCertificatesCall := loadBalancerModel.EXPECT().
+				reconcileListenersCertificates(t.Context(), mock.Anything).
+				Return(reconcileListenersCertificatesResult{}, statusErr)
+			loadBalancerModel.EXPECT().
+				removeMissingListeners(t.Context(), removeMissingListenersParams{
+					loadBalancerID:       config.Spec.LoadBalancerID,
+					knownListeners:       loadBalancer.Listeners,
+					knownRoutingPolicies: loadBalancer.RoutingPolicies,
+					gatewayListeners:     nil,
+				}).
+				Return(nil).
+				Once().
+				NotBefore(reconcileCertificatesCall.Call)
+
+			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  config,
+			})
+
+			require.ErrorIs(t, err, statusErr)
+		})
+		t.Run("returns fail closed listener removal errors", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			config := makeRandomGatewayConfig()
+			listener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway()
+			gateway.Spec.Listeners = []gatewayv1.Listener{listener}
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+						CACertificateRefs: []gatewayv1.ObjectReference{{
+							Name: gatewayv1.ObjectName("ca-bundle-" + fake.Lorem().Word()),
+						}},
+					}},
+				},
+			}
+			loadBalancer := makeRandomOCILoadBalancer(
+				randomOCILoadBalancerWithRandomBackendSetsOpt(),
+				randomOCILoadBalancerWithRandomPoliciesOpt(),
+				randomOCILoadBalancerWithRandomCertificatesOpt(),
+			)
+			loadBalancer.Listeners = map[string]loadbalancer.Listener{
+				string(listener.Name): makeRandomOCIListener(),
+			}
+			defaultBackendSet := makeRandomOCIBackendSet()
+			statusErr := frontendMTLSStatusError(
+				string(gatewayv1.GatewayReasonInvalidParameters),
+				"frontend mTLS caCertificateRef is not permitted by a ReferenceGrant",
+			)
+			wantErr := errors.New("remove failed")
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadBalancer}, nil)
+			loadBalancerModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			loadBalancerModel.EXPECT().
+				reconcileDefaultBackendSet(t.Context(), mock.Anything).
+				Return(defaultBackendSet, nil)
+			reconcileCertificatesCall := loadBalancerModel.EXPECT().
+				reconcileListenersCertificates(t.Context(), mock.Anything).
+				Return(reconcileListenersCertificatesResult{}, statusErr)
+			loadBalancerModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.Anything).
+				Return(wantErr).
+				Once().
+				NotBefore(reconcileCertificatesCall.Call)
+
+			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  config,
+			})
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to fail closed frontend mTLS listeners")
+		})
 		t.Run("failed to get OCI Load Balancer", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)
@@ -3172,6 +3303,41 @@ func TestProgrammedGatewayCertificatesAnnotation(t *testing.T) {
 			ociCertificateNameFromSecret(secretB),
 		}, got)
 	})
+}
+
+func TestGatewayFrontendMTLSListenerFiltering(t *testing.T) {
+	fake := faker.New()
+	plainHTTPListener := makeRandomListener(func(listener *gatewayv1.Listener) {
+		listener.Protocol = gatewayv1.HTTPProtocolType
+		listener.TLS = nil
+	})
+	httpsListener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+	ociCAListener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+	gateway := newRandomGateway()
+	gateway.Spec.Listeners = []gatewayv1.Listener{plainHTTPListener, httpsListener, ociCAListener}
+	gateway.Annotations = map[string]string{}
+	gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+		Frontend: &gatewayv1.FrontendTLSConfig{
+			PerPort: []gatewayv1.TLSPortConfig{{
+				Port: httpsListener.Port,
+				TLS: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+					CACertificateRefs: []gatewayv1.ObjectReference{{
+						Name: gatewayv1.ObjectName("ca-" + fake.Lorem().Word()),
+					}},
+				}},
+			}},
+		},
+	}
+	gateway.Annotations[frontendMTLSPortTrustedCABundleOCIDsAnnotation(ociCAListener.Port)] =
+		"ocid1.cabundle.oc1.." + fake.UUID().V4()
+
+	assert.False(t, listenerUsesFrontendMTLS(*gateway, plainHTTPListener))
+	assert.True(t, listenerUsesFrontendMTLS(*gateway, httpsListener))
+	assert.True(t, listenerUsesFrontendMTLS(*gateway, ociCAListener))
+	assert.Equal(t, []gatewayv1.Listener{plainHTTPListener}, gatewayListenersWithoutFrontendMTLS(
+		*gateway,
+		[]gatewayv1.Listener{plainHTTPListener, httpsListener, ociCAListener},
+	))
 }
 
 func TestGatewayCertificateOptionsValidation(t *testing.T) {

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1166,8 +1166,6 @@ func TestGatewayModelImpl(t *testing.T) {
 			certificatesByListener := map[string][]loadbalancer.Certificate{
 				string(httpsListener.Name): {makeRandomOCICertificate()},
 			}
-			desiredBundleName := frontendMTLSCABundleName(*gateway, httpsListener.Port, ref)
-
 			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
 			mockOciClient.EXPECT().
 				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
@@ -1192,23 +1190,13 @@ func TestGatewayModelImpl(t *testing.T) {
 				Return(nil).
 				Once().
 				NotBefore(reconcileCertificatesCall.Call)
-			cleanupCall := loadBalancerModel.EXPECT().
-				cleanupFrontendMTLSCABundles(t.Context(), cleanupFrontendMTLSCABundlesParams{
-					gateway:       gateway,
-					compartmentID: compartmentID,
-					desiredBundleNames: map[string]struct{}{
-						desiredBundleName: {},
-					},
-				}).
-				Return(nil)
 			removeCall := loadBalancerModel.EXPECT().
 				removeMissingListeners(t.Context(), mock.Anything).
-				Return(nil).
-				NotBefore(cleanupCall.Call)
+				Return(nil)
 			loadBalancerModel.EXPECT().
 				removeUnusedCertificates(t.Context(), mock.Anything).
 				Return(nil).
-				NotBefore(removeCall)
+				NotBefore(removeCall.Call)
 
 			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
 				gateway: *gateway,

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1244,9 +1244,13 @@ func TestGatewayModelImpl(t *testing.T) {
 				reconcileHTTPListener(t.Context(), mock.Anything).
 				Return(nil).
 				NotBefore(reconcileCertificatesCall.Call)
+			removeCall := loadBalancerModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.Anything).
+				Return(nil)
 			loadBalancerModel.EXPECT().
 				cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).
-				Return(errors.New("cleanup failed"))
+				Return(errors.New("cleanup failed")).
+				NotBefore(removeCall.Call)
 
 			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
 				gateway: *gateway,
@@ -1254,6 +1258,61 @@ func TestGatewayModelImpl(t *testing.T) {
 			})
 
 			require.ErrorContains(t, err, "failed to clean up frontend mTLS CA bundles")
+		})
+		t.Run("removes missing listeners before cleaning up frontend mTLS CA bundles", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			fakeData := faker.New()
+
+			config := makeRandomGatewayConfig()
+			httpsListener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway()
+			gateway.Spec.Listeners = []gatewayv1.Listener{httpsListener}
+			gateway.Annotations = map[string]string{
+				GatewayFrontendMTLSCABundleCompartmentsAnnotation: "ocid1.compartment.oc1.." + fakeData.UUID().V4(),
+			}
+			loadBalancer := makeRandomOCILoadBalancer(
+				randomOCILoadBalancerWithRandomBackendSetsOpt(),
+				randomOCILoadBalancerWithRandomPoliciesOpt(),
+				randomOCILoadBalancerWithRandomCertificatesOpt(),
+			)
+			defaultBackendSet := makeRandomOCIBackendSet()
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadBalancer}, nil)
+
+			loadBalancerModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			loadBalancerModel.EXPECT().
+				reconcileDefaultBackendSet(t.Context(), mock.Anything).
+				Return(defaultBackendSet, nil)
+			reconcileCertificatesCall := loadBalancerModel.EXPECT().
+				reconcileListenersCertificates(t.Context(), mock.Anything).
+				Return(reconcileListenersCertificatesResult{}, nil)
+			loadBalancerModel.EXPECT().
+				reconcileHTTPListener(t.Context(), mock.Anything).
+				Return(nil).
+				NotBefore(reconcileCertificatesCall.Call)
+			removeCall := loadBalancerModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.Anything).
+				Return(nil)
+			cleanupCall := loadBalancerModel.EXPECT().
+				cleanupFrontendMTLSCABundles(t.Context(), mock.Anything)
+			cleanupCall.Return(nil).NotBefore(removeCall.Call)
+			loadBalancerModel.EXPECT().
+				removeUnusedCertificates(t.Context(), mock.Anything).
+				Return(nil).
+				NotBefore(cleanupCall.Call)
+
+			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  config,
+			})
+
+			require.NoError(t, err)
 		})
 		t.Run("programs ListenerSet listeners with derived OCI listener names", func(t *testing.T) {
 			deps := newMockDeps(t)
@@ -1892,6 +1951,144 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			mockResourcesModel.AssertExpectations(t)
 		})
+
+		t.Run(
+			"should check frontend mTLS dependency annotations when gateway references CA config maps",
+			func(t *testing.T) {
+				deps := newMockDeps(t)
+				model := newGatewayModel(deps)
+				fakeData := faker.New()
+
+				configMapName := "ca-" + fakeData.Lorem().Word()
+				configMapUID := apitypes.UID(fakeData.UUID().V4())
+				configMapResourceVersion := fakeData.UUID().V4()
+				gateway := newRandomGateway()
+				gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+					Frontend: &gatewayv1.FrontendTLSConfig{
+						Default: gatewayv1.TLSConfig{
+							Validation: &gatewayv1.FrontendTLSValidation{
+								CACertificateRefs: []gatewayv1.ObjectReference{{
+									Group: "",
+									Kind:  "ConfigMap",
+									Name:  gatewayv1.ObjectName(configMapName),
+								}},
+							},
+						},
+					},
+				}
+				data := &resolvedGatewayDetails{
+					gateway: *gateway,
+					gatewayFrontendMTLSConfigMaps: map[string]corev1.ConfigMap{
+						gateway.Namespace + "/" + configMapName: {
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:       gateway.Namespace,
+								Name:            configMapName,
+								UID:             configMapUID,
+								ResourceVersion: configMapResourceVersion,
+							},
+						},
+					},
+				}
+
+				mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+				mockResourcesModel.EXPECT().isConditionSet(
+					isConditionSetParams{
+						resource:      &data.gateway,
+						conditions:    data.gateway.Status.Conditions,
+						conditionType: string(gatewayv1.GatewayConditionProgrammed),
+						annotations: map[string]string{
+							GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
+							GatewayProgrammedCertificatesAnnotation: "",
+							GatewayFrontendMTLSConfigMapsAnnotation: gateway.Namespace + "/" + configMapName +
+								"=" + string(configMapUID) + "/" + configMapResourceVersion,
+						},
+					},
+				).Return(false)
+
+				result := model.isProgrammed(t.Context(), data)
+
+				require.False(t, result)
+				mockResourcesModel.AssertExpectations(t)
+			},
+		)
+
+		t.Run(
+			"should check frontend mTLS ReferenceGrant annotations for cross namespace CA config maps",
+			func(t *testing.T) {
+				deps := newMockDeps(t)
+				model := newGatewayModel(deps)
+				fakeData := faker.New()
+
+				configMapNamespace := "ca-" + fakeData.Lorem().Word()
+				configMapName := "ca-" + fakeData.Lorem().Word()
+				configMapNamespaceRef := gatewayv1.Namespace(configMapNamespace)
+				configMapUID := apitypes.UID(fakeData.UUID().V4())
+				configMapResourceVersion := fakeData.UUID().V4()
+				grantName := "allow-" + fakeData.Lorem().Word()
+				grantUID := apitypes.UID(fakeData.UUID().V4())
+				grantResourceVersion := fakeData.UUID().V4()
+				gateway := newRandomGateway()
+				gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+					Frontend: &gatewayv1.FrontendTLSConfig{
+						Default: gatewayv1.TLSConfig{
+							Validation: &gatewayv1.FrontendTLSValidation{
+								CACertificateRefs: []gatewayv1.ObjectReference{{
+									Group:     "",
+									Kind:      "ConfigMap",
+									Name:      gatewayv1.ObjectName(configMapName),
+									Namespace: &configMapNamespaceRef,
+								}},
+							},
+						},
+					},
+				}
+				data := &resolvedGatewayDetails{
+					gateway: *gateway,
+					gatewayFrontendMTLSConfigMaps: map[string]corev1.ConfigMap{
+						configMapNamespace + "/" + configMapName: {
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:       configMapNamespace,
+								Name:            configMapName,
+								UID:             configMapUID,
+								ResourceVersion: configMapResourceVersion,
+							},
+						},
+					},
+					gatewayFrontendMTLSReferenceGrants: map[string]gatewayv1beta1.ReferenceGrant{
+						configMapNamespace + "/" + grantName: {
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:       configMapNamespace,
+								Name:            grantName,
+								UID:             grantUID,
+								ResourceVersion: grantResourceVersion,
+							},
+						},
+					},
+				}
+
+				mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+				mockResourcesModel.EXPECT().isConditionSet(
+					isConditionSetParams{
+						resource:      &data.gateway,
+						conditions:    data.gateway.Status.Conditions,
+						conditionType: string(gatewayv1.GatewayConditionProgrammed),
+						annotations: map[string]string{
+							GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
+							GatewayProgrammedCertificatesAnnotation: "",
+							GatewayFrontendMTLSConfigMapsAnnotation: configMapNamespace + "/" + configMapName +
+								"=" + string(configMapUID) + "/" + configMapResourceVersion,
+							GatewayFrontendMTLSReferenceGrantsAnnotation: configMapNamespace + "/" + grantName +
+								"=" + string(grantUID) + "/" + grantResourceVersion,
+						},
+					},
+				).Return(false)
+
+				result := model.isProgrammed(t.Context(), data)
+
+				require.False(t, result)
+				mockResourcesModel.AssertExpectations(t)
+			},
+		)
 	})
 
 	t.Run("populateAttachedListenerSets", func(t *testing.T) {
@@ -2505,6 +2702,231 @@ func TestGatewayModelImpl(t *testing.T) {
 		err := model.setProgrammed(t.Context(), data)
 
 		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("populateGatewayFrontendMTLSDependencies", func(t *testing.T) {
+		t.Run("initializes empty dependency maps when gateway has no frontend mTLS refs", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			data := &resolvedGatewayDetails{gateway: *newRandomGateway()}
+
+			err := model.populateGatewayFrontendMTLSDependencies(t.Context(), data)
+
+			require.NoError(t, err)
+			assert.Empty(t, data.gatewayFrontendMTLSConfigMaps)
+			assert.Empty(t, data.gatewayFrontendMTLSReferenceGrants)
+		})
+
+		t.Run("collects local and cross namespace CA ConfigMaps and ReferenceGrants", func(t *testing.T) {
+			fakeData := faker.New()
+			gateway := newRandomGateway()
+			localRefName := gatewayv1.ObjectName("local-" + fakeData.Lorem().Word())
+			crossNamespace := "security-" + fakeData.Lorem().Word()
+			crossNamespaceRef := gatewayv1.Namespace(crossNamespace)
+			crossRefName := gatewayv1.ObjectName("cross-" + fakeData.Lorem().Word())
+			perPortRefName := gatewayv1.ObjectName("per-port-" + fakeData.Lorem().Word())
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{
+							CACertificateRefs: []gatewayv1.ObjectReference{
+								{Group: "", Kind: "ConfigMap", Name: localRefName},
+								{Group: "", Kind: "ConfigMap", Name: crossRefName, Namespace: &crossNamespaceRef},
+								{Group: "example.com", Kind: "Other", Name: "ignored"},
+							},
+						},
+					},
+					PerPort: []gatewayv1.TLSPortConfig{{
+						Port: 8443,
+						TLS: gatewayv1.TLSConfig{
+							Validation: &gatewayv1.FrontendTLSValidation{
+								CACertificateRefs: []gatewayv1.ObjectReference{
+									{Group: "", Kind: "ConfigMap", Name: perPortRefName, Namespace: &crossNamespaceRef},
+								},
+							},
+						},
+					}},
+				},
+			}
+			localConfigMap := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: gateway.Namespace,
+					Name:      string(localRefName),
+				},
+			}
+			crossConfigMap := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: crossNamespace,
+					Name:      string(crossRefName),
+				},
+			}
+			perPortConfigMap := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: crossNamespace,
+					Name:      string(perPortRefName),
+				},
+			}
+			grantName := "allow-" + fakeData.Lorem().Word()
+			grantToName := crossRefName
+			grant := gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Namespace: crossNamespace, Name: grantName},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{{
+						Group:     gatewayv1.Group(gatewayAPIGroup),
+						Kind:      gatewayv1.Kind("Gateway"),
+						Namespace: gatewayv1.Namespace(gateway.Namespace),
+					}},
+					To: []gatewayv1beta1.ReferenceGrantTo{{
+						Group: "",
+						Kind:  gatewayv1.Kind("ConfigMap"),
+						Name:  &grantToName,
+					}},
+				},
+			}
+			irrelevantGrant := *grant.DeepCopy()
+			irrelevantGrant.Name = "ignore-" + fakeData.Lorem().Word()
+			irrelevantGrant.Spec.From[0].Namespace = gatewayv1.Namespace("other-" + fakeData.Lorem().Word())
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(&localConfigMap, &crossConfigMap, &perPortConfigMap, &grant, &irrelevantGrant).
+				Build()
+			model := newGatewayModel(gatewayModelDeps{
+				K8sClient:            k8sClient,
+				ResourcesModel:       NewMockresourcesModel(t),
+				RootLogger:           diag.RootTestLogger(),
+				OciClient:            NewMockociLoadBalancerClient(t),
+				OciLoadBalancerModel: NewMockociLoadBalancerModel(t),
+			})
+			data := &resolvedGatewayDetails{gateway: *gateway}
+
+			err := model.populateGatewayFrontendMTLSDependencies(t.Context(), data)
+
+			require.NoError(t, err)
+			assert.Contains(t, data.gatewayFrontendMTLSConfigMaps, gateway.Namespace+"/"+string(localRefName))
+			assert.Contains(t, data.gatewayFrontendMTLSConfigMaps, crossNamespace+"/"+string(crossRefName))
+			assert.Contains(t, data.gatewayFrontendMTLSConfigMaps, crossNamespace+"/"+string(perPortRefName))
+			assert.Contains(t, data.gatewayFrontendMTLSReferenceGrants, crossNamespace+"/"+grantName)
+			assert.NotContains(t, data.gatewayFrontendMTLSReferenceGrants, crossNamespace+"/"+irrelevantGrant.Name)
+
+			refs := frontendMTLSConfigMapRefs(*gateway)
+			assert.ElementsMatch(t, []apitypes.NamespacedName{
+				{Namespace: gateway.Namespace, Name: string(localRefName)},
+				{Namespace: crossNamespace, Name: string(crossRefName)},
+				{Namespace: crossNamespace, Name: string(perPortRefName)},
+			}, refs)
+			assert.True(t, gatewayHasCrossNamespaceFrontendMTLSConfigMapRefs(*gateway))
+		})
+
+		t.Run("tracks missing ConfigMaps by omitting their revision", func(t *testing.T) {
+			fakeData := faker.New()
+			gateway := newRandomGateway()
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{
+							CACertificateRefs: []gatewayv1.ObjectReference{{
+								Group: "",
+								Kind:  "ConfigMap",
+								Name:  gatewayv1.ObjectName("missing-" + fakeData.Lorem().Word()),
+							}},
+						},
+					},
+				},
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).Build()
+			model := newGatewayModel(gatewayModelDeps{
+				K8sClient:            k8sClient,
+				ResourcesModel:       NewMockresourcesModel(t),
+				RootLogger:           diag.RootTestLogger(),
+				OciClient:            NewMockociLoadBalancerClient(t),
+				OciLoadBalancerModel: NewMockociLoadBalancerModel(t),
+			})
+			data := &resolvedGatewayDetails{gateway: *gateway}
+
+			err := model.populateGatewayFrontendMTLSDependencies(t.Context(), data)
+
+			require.NoError(t, err)
+			assert.Empty(t, data.gatewayFrontendMTLSConfigMaps)
+			assert.Empty(t, data.gatewayFrontendMTLSReferenceGrants)
+		})
+
+		t.Run("returns ConfigMap lookup errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			fakeData := faker.New()
+			refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+			gateway := newRandomGateway()
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{
+							CACertificateRefs: []gatewayv1.ObjectReference{{
+								Group: "",
+								Kind:  "ConfigMap",
+								Name:  refName,
+							}},
+						},
+					},
+				},
+			}
+			wantErr := errors.New("get failed")
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				Get(t.Context(), apitypes.NamespacedName{
+					Namespace: gateway.Namespace,
+					Name:      string(refName),
+				}, mock.AnythingOfType("*v1.ConfigMap")).
+				Return(wantErr)
+
+			err := model.populateGatewayFrontendMTLSDependencies(
+				t.Context(),
+				&resolvedGatewayDetails{gateway: *gateway},
+			)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to get frontend mTLS ConfigMap")
+		})
+
+		t.Run("returns ReferenceGrant list errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			fakeData := faker.New()
+			refNamespace := "security-" + fakeData.Lorem().Word()
+			refNamespaceValue := gatewayv1.Namespace(refNamespace)
+			refName := gatewayv1.ObjectName("ca-" + fakeData.Lorem().Word())
+			gateway := newRandomGateway()
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{
+							CACertificateRefs: []gatewayv1.ObjectReference{{
+								Group:     "",
+								Kind:      "ConfigMap",
+								Name:      refName,
+								Namespace: &refNamespaceValue,
+							}},
+						},
+					},
+				},
+			}
+			wantErr := errors.New("list failed")
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			setupClientGet(t, mockClient, apitypes.NamespacedName{
+				Namespace: refNamespace,
+				Name:      string(refName),
+			}, corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: refNamespace, Name: string(refName)}})
+			mockClient.EXPECT().
+				List(t.Context(), mock.AnythingOfType("*v1beta1.ReferenceGrantList"), mock.Anything).
+				Return(wantErr)
+
+			err := model.populateGatewayFrontendMTLSDependencies(
+				t.Context(),
+				&resolvedGatewayDetails{gateway: *gateway},
+			)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to list frontend mTLS ReferenceGrants")
+		})
 	})
 
 	t.Run("populateGatewaySecrets with effective listeners", func(t *testing.T) {

--- a/internal/app/grpcroute_controller.go
+++ b/internal/app/grpcroute_controller.go
@@ -107,6 +107,14 @@ func (r *GRPCRouteController) reconcileResolvedRoute(
 		knownBackends:    knownBackends,
 	})
 	if err != nil {
+		if isParentGatewayStatusError(err) {
+			r.logger.InfoContext(ctx, "GRPCRoute parent Gateway is not programmable",
+				slog.String("grpcRoute", resolvedData.grpcRoute.Name),
+				slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
+				slog.String("reason", err.Error()),
+			)
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to program route: %w", err)
 	}
 

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -408,6 +408,41 @@ func TestGRPCRouteController(t *testing.T) {
 		require.ErrorIs(t, err, wantErr)
 	})
 
+	t.Run("does not retry when parent Gateway rejects programming", func(t *testing.T) {
+		route := makeRoute()
+		resolved := makeResolved(route)
+		service := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: "grpc-svc"}}
+		backendModel := NewMockhttpBackendModel(t)
+		routeModel := fakeGRPCRouteModel{
+			resolveRequestFunc: func(
+				_ context.Context,
+				_ reconcile.Request,
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
+				return resolvedMap(route, resolved), nil
+			},
+			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
+			acceptRouteFunc: func(_ context.Context, details resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
+				return &details.grpcRoute, nil
+			},
+			resolveBackendRefsFunc: func(context.Context, resolveGRPCBackendRefsParams) (map[string]corev1.Service, error) {
+				return map[string]corev1.Service{service.Namespace + "/" + service.Name: service}, nil
+			},
+			programRouteFunc: func(context.Context, programGRPCRouteParams) (programGRPCRouteResult, error) {
+				return programGRPCRouteResult{}, &resourceStatusError{
+					conditionType: string(gatewayv1.GatewayConditionAccepted),
+					reason:        string(gatewayv1.GatewayReasonRefNotPermitted),
+					message:       "frontend mTLS caCertificateRef is not permitted by a ReferenceGrant",
+				}
+			},
+		}
+
+		got, err := newController(routeModel, backendModel).Reconcile(t.Context(), reconcile.Request{})
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, got, 2*time.Minute)
+		backendModel.AssertNotCalled(t, "syncGRPCRouteEndpoints", mock.Anything, mock.Anything)
+	})
+
 	t.Run("sets rejected status for backend ref status errors", func(t *testing.T) {
 		route := makeRoute()
 		resolved := makeResolved(route)

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -116,6 +116,14 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 		knownBackends:    knownBackends,
 	})
 	if err != nil {
+		if isParentGatewayStatusError(err) {
+			r.logger.InfoContext(ctx, "HTTPRoute parent Gateway is not programmable",
+				slog.String("httpRoute", resolvedData.httpRoute.Name),
+				slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
+				slog.String("reason", err.Error()),
+			)
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to program route: %w", err)
 	}
 

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -14,6 +14,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client" // Import client for ObjectKey
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
 )
@@ -439,6 +440,75 @@ func TestHTTPRouteController(t *testing.T) {
 
 			require.ErrorIs(t, err, wantErr)
 			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("does not retry when parent Gateway rejects programming", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			controller := NewHTTPRouteController(deps)
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: fake.Internet().Domain(),
+					Name:      fake.Lorem().Word(),
+				},
+			}
+
+			wantResolvedData := resolvedRouteDetails{
+				httpRoute: makeRandomHTTPRoute(),
+				gatewayDetails: resolvedGatewayDetails{
+					gateway: *newRandomGateway(),
+					config:  makeRandomGatewayConfig(),
+				},
+			}
+
+			wantBackendRefs := make(map[string]v1.Service)
+			for range 3 {
+				svc := makeRandomService()
+				fullName := types.NamespacedName{
+					Namespace: svc.Namespace,
+					Name:      svc.Name,
+				}
+				wantBackendRefs[fullName.String()] = svc
+			}
+
+			mockModel, _ := deps.HTTPRouteModel.(*MockhttpRouteModel)
+			mockModel.EXPECT().resolveRequest(
+				t.Context(),
+				req,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
+			}, (error)(nil))
+			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
+
+			wantAcceptedRoute := makeRandomHTTPRoute()
+			mockModel.EXPECT().acceptRoute(
+				t.Context(),
+				wantResolvedData,
+			).Return(&wantAcceptedRoute, nil)
+			mockModel.EXPECT().resolveBackendRefs(
+				t.Context(),
+				resolveBackendRefsParams{httpRoute: wantAcceptedRoute},
+			).Return(wantBackendRefs, nil)
+			mockModel.EXPECT().programRoute(
+				t.Context(),
+				programRouteParams{
+					gateway:       wantResolvedData.gatewayDetails.gateway,
+					config:        wantResolvedData.gatewayDetails.config,
+					httpRoute:     wantAcceptedRoute,
+					knownBackends: wantBackendRefs,
+				},
+			).Return(programRouteResult{}, &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionAccepted),
+				reason:        string(gatewayv1.GatewayReasonRefNotPermitted),
+				message:       "frontend mTLS caCertificateRef is not permitted by a ReferenceGrant",
+			})
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+			mockModel.AssertNotCalled(t, "setProgrammed", mock.Anything, mock.Anything)
 		})
 
 		t.Run("ProgrammingNotRequired", func(t *testing.T) {

--- a/internal/app/l4_controller_test.go
+++ b/internal/app/l4_controller_test.go
@@ -393,6 +393,27 @@ func TestTLSRouteController(t *testing.T) {
 		assert.False(t, model.programmed)
 	})
 
+	t.Run("does not retry when parent Gateway rejects programming", func(t *testing.T) {
+		model := &stubTLSRouteModel{
+			resolved: []resolvedTLSRouteDetails{{tlsRoute: gatewayv1.TLSRoute{}}},
+			programErr: &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionAccepted),
+				reason:        string(gatewayv1.GatewayReasonRefNotPermitted),
+				message:       "frontend mTLS caCertificateRef is not permitted by a ReferenceGrant",
+			},
+		}
+		controller := NewTLSRouteController(TLSRouteControllerDeps{
+			RootLogger:    diag.RootTestLogger(),
+			TLSRouteModel: model,
+		})
+
+		_, err := controller.Reconcile(t.Context(), req)
+
+		require.NoError(t, err)
+		assert.False(t, model.rejected)
+		assert.False(t, model.programmed)
+	})
+
 	t.Run("deprovisions deleted route with matching finalizer", func(t *testing.T) {
 		model := &stubTLSRouteModel{resolved: []resolvedTLSRouteDetails{{
 			gatewayDetails: resolvedGatewayDetails{

--- a/internal/app/mock_oci_load_balancer_model.go
+++ b/internal/app/mock_oci_load_balancer_model.go
@@ -629,6 +629,53 @@ func (_c *MockociLoadBalancerModel_removeUnusedCertificates_Call) RunAndReturn(r
 	return _c
 }
 
+// cleanupFrontendMTLSCABundles provides a mock function with given fields: ctx, params
+func (_m *MockociLoadBalancerModel) cleanupFrontendMTLSCABundles(ctx context.Context, params cleanupFrontendMTLSCABundlesParams) error {
+	ret := _m.Called(ctx, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for cleanupFrontendMTLSCABundles")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, cleanupFrontendMTLSCABundlesParams) error); ok {
+		r0 = rf(ctx, params)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'cleanupFrontendMTLSCABundles'
+type MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call struct {
+	*mock.Call
+}
+
+// cleanupFrontendMTLSCABundles is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params cleanupFrontendMTLSCABundlesParams
+func (_e *MockociLoadBalancerModel_Expecter) cleanupFrontendMTLSCABundles(ctx interface{}, params interface{}) *MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call {
+	return &MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call{Call: _e.mock.On("cleanupFrontendMTLSCABundles", ctx, params)}
+}
+
+func (_c *MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call) Run(run func(ctx context.Context, params cleanupFrontendMTLSCABundlesParams)) *MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(cleanupFrontendMTLSCABundlesParams))
+	})
+	return _c
+}
+
+func (_c *MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call) Return(_a0 error) *MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call) RunAndReturn(run func(context.Context, cleanupFrontendMTLSCABundlesParams) error) *MockociLoadBalancerModel_cleanupFrontendMTLSCABundles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockociLoadBalancerModel creates a new instance of MockociLoadBalancerModel. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockociLoadBalancerModel(t interface {

--- a/internal/app/network_load_balancer_gateway_model.go
+++ b/internal/app/network_load_balancer_gateway_model.go
@@ -670,6 +670,14 @@ func (m *networkLoadBalancerGatewayModelImpl) programGateway(
 }
 
 func validateNetworkLoadBalancerGatewayListeners(data *resolvedGatewayDetails) error {
+	if gatewayFrontendMTLSConfigured(data.gateway) {
+		return &resourceStatusError{
+			conditionType: string(gatewayv1.GatewayConditionAccepted),
+			reason:        string(gatewayv1.GatewayReasonInvalid),
+			message:       "frontend mTLS is not supported by OCI Network Load Balancer gateways",
+		}
+	}
+
 	effectiveListeners := data.effectiveListeners
 	if len(effectiveListeners) == 0 {
 		effectiveListeners = effectiveListenersForGateway(data.gateway, nil)

--- a/internal/app/network_load_balancer_gateway_model_test.go
+++ b/internal/app/network_load_balancer_gateway_model_test.go
@@ -677,6 +677,36 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		assert.Equal(t, "spec.loadBalancerId is required for OCI Network Load Balancer gateways", statusErr.message)
 	})
 
+	t.Run("rejects frontend mTLS configuration", func(t *testing.T) {
+		model := newModel(&stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new("ocid1.networkloadbalancer.oc1..existing"),
+				},
+			},
+		}, &stubWorkRequestsWatcher{})
+		details := newDetails()
+		details.gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+			Frontend: &gatewayv1.FrontendTLSConfig{
+				Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+					CACertificateRefs: []gatewayv1.ObjectReference{{
+						Group: "",
+						Kind:  "ConfigMap",
+						Name:  gatewayv1.ObjectName("client-ca"),
+					}},
+				}},
+			},
+		}
+
+		err := model.programGateway(t.Context(), details)
+
+		var statusErr *resourceStatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, string(gatewayv1.GatewayConditionAccepted), statusErr.conditionType)
+		assert.Equal(t, string(gatewayv1.GatewayReasonInvalid), statusErr.reason)
+		assert.Equal(t, "frontend mTLS is not supported by OCI Network Load Balancer gateways", statusErr.message)
+	})
+
 	t.Run("covers unsupported listener protocols", func(t *testing.T) {
 		_, supported := networkLoadBalancerListenerProtocol(gatewayv1.HTTPProtocolType)
 		assert.False(t, supported)

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -122,9 +122,10 @@ type commitRoutingPolicyParams struct {
 }
 
 type removeMissingListenersParams struct {
-	loadBalancerID   string
-	knownListeners   map[string]loadbalancer.Listener
-	gatewayListeners []gatewayv1.Listener
+	loadBalancerID       string
+	knownListeners       map[string]loadbalancer.Listener
+	knownRoutingPolicies map[string]loadbalancer.RoutingPolicy
+	gatewayListeners     []gatewayv1.Listener
 }
 
 type removeUnusedCertificatesParams struct {
@@ -1390,34 +1391,87 @@ func (m *ociLoadBalancerModelImpl) deleteMissingListener(
 func (m *ociLoadBalancerModelImpl) deleteMissingRoutingPolicy(
 	ctx context.Context,
 	loadBalancerID string,
-	listener loadbalancer.Listener,
+	routingPolicyName *string,
 ) error {
-	if listener.RoutingPolicyName != nil {
+	if routingPolicyName != nil {
 		m.logger.DebugContext(ctx, "Deleting routing policy",
-			slog.String("routingPolicyName", *listener.RoutingPolicyName),
+			slog.String("routingPolicyName", *routingPolicyName),
 			slog.String("loadBalancerId", loadBalancerID),
 		)
 		var deletePolicyRes loadbalancer.DeleteRoutingPolicyResponse
 		deletePolicyRes, err := m.ociClient.DeleteRoutingPolicy(ctx, loadbalancer.DeleteRoutingPolicyRequest{
 			LoadBalancerId:    &loadBalancerID,
-			RoutingPolicyName: listener.RoutingPolicyName,
+			RoutingPolicyName: routingPolicyName,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to delete routing policy %s: %w", *listener.RoutingPolicyName, err)
+			return fmt.Errorf("failed to delete routing policy %s: %w", *routingPolicyName, err)
 		}
 		if deletePolicyRes.OpcWorkRequestId == nil {
 			return fmt.Errorf(
 				"failed to delete routing policy %s: missing work request id",
-				*listener.RoutingPolicyName,
+				*routingPolicyName,
 			)
 		}
 
 		if err = m.workRequestsWatcher.WaitFor(ctx, *deletePolicyRes.OpcWorkRequestId); err != nil {
-			return fmt.Errorf("failed to wait for routing policy %s deletion: %w", *listener.RoutingPolicyName, err)
+			return fmt.Errorf("failed to wait for routing policy %s deletion: %w", *routingPolicyName, err)
 		}
 	}
 
 	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) removeOrphanedListenerRoutingPolicies(
+	ctx context.Context,
+	params removeMissingListenersParams,
+) []error {
+	desiredPolicyNames := lo.SliceToMap(params.gatewayListeners, func(l gatewayv1.Listener) (string, struct{}) {
+		return listenerPolicyName(string(l.Name)), struct{}{}
+	})
+	attachedPolicyNames := map[string]struct{}{}
+	for _, listener := range params.knownListeners {
+		if listener.RoutingPolicyName != nil {
+			attachedPolicyNames[*listener.RoutingPolicyName] = struct{}{}
+		}
+	}
+
+	var errs []error
+	for policyName := range params.knownRoutingPolicies {
+		if !isControllerManagedListenerPolicyName(policyName) {
+			continue
+		}
+		policy := params.knownRoutingPolicies[policyName]
+		if !isDefaultCatchAllOnlyRoutingPolicy(policy) {
+			continue
+		}
+		if _, desired := desiredPolicyNames[policyName]; desired {
+			continue
+		}
+		if _, attached := attachedPolicyNames[policyName]; attached {
+			continue
+		}
+
+		routingPolicyName := policyName
+		if err := m.deleteMissingRoutingPolicy(ctx, params.loadBalancerID, &routingPolicyName); err != nil {
+			m.logger.WarnContext(ctx, "Failed to delete orphaned routing policy, will try with others",
+				diag.ErrAttr(err),
+				slog.String("routingPolicyName", policyName),
+				slog.String("loadBalancerId", params.loadBalancerID),
+			)
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+func isDefaultCatchAllOnlyRoutingPolicy(policy loadbalancer.RoutingPolicy) bool {
+	if len(policy.Rules) != 1 {
+		return false
+	}
+	rule := policy.Rules[0]
+	return lo.FromPtr(rule.Name) == defaultCatchAllRuleName &&
+		lo.FromPtr(rule.Condition) == "any(http.request.url.path sw '/')"
 }
 
 func (m *ociLoadBalancerModelImpl) removeMissingListeners(
@@ -1444,7 +1498,7 @@ func (m *ociLoadBalancerModelImpl) removeMissingListeners(
 				continue
 			}
 
-			if err := m.deleteMissingRoutingPolicy(ctx, params.loadBalancerID, listener); err != nil {
+			if err := m.deleteMissingRoutingPolicy(ctx, params.loadBalancerID, listener.RoutingPolicyName); err != nil {
 				m.logger.WarnContext(ctx, "Failed to delete routing policy, will try with others",
 					diag.ErrAttr(err),
 					slog.String("listenerName", listenerName),
@@ -1457,6 +1511,7 @@ func (m *ociLoadBalancerModelImpl) removeMissingListeners(
 			m.logger.DebugContext(ctx, "Completed listener removal", slog.String("listenerName", listenerName))
 		}
 	}
+	errs = append(errs, m.removeOrphanedListenerRoutingPolicies(ctx, params)...)
 
 	return errors.Join(errs...)
 }
@@ -1762,10 +1817,16 @@ and upper- or lowercase letters.
 */
 var invalidCharsForPolicyNamePattern = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 var validOCIRoutingPolicyNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+var hashedListenerPolicyNamePattern = regexp.MustCompile(`^p_[0-9a-f]{16}_[a-zA-Z0-9_]+$`)
 
 func isValidOCIRoutingPolicyName(policyName string) bool {
 	return len(policyName) <= maxListenerPolicyNameLength &&
 		validOCIRoutingPolicyNamePattern.MatchString(policyName)
+}
+
+func isControllerManagedListenerPolicyName(policyName string) bool {
+	return hashedListenerPolicyNamePattern.MatchString(policyName) ||
+		(strings.HasSuffix(policyName, "_policy") && isValidOCIRoutingPolicyName(policyName))
 }
 
 // ociListerPolicyRuleName returns the name of the routing rule for the listener policy.

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -1806,7 +1806,7 @@ func knownFrontendMTLSCertificateNames(
 ) []string {
 	prefixes := make([]string, 0, len(controllerCertificates))
 	for _, certName := range normalizeProgrammedCertificateNames(controllerCertificates) {
-		prefixes = append(prefixes, certName+"-fmtls-")
+		prefixes = append(prefixes, frontendMTLSCertificateRootName(certName)+"-fmtls-")
 	}
 	if len(prefixes) == 0 {
 		return nil
@@ -1822,6 +1822,13 @@ func knownFrontendMTLSCertificateNames(
 		}
 	}
 	return normalizeProgrammedCertificateNames(matched)
+}
+
+func frontendMTLSCertificateRootName(certName string) string {
+	if root, _, ok := strings.Cut(certName, "-fmtls-"); ok {
+		return root
+	}
+	return certName
 }
 
 func listenerPolicyName(listenerName string) string {

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -60,13 +60,15 @@ type deprovisionBackendSetParams struct {
 }
 
 type reconcileHTTPListenerParams struct {
-	loadBalancerID        string
-	knownListeners        map[string]loadbalancer.Listener
-	knownRoutingPolicies  map[string]loadbalancer.RoutingPolicy
-	listenerCertificates  []loadbalancer.Certificate
-	listenerCertificateID string
-	defaultBackendSetName string
-	listenerSpec          *gatewayv1.Listener
+	loadBalancerID            string
+	loadBalancerCompartmentID string
+	knownListeners            map[string]loadbalancer.Listener
+	knownRoutingPolicies      map[string]loadbalancer.RoutingPolicy
+	listenerCertificates      []loadbalancer.Certificate
+	listenerCertificateID     string
+	defaultBackendSetName     string
+	listenerSpec              *gatewayv1.Listener
+	gateway                   *gatewayv1.Gateway
 }
 
 type reconcileListenersCertificatesParams struct {
@@ -192,11 +194,17 @@ type ociLoadBalancerModel interface {
 		ctx context.Context,
 		params removeUnusedCertificatesParams,
 	) error
+
+	cleanupFrontendMTLSCABundles(
+		ctx context.Context,
+		params cleanupFrontendMTLSCABundlesParams,
+	) error
 }
 
 type ociLoadBalancerModelImpl struct {
 	k8sClient           k8sClient
 	ociClient           ociLoadBalancerClient
+	certsClient         ociCertificatesManagementClient
 	logger              *slog.Logger
 	workRequestsWatcher workRequestsWatcher
 	routingRulesMapper  ociLoadBalancerRoutingRulesMapper
@@ -274,6 +282,15 @@ func loadBalancerListenerSSLConfigurationsEqual(
 		return false
 	}
 	if len(desired.Protocols) > 0 && !stringSlicesEqual(current.Protocols, desired.Protocols) {
+		return false
+	}
+	if lo.FromPtr(current.VerifyPeerCertificate) != lo.FromPtr(desired.VerifyPeerCertificate) {
+		return false
+	}
+	if desired.VerifyDepth != nil && lo.FromPtr(current.VerifyDepth) != lo.FromPtr(desired.VerifyDepth) {
+		return false
+	}
+	if !stringSlicesEqual(current.TrustedCertificateAuthorityIds, desired.TrustedCertificateAuthorityIds) {
 		return false
 	}
 	return true
@@ -873,6 +890,10 @@ func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
 			CertificateName: cert.CertificateName,
 		}
 		applyListenerTLSOptions(sslConfig, params.listenerSpec.TLS)
+	}
+	sslConfig, err := m.applyFrontendMTLS(ctx, params, sslConfig)
+	if err != nil {
+		return err
 	}
 
 	if existingListener, ok := params.knownListeners[listenerName]; ok {
@@ -1843,17 +1864,19 @@ func applyListenerTLSOptions(
 type ociLoadBalancerModelDeps struct {
 	dig.In
 
-	RootLogger          *slog.Logger
-	K8sClient           k8sClient
-	OciClient           ociLoadBalancerClient
-	WorkRequestsWatcher workRequestsWatcher
-	RoutingRulesMapper  ociLoadBalancerRoutingRulesMapper
+	RootLogger                *slog.Logger
+	K8sClient                 k8sClient
+	OciClient                 ociLoadBalancerClient
+	OciCertificatesMgmtClient ociCertificatesManagementClient
+	WorkRequestsWatcher       workRequestsWatcher
+	RoutingRulesMapper        ociLoadBalancerRoutingRulesMapper
 }
 
 func newOciLoadBalancerModel(deps ociLoadBalancerModelDeps) *ociLoadBalancerModelImpl {
 	return &ociLoadBalancerModelImpl{
 		logger:              deps.RootLogger.WithGroup("oci-load-balancer-model"),
 		ociClient:           deps.OciClient,
+		certsClient:         deps.OciCertificatesMgmtClient,
 		k8sClient:           deps.K8sClient,
 		workRequestsWatcher: deps.WorkRequestsWatcher,
 		routingRulesMapper:  deps.RoutingRulesMapper,

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -1425,7 +1425,10 @@ func (m *ociLoadBalancerModelImpl) removeOrphanedListenerRoutingPolicies(
 	ctx context.Context,
 	params removeMissingListenersParams,
 ) []error {
-	desiredPolicyNames := lo.SliceToMap(params.gatewayListeners, func(l gatewayv1.Listener) (string, struct{}) {
+	httpListeners := lo.Filter(params.gatewayListeners, func(l gatewayv1.Listener, _ int) bool {
+		return l.Protocol == gatewayv1.HTTPProtocolType || l.Protocol == gatewayv1.HTTPSProtocolType
+	})
+	desiredPolicyNames := lo.SliceToMap(httpListeners, func(l gatewayv1.Listener) (string, struct{}) {
 		return listenerPolicyName(string(l.Name)), struct{}{}
 	})
 	attachedPolicyNames := map[string]struct{}{}

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -981,6 +981,9 @@ func (m *ociLoadBalancerModelImpl) reconcileExistingHTTPListener(
 		listenerSpec:          params.listenerSpec,
 		defaultBackendSetName: params.defaultBackendSetName,
 		sslConfig:             sslConfig,
+		preserveHTTP2: listenerPolicyContainsGRPCRules(
+			params.knownRoutingPolicies[listenerPolicyName(listenerName)],
+		),
 	})
 	if !hasChanges {
 		m.logger.DebugContext(ctx, "Listener already up to date, skipping update",
@@ -1716,8 +1719,16 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 	for _, certName := range params.desiredCertificates {
 		desiredCertificates[certName] = struct{}{}
 	}
+	previouslyProgrammedCertificates := append(
+		[]string(nil),
+		params.previouslyProgrammedCertificates...,
+	)
+	previouslyProgrammedCertificates = append(
+		previouslyProgrammedCertificates,
+		knownFrontendMTLSCertificateNames(params.knownCertificates, params.desiredCertificates)...,
+	)
 
-	for _, certName := range params.previouslyProgrammedCertificates {
+	for _, certName := range normalizeProgrammedCertificateNames(previouslyProgrammedCertificates) {
 		if _, isDesired := desiredCertificates[certName]; isDesired {
 			continue
 		}
@@ -1787,6 +1798,30 @@ func certificateNamesFromListenerCertificates(
 		}
 	}
 	return normalizeProgrammedCertificateNames(certNames)
+}
+
+func knownFrontendMTLSCertificateNames(
+	knownCertificates map[string]loadbalancer.Certificate,
+	controllerCertificates []string,
+) []string {
+	prefixes := make([]string, 0, len(controllerCertificates))
+	for _, certName := range normalizeProgrammedCertificateNames(controllerCertificates) {
+		prefixes = append(prefixes, certName+"-fmtls-")
+	}
+	if len(prefixes) == 0 {
+		return nil
+	}
+
+	matched := make([]string, 0)
+	for certName := range knownCertificates {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(certName, prefix) {
+				matched = append(matched, certName)
+				break
+			}
+		}
+	}
+	return normalizeProgrammedCertificateNames(matched)
 }
 
 func listenerPolicyName(listenerName string) string {
@@ -1924,12 +1959,13 @@ type makeOciListenerUpdateDetailsParams struct {
 	listenerSpec          *gatewayv1.Listener
 	defaultBackendSetName string
 	sslConfig             *loadbalancer.SslConfigurationDetails
+	preserveHTTP2         bool
 }
 
 func makeOciListenerUpdateDetails(
 	params makeOciListenerUpdateDetailsParams,
 ) (loadbalancer.UpdateListenerDetails, bool) {
-	expectedProtocol := expectedHTTPListenerProtocol(params.existingListenerData)
+	expectedProtocol := expectedHTTPListenerProtocol(params.preserveHTTP2)
 	hasChanges := params.existingListenerData.Protocol == nil ||
 		*params.existingListenerData.Protocol != expectedProtocol
 
@@ -1966,11 +2002,20 @@ func makeOciListenerUpdateDetails(
 	}, true
 }
 
-func expectedHTTPListenerProtocol(existingListener loadbalancer.Listener) string {
-	if lo.FromPtr(existingListener.Protocol) == ociListenerProtocolHTTP2 {
+func expectedHTTPListenerProtocol(preserveHTTP2 bool) string {
+	if preserveHTTP2 {
 		return ociListenerProtocolHTTP2
 	}
 	return ociListenerProtocolHTTP
+}
+
+func listenerPolicyContainsGRPCRules(policy loadbalancer.RoutingPolicy) bool {
+	for _, rule := range policy.Rules {
+		if rule.Condition != nil && strings.Contains(strings.ToLower(*rule.Condition), "application/grpc") {
+			return true
+		}
+	}
+	return false
 }
 
 func applyListenerTLSOptions(

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -485,6 +485,9 @@ func (m *ociLoadBalancerModelImpl) reconcileListenersCertificates(
 	)
 
 	resultingCertificates := maps.Clone(params.knownCertificates)
+	if resultingCertificates == nil {
+		resultingCertificates = map[string]loadbalancer.Certificate{}
+	}
 	listenerCertificates := make(map[string][]loadbalancer.Certificate)
 	gatewayListeners := params.gatewayListeners
 	if len(gatewayListeners) == 0 {
@@ -499,6 +502,7 @@ func (m *ociLoadBalancerModelImpl) reconcileListenersCertificates(
 		certs, reconcileErr := m.reconcileListenerSecretCertificates(ctx, listenerSecretCertificatesParams{
 			loadBalancerID:        params.loadBalancerID,
 			gatewayNamespace:      params.gateway.Namespace,
+			gateway:               params.gateway,
 			listenerSpec:          listenerSpec,
 			resultingCertificates: resultingCertificates,
 		})
@@ -520,6 +524,7 @@ func (m *ociLoadBalancerModelImpl) reconcileListenersCertificates(
 type listenerSecretCertificatesParams struct {
 	loadBalancerID        string
 	gatewayNamespace      string
+	gateway               *gatewayv1.Gateway
 	listenerSpec          gatewayv1.Listener
 	resultingCertificates map[string]loadbalancer.Certificate
 }
@@ -562,17 +567,68 @@ func (m *ociLoadBalancerModelImpl) reconcileListenerSecretCertificate(
 	}
 
 	certName := ociCertificateNameFromSecret(secret)
+	caPEM := ""
+	if params.gateway != nil {
+		frontendMTLSCA, frontendMTLSErr := m.frontendMTLSCAForListenerCertificate(ctx, params)
+		if frontendMTLSErr != nil {
+			return loadbalancer.Certificate{}, frontendMTLSErr
+		}
+		if frontendMTLSCA != "" {
+			caPEM = frontendMTLSCA
+			certName = frontendMTLSListenerCertificateName(secret, params.listenerSpec.Port, caPEM)
+		}
+	}
 	if cert, ok := params.resultingCertificates[certName]; ok {
 		m.logCertificateAlreadyExists(ctx, params.loadBalancerID, params.listenerSpec.Name, certName, secret)
 		return cert, nil
 	}
 
-	cert, err := m.createListenerCertificate(ctx, params.loadBalancerID, params.listenerSpec.Name, certName, secret)
+	cert, err := m.createListenerCertificate(ctx, createListenerCertificateParams{
+		loadBalancerID: params.loadBalancerID,
+		listenerName:   params.listenerSpec.Name,
+		certName:       certName,
+		secret:         secret,
+		caPEM:          caPEM,
+	})
 	if err != nil {
 		return loadbalancer.Certificate{}, err
 	}
 	params.resultingCertificates[certName] = cert
 	return cert, nil
+}
+
+func (m *ociLoadBalancerModelImpl) frontendMTLSCAForListenerCertificate(
+	ctx context.Context,
+	params listenerSecretCertificatesParams,
+) (string, error) {
+	optionCAIDs := frontendMTLSOCICABundleIDs(*params.gateway, params.listenerSpec.Port)
+	validation := effectiveFrontendTLSValidation(*params.gateway, params.listenerSpec.Port)
+	if validation == nil && len(optionCAIDs) == 0 {
+		return "", nil
+	}
+	settings, err := resolveFrontendMTLSSettings(*params.gateway, params.listenerSpec.Port, validation, optionCAIDs)
+	if err != nil {
+		return "", err
+	}
+	if len(settings.ociCAIDs) > 0 {
+		return "", frontendMTLSStatusError(string(gatewayv1.GatewayReasonInvalidParameters),
+			fmt.Sprintf(
+				"frontend mTLS OCI CA bundle OCID annotations require listener %s to use %s",
+				params.listenerSpec.Name,
+				ListenerTLSOptionOCICertificateOCID,
+			),
+		)
+	}
+
+	caPEMs := make([]string, 0, len(settings.caRefs))
+	for _, ref := range settings.caRefs {
+		resolved, resolveErr := m.resolveFrontendMTLSCARef(ctx, *params.gateway, ref)
+		if resolveErr != nil {
+			return "", resolveErr
+		}
+		caPEMs = append(caPEMs, strings.TrimSpace(resolved.caPEM))
+	}
+	return strings.Join(caPEMs, "\n"), nil
 }
 
 func (m *ociLoadBalancerModelImpl) getListenerCertificateSecret(
@@ -598,47 +654,55 @@ func certificateRefNamespacedName(
 	}
 }
 
+type createListenerCertificateParams struct {
+	loadBalancerID string
+	listenerName   gatewayv1.SectionName
+	certName       string
+	secret         corev1.Secret
+	caPEM          string
+}
+
 func (m *ociLoadBalancerModelImpl) createListenerCertificate(
 	ctx context.Context,
-	loadBalancerID string,
-	listenerName gatewayv1.SectionName,
-	certName string,
-	secret corev1.Secret,
+	params createListenerCertificateParams,
 ) (loadbalancer.Certificate, error) {
 	m.logger.InfoContext(ctx, "Creating certificate",
-		slog.String("loadBalancerId", loadBalancerID),
-		slog.String("listenerName", string(listenerName)),
-		slog.String("certificateName", certName),
-		slog.String("secretName", secret.Name),
-		slog.String("secretNamespace", secret.Namespace),
-		slog.String("secretVersion", secret.ResourceVersion),
+		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("listenerName", string(params.listenerName)),
+		slog.String("certificateName", params.certName),
+		slog.String("secretName", params.secret.Name),
+		slog.String("secretNamespace", params.secret.Namespace),
+		slog.String("secretVersion", params.secret.ResourceVersion),
 	)
 
 	certCreateDetails := loadbalancer.CreateCertificateDetails{
-		CertificateName:   &certName,
-		PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
-		PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
+		CertificateName:   &params.certName,
+		PublicCertificate: new(string(params.secret.Data[corev1.TLSCertKey])),
+		PrivateKey:        new(string(params.secret.Data[corev1.TLSPrivateKeyKey])),
+	}
+	if params.caPEM != "" {
+		certCreateDetails.CaCertificate = &params.caPEM
 	}
 	createRes, createErr := m.ociClient.CreateCertificate(ctx, loadbalancer.CreateCertificateRequest{
-		LoadBalancerId:           &loadBalancerID,
+		LoadBalancerId:           &params.loadBalancerID,
 		CreateCertificateDetails: certCreateDetails,
 	})
 	if createErr != nil {
-		return loadbalancer.Certificate{}, fmt.Errorf("failed to create certificate %s: %w", certName, createErr)
+		return loadbalancer.Certificate{}, fmt.Errorf("failed to create certificate %s: %w", params.certName, createErr)
 	}
 	if createRes.OpcWorkRequestId == nil {
 		return loadbalancer.Certificate{}, fmt.Errorf(
 			"failed to create certificate %s: missing work request id",
-			certName,
+			params.certName,
 		)
 	}
 
 	if err := m.workRequestsWatcher.WaitFor(ctx, *createRes.OpcWorkRequestId); err != nil {
-		return loadbalancer.Certificate{}, fmt.Errorf("failed to wait for certificate %s: %w", certName, err)
+		return loadbalancer.Certificate{}, fmt.Errorf("failed to wait for certificate %s: %w", params.certName, err)
 	}
 
 	return loadbalancer.Certificate{
-		CertificateName:   &certName,
+		CertificateName:   &params.certName,
 		PublicCertificate: certCreateDetails.PublicCertificate,
 	}, nil
 }
@@ -862,10 +926,6 @@ func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
 ) error {
 	listenerName := string(params.listenerSpec.Name)
 
-	if err := m.reconcileListenerRoutingPolicy(ctx, params); err != nil {
-		return fmt.Errorf("failed to reconcile listener routing policy: %w", err)
-	}
-
 	var sslConfig *loadbalancer.SslConfigurationDetails
 	if params.listenerCertificateID != "" {
 		sslConfig = &loadbalancer.SslConfigurationDetails{
@@ -894,6 +954,10 @@ func (m *ociLoadBalancerModelImpl) reconcileHTTPListener(
 	sslConfig, err := m.applyFrontendMTLS(ctx, params, sslConfig)
 	if err != nil {
 		return err
+	}
+
+	if err = m.reconcileListenerRoutingPolicy(ctx, params); err != nil {
+		return fmt.Errorf("failed to reconcile listener routing policy: %w", err)
 	}
 
 	if existingListener, ok := params.knownListeners[listenerName]; ok {
@@ -1887,4 +1951,12 @@ func ociCertificateNameFromSecret(
 	secret corev1.Secret,
 ) string {
 	return secret.Namespace + "-" + secret.Name + "-rev-" + secret.ResourceVersion
+}
+
+func frontendMTLSListenerCertificateName(
+	secret corev1.Secret,
+	port gatewayv1.PortNumber,
+	caPEM string,
+) string {
+	return fmt.Sprintf("%s-fmtls-%d-%s", ociCertificateNameFromSecret(secret), port, sha256Hex(caPEM)[:8])
 }

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -770,6 +770,85 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			)
 		})
 
+		t.Run("creates frontend mTLS certificate aliases with CA certificate", func(t *testing.T) {
+			fakeData := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			certRefName := gatewayv1.ObjectName("server-cert-" + fakeData.Lorem().Word())
+			certRefNamespace := gatewayv1.Namespace("server-ns-" + fakeData.Lorem().Word())
+			listener := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+				func(l *gatewayv1.Listener) {
+					l.TLS.CertificateRefs = []gatewayv1.SecretObjectReference{{
+						Name:      certRefName,
+						Namespace: &certRefNamespace,
+					}}
+				},
+			)
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(listener))
+			caRefName := gatewayv1.ObjectName("client-ca-" + fakeData.Lorem().Word())
+			gateway.Spec.TLS = &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+						CACertificateRefs: []gatewayv1.ObjectReference{{
+							Group: "",
+							Kind:  "ConfigMap",
+							Name:  caRefName,
+						}},
+					}},
+				},
+			}
+			ref := listener.TLS.CertificateRefs[0]
+			secret := makeRandomSecret(randomSecretWithTLSDataOpt())
+			caPEM := testCAPEM(t)
+			configMap := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: gateway.Namespace,
+					Name:      string(caRefName),
+				},
+				Data: map[string]string{"ca.crt": caPEM},
+			}
+			trimmedCAPEM := strings.TrimSpace(caPEM)
+			certName := frontendMTLSListenerCertificateName(secret, listener.Port, trimmedCAPEM)
+			loadBalancerID := fakeData.UUID().V4()
+			workRequestID := fakeData.UUID().V4()
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			setupClientGet(t, k8sClient, types.NamespacedName{
+				Namespace: string(lo.FromPtr(ref.Namespace)),
+				Name:      string(ref.Name),
+			}, secret).Once()
+			setupClientGet(t, k8sClient, types.NamespacedName{
+				Namespace: gateway.Namespace,
+				Name:      string(caRefName),
+			}, configMap).Once()
+			ociLoadBalancerClient.EXPECT().CreateCertificate(t.Context(), loadbalancer.CreateCertificateRequest{
+				LoadBalancerId: &loadBalancerID,
+				CreateCertificateDetails: loadbalancer.CreateCertificateDetails{
+					CertificateName:   &certName,
+					PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
+					PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
+					CaCertificate:     &trimmedCAPEM,
+				},
+			}).Return(loadbalancer.CreateCertificateResponse{
+				OpcWorkRequestId: &workRequestID,
+			}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			gotResult, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+				loadBalancerID: loadBalancerID,
+				gateway:        gateway,
+			})
+
+			require.NoError(t, err)
+			gotCerts := gotResult.certificatesByListener[string(listener.Name)]
+			require.Len(t, gotCerts, 1)
+			assert.Equal(t, certName, lo.FromPtr(gotCerts[0].CertificateName))
+			assert.Contains(t, gotResult.reconciledCertificates, certName)
+		})
+
 		t.Run("fails when secret get fails", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
@@ -1399,6 +1478,38 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 			ociLoadBalancerClient.AssertNotCalled(t, "CreateRoutingPolicy")
 			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
+		})
+
+		t.Run("does not create routing policy when frontend mTLS validation fails", func(t *testing.T) {
+			fakeData := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(gwListener))
+			gateway.Annotations = map[string]string{}
+			gateway.Annotations[FrontendMTLSTrustedCABundleOCIDsAnnotation] =
+				"ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+			certName := "cert-" + fakeData.Lorem().Word()
+			params := reconcileHTTPListenerParams{
+				loadBalancerID:            fakeData.UUID().V4(),
+				defaultBackendSetName:     fakeData.UUID().V4(),
+				listenerSpec:              &gwListener,
+				gateway:                   gateway,
+				listenerCertificates:      []loadbalancer.Certificate{{CertificateName: &certName}},
+				knownRoutingPolicies:      map[string]loadbalancer.RoutingPolicy{},
+				knownListeners:            map[string]loadbalancer.Listener{},
+				listenerCertificateID:     "",
+				loadBalancerCompartmentID: "compartment-" + fakeData.Lorem().Word(),
+			}
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.ErrorContains(t, err, "OCI CA bundle OCID annotations require listener")
+			ociLoadBalancerClient.AssertNotCalled(t, "CreateRoutingPolicy")
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
+			ociLoadBalancerClient.AssertNotCalled(t, "CreateListener")
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateListener")
 		})
 
 		t.Run("fails when created listener has no work request id", func(t *testing.T) {

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -4131,6 +4131,43 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes stale frontend mTLS certificate aliases after CA rotation", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			baseCert := makeManagedCertificate("default", "gateway-tls", fake.UUID().V4())
+			currentFrontendMTLSCert := makeRandomOCICertificate()
+			currentFrontendMTLSCertName := lo.FromPtr(baseCert.CertificateName) +
+				"-fmtls-19443-current-" + fake.RandomStringWithLength(8)
+			currentFrontendMTLSCert.CertificateName = &currentFrontendMTLSCertName
+			staleFrontendMTLSCert := makeRandomOCICertificate()
+			staleFrontendMTLSCertName := lo.FromPtr(baseCert.CertificateName) +
+				"-fmtls-19443-stale-" + fake.RandomStringWithLength(8)
+			staleFrontendMTLSCert.CertificateName = &staleFrontendMTLSCertName
+
+			params := removeUnusedCertificatesParams{
+				loadBalancerID:      fake.UUID().V4(),
+				desiredCertificates: []string{lo.FromPtr(currentFrontendMTLSCert.CertificateName)},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					lo.FromPtr(currentFrontendMTLSCert.CertificateName): currentFrontendMTLSCert,
+					lo.FromPtr(staleFrontendMTLSCert.CertificateName):   staleFrontendMTLSCert,
+				},
+			}
+
+			workRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: staleFrontendMTLSCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{OpcWorkRequestId: &workRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			err := model.removeUnusedCertificates(t.Context(), params)
+			require.NoError(t, err)
+		})
+
 		t.Run("preserves unused certificates not previously programmed by the controller", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -2516,6 +2516,155 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes orphaned listener routing policies when listeners are already gone", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			currentListener := makeRandomListener()
+			currentOCIListener := makeRandomOCIListener(func(l *loadbalancer.Listener) {
+				l.Name = new(string(currentListener.Name))
+				l.RoutingPolicyName = new(listenerPolicyName(string(currentListener.Name)))
+			})
+			removedListenerName := "removed-" + fake.UUID().V4()
+			orphanPolicyName := listenerPolicyName(removedListenerName)
+			rtmpsPolicyName := listenerPolicyName("rtmps")
+			userPolicyName := "custom_policy"
+			defaultRule := loadbalancer.RoutingRule{
+				Name:      new(defaultCatchAllRuleName),
+				Condition: new("any(http.request.url.path sw '/')"),
+			}
+
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					*currentOCIListener.Name: currentOCIListener,
+				},
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					*currentOCIListener.RoutingPolicyName: makeRandomOCIRoutingPolicy(
+						func(p *loadbalancer.RoutingPolicy) {
+							p.Name = currentOCIListener.RoutingPolicyName
+						},
+					),
+					orphanPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &orphanPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+					rtmpsPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &rtmpsPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+					userPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &userPolicyName
+					}),
+				},
+				gatewayListeners: []gatewayv1.Listener{
+					currentListener,
+				},
+			}
+
+			deletePolicyRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteRoutingPolicy(t.Context(), loadbalancer.DeleteRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &orphanPolicyName,
+			}).Return(loadbalancer.DeleteRoutingPolicyResponse{OpcWorkRequestId: &deletePolicyRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), deletePolicyRequestID).Return(nil).Once()
+			deleteRTMPSPolicyRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteRoutingPolicy(t.Context(), loadbalancer.DeleteRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &rtmpsPolicyName,
+			}).Return(loadbalancer.DeleteRoutingPolicyResponse{OpcWorkRequestId: &deleteRTMPSPolicyRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), deleteRTMPSPolicyRequestID).Return(nil).Once()
+
+			err := model.removeMissingListeners(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("skips protected orphaned listener routing policy candidates", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+
+			desiredListener := makeRandomListener()
+			attachedGatewayListener := makeRandomListener()
+			desiredPolicyName := listenerPolicyName(string(desiredListener.Name))
+			attachedPolicyName := listenerPolicyName("attached-" + fake.UUID().V4())
+			nonDefaultPolicyName := listenerPolicyName("non-default-" + fake.UUID().V4())
+			userPolicyName := "manual." + fake.Internet().Domain()
+			attachedListener := makeRandomOCIListener(func(l *loadbalancer.Listener) {
+				l.Name = new(string(attachedGatewayListener.Name))
+				l.RoutingPolicyName = &attachedPolicyName
+			})
+			defaultRule := loadbalancer.RoutingRule{
+				Name:      new(defaultCatchAllRuleName),
+				Condition: new("any(http.request.url.path sw '/')"),
+			}
+
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					*attachedListener.Name: attachedListener,
+				},
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					desiredPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &desiredPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+					attachedPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &attachedPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+					nonDefaultPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &nonDefaultPolicyName
+					}),
+					userPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &userPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+				},
+				gatewayListeners: []gatewayv1.Listener{
+					desiredListener,
+					attachedGatewayListener,
+				},
+			}
+
+			err := model.removeMissingListeners(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("returns orphaned routing policy delete errors", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			orphanPolicyName := listenerPolicyName("orphan-" + fake.UUID().V4())
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			defaultRule := loadbalancer.RoutingRule{
+				Name:      new(defaultCatchAllRuleName),
+				Condition: new("any(http.request.url.path sw '/')"),
+			}
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					orphanPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &orphanPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+				},
+			}
+
+			ociLoadBalancerClient.EXPECT().DeleteRoutingPolicy(t.Context(), loadbalancer.DeleteRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &orphanPolicyName,
+			}).Return(loadbalancer.DeleteRoutingPolicyResponse{}, wantErr).Once()
+
+			err := model.removeMissingListeners(t.Context(), params)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, wantErr)
+		})
+
 		t.Run("fail when delete listener fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -2528,9 +2528,14 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				l.Name = new(string(currentListener.Name))
 				l.RoutingPolicyName = new(listenerPolicyName(string(currentListener.Name)))
 			})
+			tlsListener := gatewayv1.Listener{
+				Name:     "rtmps",
+				Protocol: gatewayv1.TLSProtocolType,
+				Port:     1936,
+			}
 			removedListenerName := "removed-" + fake.UUID().V4()
 			orphanPolicyName := listenerPolicyName(removedListenerName)
-			rtmpsPolicyName := listenerPolicyName("rtmps")
+			rtmpsPolicyName := listenerPolicyName(string(tlsListener.Name))
 			userPolicyName := "custom_policy"
 			defaultRule := loadbalancer.RoutingRule{
 				Name:      new(defaultCatchAllRuleName),
@@ -2562,6 +2567,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				},
 				gatewayListeners: []gatewayv1.Listener{
 					currentListener,
+					tlsListener,
 				},
 			}
 
@@ -2587,7 +2593,9 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
 
-			desiredListener := makeRandomListener()
+			desiredListener := makeRandomListener(func(l *gatewayv1.Listener) {
+				l.Protocol = gatewayv1.HTTPSProtocolType
+			})
 			attachedGatewayListener := makeRandomListener()
 			desiredPolicyName := listenerPolicyName(string(desiredListener.Name))
 			attachedPolicyName := listenerPolicyName("attached-" + fake.UUID().V4())

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -4093,6 +4093,44 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes stale frontend mTLS certificate aliases", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			usedCert := makeManagedCertificate("default", "gateway-tls", fake.UUID().V4())
+			staleFrontendMTLSCert := makeRandomOCICertificate()
+			staleFrontendMTLSCertName := lo.FromPtr(usedCert.CertificateName) +
+				"-fmtls-19443-" + fake.RandomStringWithLength(8)
+			staleFrontendMTLSCert.CertificateName = &staleFrontendMTLSCertName
+			externalFrontendMTLSLikeCert := makeRandomOCICertificate()
+			externalFrontendMTLSLikeCertName := "external-gateway-tls-rev-" + fake.UUID().V4() +
+				"-fmtls-19443-" + fake.RandomStringWithLength(8)
+			externalFrontendMTLSLikeCert.CertificateName = &externalFrontendMTLSLikeCertName
+
+			params := removeUnusedCertificatesParams{
+				loadBalancerID:      fake.UUID().V4(),
+				desiredCertificates: []string{lo.FromPtr(usedCert.CertificateName)},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					lo.FromPtr(usedCert.CertificateName):                     usedCert,
+					lo.FromPtr(staleFrontendMTLSCert.CertificateName):        staleFrontendMTLSCert,
+					lo.FromPtr(externalFrontendMTLSLikeCert.CertificateName): externalFrontendMTLSLikeCert,
+				},
+			}
+
+			workRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: staleFrontendMTLSCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{OpcWorkRequestId: &workRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			err := model.removeUnusedCertificates(t.Context(), params)
+			require.NoError(t, err)
+		})
+
 		t.Run("preserves unused certificates not previously programmed by the controller", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -5659,6 +5697,7 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 					listenerName:          listenerName,
 					listenerSpec:          &listenerSpec,
 					defaultBackendSetName: defaultBackendSetName,
+					preserveHTTP2:         true,
 				},
 				want:   loadbalancer.UpdateListenerDetails{},
 				wantOk: false,
@@ -5685,9 +5724,40 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 					listenerName:          listenerName,
 					listenerSpec:          &listenerSpec,
 					defaultBackendSetName: defaultBackendSetName,
+					preserveHTTP2:         true,
 				},
 				want: loadbalancer.UpdateListenerDetails{
 					Protocol:              new(ociListenerProtocolHTTP2),
+					Port:                  new(int(listenerSpec.Port)),
+					DefaultBackendSetName: new(defaultBackendSetName),
+					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+				},
+				wantOk: true,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+
+			return testCase{
+				name: "repairs HTTP2 protocol drift when listener has no GRPCRoute rules",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new(ociListenerProtocolHTTP2),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+				},
+				want: loadbalancer.UpdateListenerDetails{
+					Protocol:              new(ociListenerProtocolHTTP),
 					Port:                  new(int(listenerSpec.Port)),
 					DefaultBackendSetName: new(defaultBackendSetName),
 					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
@@ -6136,6 +6206,40 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 			assert.Equal(t, tc.wantOk, gotOk)
 		})
 	}
+}
+
+func TestListenerPolicyContainsGRPCRules(t *testing.T) {
+	fake := faker.New()
+	assert.False(t, listenerPolicyContainsGRPCRules(loadbalancer.RoutingPolicy{}))
+	assert.False(t, listenerPolicyContainsGRPCRules(loadbalancer.RoutingPolicy{
+		Rules: []loadbalancer.RoutingRule{{
+			Condition: new("any(http.request.url.path sw '/')"),
+		}},
+	}))
+	assert.True(t, listenerPolicyContainsGRPCRules(loadbalancer.RoutingPolicy{
+		Name: new("policy-" + fake.Lorem().Word()),
+		Rules: []loadbalancer.RoutingRule{{
+			Condition: new("all(http.request.headers[(i 'content-type')][0] sw (i 'application/grpc+'))"),
+		}},
+	}))
+}
+
+func TestKnownFrontendMTLSCertificateNames(t *testing.T) {
+	fake := faker.New()
+	controllerCert := "default-gateway-tls-rev-" + fake.UUID().V4()
+	frontendCert := controllerCert + "-fmtls-443-" + fake.RandomStringWithLength(8)
+	externalCert := "external-gateway-tls-rev-" + fake.UUID().V4() + "-fmtls-443-" + fake.RandomStringWithLength(8)
+
+	assert.Empty(t, knownFrontendMTLSCertificateNames(map[string]loadbalancer.Certificate{
+		frontendCert: {CertificateName: &frontendCert},
+	}, nil))
+	assert.Equal(t, []string{frontendCert}, knownFrontendMTLSCertificateNames(
+		map[string]loadbalancer.Certificate{
+			frontendCert: {CertificateName: &frontendCert},
+			externalCert: {CertificateName: &externalCert},
+		},
+		[]string{controllerCert},
+	))
 }
 
 func Test_applyListenerTLSOptions(t *testing.T) {

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -5245,11 +5245,14 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 
 	makeSslConfigFromDetails := func(details *loadbalancer.SslConfigurationDetails) *loadbalancer.SslConfiguration {
 		return &loadbalancer.SslConfiguration{
-			CertificateName:      details.CertificateName,
-			CertificateIds:       details.CertificateIds,
-			CipherSuiteName:      details.CipherSuiteName,
-			Protocols:            details.Protocols,
-			HasSessionResumption: details.HasSessionResumption,
+			CertificateName:                details.CertificateName,
+			CertificateIds:                 details.CertificateIds,
+			CipherSuiteName:                details.CipherSuiteName,
+			Protocols:                      details.Protocols,
+			HasSessionResumption:           details.HasSessionResumption,
+			VerifyPeerCertificate:          details.VerifyPeerCertificate,
+			VerifyDepth:                    details.VerifyDepth,
+			TrustedCertificateAuthorityIds: details.TrustedCertificateAuthorityIds,
 		}
 	}
 
@@ -5277,6 +5280,95 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 				},
 				want:   loadbalancer.UpdateListenerDetails{},
 				wantOk: false,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+			certName := fake.UUID().V4()
+			verifyPeer := true
+			verifyDepth := 3
+			sslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateName:                &certName,
+				VerifyPeerCertificate:          &verifyPeer,
+				VerifyDepth:                    &verifyDepth,
+				TrustedCertificateAuthorityIds: []string{"ca-b", "ca-a"},
+			}
+
+			return testCase{
+				name: "ssl config frontend mTLS CA ids match regardless of order",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+						SslConfiguration: &loadbalancer.SslConfiguration{
+							CertificateName:                &certName,
+							VerifyPeerCertificate:          &verifyPeer,
+							VerifyDepth:                    &verifyDepth,
+							TrustedCertificateAuthorityIds: []string{"ca-a", "ca-b"},
+						},
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+					sslConfig:             sslConfig,
+				},
+				want:   loadbalancer.UpdateListenerDetails{},
+				wantOk: false,
+			}
+		},
+		func() testCase {
+			fake := faker.New()
+			listenerName := fake.UUID().V4()
+			listenerSpec := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+			)
+			defaultBackendSetName := fake.UUID().V4()
+			certName := fake.UUID().V4()
+			verifyPeer := true
+			oldVerifyDepth := 3
+			newVerifyDepth := 4
+			sslConfig := &loadbalancer.SslConfigurationDetails{
+				CertificateName:                &certName,
+				VerifyPeerCertificate:          &verifyPeer,
+				VerifyDepth:                    &newVerifyDepth,
+				TrustedCertificateAuthorityIds: []string{"ca-a"},
+			}
+
+			return testCase{
+				name: "ssl config frontend mTLS verify depth change",
+				params: makeOciListenerUpdateDetailsParams{
+					existingListenerData: loadbalancer.Listener{
+						Protocol:              new("HTTP"),
+						Port:                  new(int(listenerSpec.Port)),
+						DefaultBackendSetName: new(defaultBackendSetName),
+						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+						SslConfiguration: &loadbalancer.SslConfiguration{
+							CertificateName:                &certName,
+							VerifyPeerCertificate:          &verifyPeer,
+							VerifyDepth:                    &oldVerifyDepth,
+							TrustedCertificateAuthorityIds: []string{"ca-a"},
+						},
+					},
+					listenerName:          listenerName,
+					listenerSpec:          &listenerSpec,
+					defaultBackendSetName: defaultBackendSetName,
+					sslConfig:             sslConfig,
+				},
+				want: loadbalancer.UpdateListenerDetails{
+					Protocol:              new("HTTP"),
+					Port:                  new(int(listenerSpec.Port)),
+					DefaultBackendSetName: new(defaultBackendSetName),
+					RoutingPolicyName:     new(listenerPolicyName(listenerName)),
+					SslConfiguration:      sslConfig,
+				},
+				wantOk: true,
 			}
 		},
 		func() testCase {

--- a/internal/app/referencegrant_policy.go
+++ b/internal/app/referencegrant_policy.go
@@ -44,20 +44,31 @@ func referenceGrantAllowsSecretRef(
 	fromNamespace string,
 	secretName apitypes.NamespacedName,
 ) (bool, error) {
-	if secretName.Namespace == fromNamespace {
+	return referenceGrantAllowsCoreRef(ctx, k8sClient, fromKind, fromNamespace, "Secret", secretName)
+}
+
+func referenceGrantAllowsCoreRef(
+	ctx context.Context,
+	k8sClient k8sClient,
+	fromKind gatewayv1.Kind,
+	fromNamespace string,
+	toKind gatewayv1.Kind,
+	refName apitypes.NamespacedName,
+) (bool, error) {
+	if refName.Namespace == fromNamespace {
 		return true, nil
 	}
 
 	var grants gatewayv1beta1.ReferenceGrantList
-	if err := k8sClient.List(ctx, &grants, client.InNamespace(secretName.Namespace)); err != nil {
-		return false, fmt.Errorf("failed to list ReferenceGrants in namespace %s: %w", secretName.Namespace, err)
+	if err := k8sClient.List(ctx, &grants, client.InNamespace(refName.Namespace)); err != nil {
+		return false, fmt.Errorf("failed to list ReferenceGrants in namespace %s: %w", refName.Namespace, err)
 	}
 
 	for _, grant := range grants.Items {
 		if !referenceGrantHasMatchingFrom(grant, fromKind, fromNamespace) {
 			continue
 		}
-		if referenceGrantHasMatchingSecretTo(grant, secretName.Name) {
+		if referenceGrantHasMatchingCoreTo(grant, toKind, refName.Name) {
 			return true, nil
 		}
 	}

--- a/internal/app/resources_model.go
+++ b/internal/app/resources_model.go
@@ -14,14 +14,15 @@ import (
 )
 
 type setConditionParams struct {
-	resource      client.Object
-	conditions    *[]metav1.Condition
-	conditionType string
-	status        metav1.ConditionStatus
-	reason        string
-	message       string
-	annotations   map[string]string
-	finalizer     string
+	resource          client.Object
+	conditions        *[]metav1.Condition
+	conditionType     string
+	status            metav1.ConditionStatus
+	reason            string
+	message           string
+	annotations       map[string]string
+	removeAnnotations []string
+	finalizer         string
 }
 
 type isConditionSetParams struct {
@@ -78,10 +79,13 @@ func (m *resourcesModelImpl) setCondition(ctx context.Context, params setConditi
 		needsResourceUpdate = controllerutil.AddFinalizer(params.resource, params.finalizer)
 	}
 
-	if len(params.annotations) > 0 {
+	if len(params.annotations) > 0 || len(params.removeAnnotations) > 0 {
 		currentAnnotations := params.resource.GetAnnotations()
 		if currentAnnotations == nil {
 			currentAnnotations = make(map[string]string)
+		}
+		for _, key := range params.removeAnnotations {
+			delete(currentAnnotations, key)
 		}
 		maps.Copy(currentAnnotations, params.annotations)
 		params.resource.SetAnnotations(currentAnnotations)

--- a/internal/app/resources_model_test.go
+++ b/internal/app/resources_model_test.go
@@ -222,6 +222,71 @@ func TestResourcesModelImpl_setCondition(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("RemovesStaleFrontendMTLSDependencyAnnotation", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+
+		keepKey := "keep-" + fake.Lorem().Word()
+		keepValue := fake.UUID().V4()
+		newRevision := fake.UUID().V4()
+		gateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fake.Lorem().Word(),
+				Name:       "gateway-" + fake.Lorem().Word(),
+				Generation: rand.Int64(),
+				Annotations: map[string]string{
+					keepKey:                                 keepValue,
+					GatewayFrontendMTLSConfigMapsAnnotation: "old-ns/old-ca=" + fake.UUID().V4(),
+					GatewayFrontendMTLSReferenceGrantsAnnotation: "old-ns/old-grant=" + fake.UUID().V4(),
+				},
+			},
+			Status: gatewayv1.GatewayStatus{Conditions: []metav1.Condition{}},
+		}
+		wantAnnotations := map[string]string{
+			keepKey:                              keepValue,
+			GatewayProgrammingRevisionAnnotation: newRevision,
+		}
+
+		params := setConditionParams{
+			resource:      gateway,
+			conditions:    &gateway.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayConditionProgrammed),
+			status:        metav1.ConditionTrue,
+			reason:        string(gatewayv1.GatewayReasonProgrammed),
+			message:       fake.Lorem().Sentence(10),
+			annotations: map[string]string{
+				GatewayProgrammingRevisionAnnotation: newRevision,
+			},
+			removeAnnotations: []string{
+				GatewayFrontendMTLSConfigMapsAnnotation,
+				GatewayFrontendMTLSReferenceGrantsAnnotation,
+			},
+		}
+
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+		statusUpdateCall := mockStatusWriter.EXPECT().
+			Update(t.Context(), gateway, mock.Anything).
+			Return(nil).
+			Once()
+
+		mockClient.EXPECT().
+			Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				gotGateway, ok := obj.(*gatewayv1.Gateway)
+				require.True(t, ok)
+				assert.Equal(t, wantAnnotations, gotGateway.GetAnnotations())
+				return true
+			}), mock.Anything).
+			Return(nil).
+			Once().
+			NotBefore(statusUpdateCall)
+
+		err := model.setCondition(t.Context(), params)
+		require.NoError(t, err)
+	})
+
 	t.Run("HappyPath_AddsAnnotations_NoInitial", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)

--- a/internal/app/tlsroute_controller.go
+++ b/internal/app/tlsroute_controller.go
@@ -97,6 +97,13 @@ func (r *TLSRouteController) reconcileResolvedRoute(
 			}
 			return nil
 		}
+		if isParentGatewayStatusError(err) {
+			r.logger.InfoContext(ctx, "TLSRoute parent Gateway is not programmable",
+				slog.String("tlsRoute", req.NamespacedName.String()),
+				slog.String("reason", err.Error()),
+			)
+			return nil
+		}
 		return fmt.Errorf("failed to program TLSRoute %s: %w", req.NamespacedName, err)
 	}
 	if err := r.tlsRouteModel.setProgrammed(ctx, resolvedRoute); err != nil {

--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
@@ -28,6 +29,7 @@ const httpRouteParentGatewayIndexKey = ".metadata.parentRefs.gateway"
 const grpcRouteParentGatewayIndexKey = ".metadata.grpcParentRefs.gateway"
 const tlsRouteParentGatewayIndexKey = ".metadata.tlsParentRefs.gateway"
 const gatewayCertificateIndexKey = ".metadata.certificates" // Virtual field name, indexed
+const gatewayFrontendMTLSCAConfigMapIndexKey = ".metadata.frontendMTLSConfigMaps"
 const listenerSetParentGatewayIndexKey = ".metadata.parentRef.gateway"
 const listenerSetCertificateIndexKey = ".metadata.listenerSetCertificates"
 const tcpRouteBackendServiceIndexKey = ".metadata.tcpBackendRefs.serviceName"
@@ -49,10 +51,11 @@ type WatchesModelDeps struct {
 
 // RegisterFieldIndexersOptions controls which optional route indexers are registered.
 type RegisterFieldIndexersOptions struct {
-	EnableTCPRoute    bool
-	EnableUDPRoute    bool
-	EnableTLSRoute    bool
-	EnableListenerSet bool
+	EnableTCPRoute     bool
+	EnableUDPRoute     bool
+	EnableTLSRoute     bool
+	EnableListenerSet  bool
+	EnableFrontendMTLS bool
 }
 
 // NewWatchesModel creates a new watchesModel.
@@ -131,14 +134,14 @@ func (m *WatchesModel) RegisterFieldIndexers(
 		}
 	}
 
-	if err := indexer.IndexField(ctx,
-		&gatewayv1.Gateway{},
-		gatewayCertificateIndexKey,
-		func(o client.Object) []string {
-			return m.indexGatewayByCertificateSecrets(ctx, o)
-		},
-	); err != nil {
-		return fmt.Errorf("failed to index Gateway by certificate: %w", err)
+	if err := m.registerGatewayCertificateIndexers(ctx, indexer); err != nil {
+		return err
+	}
+
+	if opts.EnableFrontendMTLS {
+		if err := m.registerFrontendMTLSIndexers(ctx, indexer); err != nil {
+			return err
+		}
 	}
 
 	if opts.EnableListenerSet {
@@ -154,11 +157,39 @@ func (m *WatchesModel) RegisterFieldIndexers(
 		slog.String("indexKey", grpcRouteParentGatewayIndexKey),
 		slog.String("indexKey", tlsRouteParentGatewayIndexKey),
 		slog.String("indexKey", gatewayCertificateIndexKey),
+		slog.String("indexKey", gatewayFrontendMTLSCAConfigMapIndexKey),
 		slog.Bool("tcpRouteIndexEnabled", opts.EnableTCPRoute),
 		slog.Bool("udpRouteIndexEnabled", opts.EnableUDPRoute),
 		slog.Bool("tlsRouteIndexEnabled", opts.EnableTLSRoute),
 		slog.Bool("listenerSetIndexEnabled", opts.EnableListenerSet),
+		slog.Bool("frontendMTLSIndexEnabled", opts.EnableFrontendMTLS),
 	)
+	return nil
+}
+
+func (m *WatchesModel) registerGatewayCertificateIndexers(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx,
+		&gatewayv1.Gateway{},
+		gatewayCertificateIndexKey,
+		func(o client.Object) []string {
+			return m.indexGatewayByCertificateSecrets(ctx, o)
+		},
+	); err != nil {
+		return fmt.Errorf("failed to index Gateway by certificate: %w", err)
+	}
+	return nil
+}
+
+func (m *WatchesModel) registerFrontendMTLSIndexers(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx,
+		&gatewayv1.Gateway{},
+		gatewayFrontendMTLSCAConfigMapIndexKey,
+		func(o client.Object) []string {
+			return m.indexGatewayByFrontendMTLSConfigMaps(ctx, o)
+		},
+	); err != nil {
+		return fmt.Errorf("failed to index Gateway by frontend mTLS ConfigMap: %w", err)
+	}
 	return nil
 }
 
@@ -634,6 +665,53 @@ func (m *WatchesModel) indexGatewayByCertificateSecrets(ctx context.Context, obj
 	return secretKeys
 }
 
+func (m *WatchesModel) indexGatewayByFrontendMTLSConfigMaps(ctx context.Context, obj client.Object) []string {
+	gateway, isGateway := obj.(*gatewayv1.Gateway)
+	logger := m.logger.WithGroup("gateway-frontend-mtls-configmap-index")
+
+	if !isGateway {
+		logger.WarnContext(ctx, "Received non-Gateway object", slog.Any("object", obj))
+		return nil
+	}
+	if gateway.DeletionTimestamp != nil ||
+		gateway.Spec.TLS == nil ||
+		gateway.Spec.TLS.Frontend == nil {
+		return nil
+	}
+	if gateway.Annotations == nil || gateway.Annotations[ControllerClassName] != "true" {
+		return nil
+	}
+
+	uniqueConfigMapKeys := make(map[string]struct{})
+	addRefs := func(validation *gatewayv1.FrontendTLSValidation) {
+		if validation == nil {
+			return
+		}
+		for _, ref := range validation.CACertificateRefs {
+			if ref.Group != "" || ref.Kind != "ConfigMap" {
+				continue
+			}
+			ns := gateway.Namespace
+			if ref.Namespace != nil {
+				ns = string(*ref.Namespace)
+			}
+			uniqueConfigMapKeys[path.Join(ns, string(ref.Name))] = struct{}{}
+		}
+	}
+	addRefs(gateway.Spec.TLS.Frontend.Default.Validation)
+	for _, portConfig := range gateway.Spec.TLS.Frontend.PerPort {
+		addRefs(portConfig.TLS.Validation)
+	}
+
+	configMapKeys := lo.Keys(uniqueConfigMapKeys)
+	logger.DebugContext(ctx, "Indexed Gateway by frontend mTLS ConfigMap",
+		slog.String("gateway", client.ObjectKeyFromObject(gateway).String()),
+		slog.String("indexKey", gatewayFrontendMTLSCAConfigMapIndexKey),
+		slog.Any("configMapKeys", configMapKeys),
+	)
+	return configMapKeys
+}
+
 // MapEndpointSliceToHTTPRoute maps EndpointSlice events to HTTPRoute reconcile requests.
 // Its signature matches handler.MapFunc.
 func (m *WatchesModel) MapEndpointSliceToHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -987,6 +1065,36 @@ func (m *WatchesModel) MapConfigMapToTLSRoute(ctx context.Context, obj client.Ob
 			return m.MapBackendTLSPolicyToTLSRoute(ctx, &policy)
 		},
 	)
+}
+
+func (m *WatchesModel) MapConfigMapToGateway(ctx context.Context, obj client.Object) []reconcile.Request {
+	configMap, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ConfigMap object", slog.Any("object", obj))
+		return nil
+	}
+	indexKey := path.Join(configMap.Namespace, configMap.Name)
+	var gatewayList gatewayv1.GatewayList
+	if err := m.k8sClient.List(
+		ctx,
+		&gatewayList,
+		client.MatchingFields{gatewayFrontendMTLSCAConfigMapIndexKey: indexKey},
+	); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list Gateways for frontend mTLS ConfigMap",
+			slog.String("indexKey", indexKey),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(gatewayList.Items))
+	for _, gateway := range gatewayList.Items {
+		if gateway.DeletionTimestamp != nil {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&gateway)})
+	}
+	return requests
 }
 
 func (m *WatchesModel) MapServiceToHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -1543,6 +1651,40 @@ func (m *WatchesModel) MapReferenceGrantToGatewayWithListenerSets(
 	return lo.Values(requestsByKey)
 }
 
+func (m *WatchesModel) MapReferenceGrantToGatewayFrontendMTLS(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	grant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-ReferenceGrant object", slog.Any("object", obj))
+		return nil
+	}
+	if !referenceGrantHasMatchingFromKind(*grant, gatewayv1.Kind("Gateway")) ||
+		!referenceGrantHasMatchingCoreToKind(*grant, gatewayv1.Kind("ConfigMap")) {
+		return nil
+	}
+
+	var gatewayList gatewayv1.GatewayList
+	if err := m.k8sClient.List(ctx, &gatewayList); err != nil {
+		m.logger.ErrorContext(ctx,
+			"Failed to list Gateways for frontend mTLS ReferenceGrant change",
+			slog.String("referenceGrant", client.ObjectKeyFromObject(grant).String()),
+			diag.ErrAttr(err),
+		)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for _, gateway := range gatewayList.Items {
+		if gateway.DeletionTimestamp != nil || !gatewayFrontendMTLSReferencesGrantedConfigMap(gateway, *grant) {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&gateway)})
+	}
+	return requests
+}
+
 func (m *WatchesModel) MapReferenceGrantToListenerSet(ctx context.Context, obj client.Object) []reconcile.Request {
 	grant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
 	if !ok {
@@ -1588,8 +1730,12 @@ func referenceGrantHasMatchingFromKind(grant gatewayv1beta1.ReferenceGrant, kind
 }
 
 func referenceGrantHasSecretTo(grant gatewayv1beta1.ReferenceGrant) bool {
+	return referenceGrantHasMatchingCoreToKind(grant, gatewayv1.Kind("Secret"))
+}
+
+func referenceGrantHasMatchingCoreToKind(grant gatewayv1beta1.ReferenceGrant, kind gatewayv1.Kind) bool {
 	for _, to := range grant.Spec.To {
-		if string(to.Group) == "" && to.Kind == gatewayv1.Kind("Secret") {
+		if string(to.Group) == "" && to.Kind == kind {
 			return true
 		}
 	}
@@ -1618,6 +1764,42 @@ func listenerSetReferencesGrantedSecret(
 			if referenceGrantHasMatchingSecretTo(grant, string(ref.Name)) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func gatewayFrontendMTLSReferencesGrantedConfigMap(
+	gateway gatewayv1.Gateway,
+	grant gatewayv1beta1.ReferenceGrant,
+) bool {
+	if gateway.Spec.TLS == nil || gateway.Spec.TLS.Frontend == nil {
+		return false
+	}
+	if !referenceGrantHasMatchingFrom(grant, gatewayv1.Kind("Gateway"), gateway.Namespace) {
+		return false
+	}
+	matchesRef := func(ref gatewayv1.ObjectReference) bool {
+		refNamespace := gateway.Namespace
+		if ref.Namespace != nil {
+			refNamespace = string(*ref.Namespace)
+		}
+		return refNamespace == grant.Namespace &&
+			ref.Group == "" &&
+			ref.Kind == gatewayv1.Kind("ConfigMap") &&
+			referenceGrantHasMatchingCoreTo(grant, gatewayv1.Kind("ConfigMap"), string(ref.Name))
+	}
+	if validation := gateway.Spec.TLS.Frontend.Default.Validation; validation != nil {
+		if slices.ContainsFunc(validation.CACertificateRefs, matchesRef) {
+			return true
+		}
+	}
+	for _, portConfig := range gateway.Spec.TLS.Frontend.PerPort {
+		if portConfig.TLS.Validation == nil {
+			continue
+		}
+		if slices.ContainsFunc(portConfig.TLS.Validation.CACertificateRefs, matchesRef) {
+			return true
 		}
 	}
 	return false

--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -1677,7 +1677,9 @@ func (m *WatchesModel) MapReferenceGrantToGatewayFrontendMTLS(
 
 	requests := make([]reconcile.Request, 0)
 	for _, gateway := range gatewayList.Items {
-		if gateway.DeletionTimestamp != nil || !gatewayFrontendMTLSReferencesGrantedConfigMap(gateway, *grant) {
+		if gateway.DeletionTimestamp != nil ||
+			gateway.Annotations[ControllerClassName] != "true" ||
+			!gatewayFrontendMTLSReferencesGrantedConfigMap(gateway, *grant) {
 			continue
 		}
 		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&gateway)})

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -145,6 +145,109 @@ func TestWatchesModel(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("registers frontend mTLS Gateway indexer when enabled", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mockIndexer := k8sapi.NewMockFieldIndexer(t)
+
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.HTTPRoute{},
+				httpRouteBackendServiceIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.GRPCRoute{},
+				grpcRouteBackendServiceIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.HTTPRoute{},
+				httpRouteParentGatewayIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.GRPCRoute{},
+				grpcRouteParentGatewayIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.Gateway{},
+				gatewayCertificateIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.Gateway{},
+				gatewayFrontendMTLSCAConfigMapIndexKey,
+				mock.AnythingOfType("client.IndexerFunc"),
+			).Return(nil)
+
+			err := model.RegisterFieldIndexers(t.Context(), mockIndexer, RegisterFieldIndexersOptions{
+				EnableFrontendMTLS: true,
+			})
+
+			require.NoError(t, err)
+		})
+
+		t.Run("wraps frontend mTLS Gateway indexer registration errors", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mockIndexer := k8sapi.NewMockFieldIndexer(t)
+
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.HTTPRoute{},
+				httpRouteBackendServiceIndexKey,
+				mock.Anything,
+			).
+				Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.GRPCRoute{},
+				grpcRouteBackendServiceIndexKey,
+				mock.Anything,
+			).
+				Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.HTTPRoute{},
+				httpRouteParentGatewayIndexKey,
+				mock.Anything,
+			).
+				Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.GRPCRoute{},
+				grpcRouteParentGatewayIndexKey,
+				mock.Anything,
+			).
+				Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.Gateway{},
+				gatewayCertificateIndexKey,
+				mock.Anything,
+			).
+				Return(nil)
+			mockIndexer.EXPECT().IndexField(
+				t.Context(),
+				&gatewayv1.Gateway{},
+				gatewayFrontendMTLSCAConfigMapIndexKey,
+				mock.Anything,
+			).Return(errors.New("frontend index failed"))
+
+			err := model.RegisterFieldIndexers(t.Context(), mockIndexer, RegisterFieldIndexersOptions{
+				EnableFrontendMTLS: true,
+			})
+
+			require.ErrorContains(t, err, "failed to index Gateway by frontend mTLS ConfigMap")
+		})
+
 		t.Run("registers TLSRoute indexer when enabled", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := NewWatchesModel(deps)
@@ -2452,6 +2555,36 @@ func TestWatchesModel(t *testing.T) {
 	})
 
 	t.Run("MapNamespaceToGateway", func(t *testing.T) {
+		t.Run("detects Gateways using namespace selectors", func(t *testing.T) {
+			selectedFrom := gatewayv1.NamespacesFromSelector
+			require.False(t, gatewayAllowedListenersUsesNamespaceSelector(gatewayv1.Gateway{}))
+			require.True(t, gatewayAllowedListenersUsesNamespaceSelector(gatewayv1.Gateway{
+				Spec: gatewayv1.GatewaySpec{
+					AllowedListeners: &gatewayv1.AllowedListeners{
+						Namespaces: &gatewayv1.ListenerNamespaces{From: &selectedFrom},
+					},
+				},
+			}))
+		})
+
+		t.Run("returns nil for non Namespace objects", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+
+			require.Nil(t, model.MapNamespaceToGateway(t.Context(), &corev1.Service{}))
+		})
+
+		t.Run("returns nil when Gateway list fails", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.GatewayList{}).
+				Return(errors.New("gateway list failed"))
+
+			require.Nil(t, model.MapNamespaceToGateway(t.Context(), &corev1.Namespace{}))
+		})
+
 		t.Run("queues Gateways using allowedListeners namespace selectors", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := NewWatchesModel(deps)
@@ -3335,5 +3468,194 @@ func TestWatchesModel(t *testing.T) {
 			t.Context(),
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "backend"}},
 		))
+	})
+
+	t.Run("Gateway frontend mTLS ConfigMap watches", func(t *testing.T) {
+		fakeData := faker.New()
+		namespace := "ns-" + fakeData.Lorem().Word()
+		configMapName := "ca-" + fakeData.Lorem().Word()
+		otherConfigMapName := "ca-other-" + fakeData.Lorem().Word()
+		crossNamespace := "cross-" + fakeData.Lorem().Word()
+		crossNamespaceRef := gatewayv1.Namespace(crossNamespace)
+		mode := gatewayv1.TLSModeTerminate
+		gateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "gw-" + fakeData.Lorem().Word(),
+				Annotations: map[string]string{
+					ControllerClassName: "true",
+				},
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+					TLS:      &gatewayv1.ListenerTLSConfig{Mode: &mode},
+				}},
+				TLS: &gatewayv1.GatewayTLSConfig{
+					Frontend: &gatewayv1.FrontendTLSConfig{
+						Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+							CACertificateRefs: []gatewayv1.ObjectReference{{
+								Group: "",
+								Kind:  "ConfigMap",
+								Name:  gatewayv1.ObjectName(configMapName),
+							}},
+						}},
+						PerPort: []gatewayv1.TLSPortConfig{{
+							Port: 8443,
+							TLS: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+								CACertificateRefs: []gatewayv1.ObjectReference{{
+									Group:     "",
+									Kind:      "ConfigMap",
+									Name:      gatewayv1.ObjectName(otherConfigMapName),
+									Namespace: &crossNamespaceRef,
+								}},
+							}},
+						}},
+					},
+				},
+			},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(gateway).
+			WithIndex(&gatewayv1.Gateway{}, gatewayFrontendMTLSCAConfigMapIndexKey, func(obj client.Object) []string {
+				return NewWatchesModel(WatchesModelDeps{
+					K8sClient: fake.NewClientBuilder().WithScheme(newL4TestScheme(t)).Build(),
+					Logger:    diag.RootTestLogger(),
+				}).indexGatewayByFrontendMTLSConfigMaps(t.Context(), obj)
+			}).
+			Build()
+		model := NewWatchesModel(WatchesModelDeps{
+			K8sClient: k8sClient,
+			Logger:    diag.RootTestLogger(),
+		})
+
+		require.ElementsMatch(t, []string{
+			namespace + "/" + configMapName,
+			crossNamespace + "/" + otherConfigMapName,
+		}, model.indexGatewayByFrontendMTLSConfigMaps(t.Context(), gateway))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: gateway.Name},
+		}}, model.MapConfigMapToGateway(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: configMapName},
+		}))
+		require.Nil(t, model.MapConfigMapToGateway(t.Context(), &corev1.Service{}))
+
+		deletingGateway := gateway.DeepCopy()
+		deleteTime := metav1.Now()
+		deletingGateway.DeletionTimestamp = &deleteTime
+		require.Nil(t, model.indexGatewayByFrontendMTLSConfigMaps(t.Context(), deletingGateway))
+
+		noTLSGateway := gateway.DeepCopy()
+		noTLSGateway.Spec.TLS = nil
+		require.Nil(t, model.indexGatewayByFrontendMTLSConfigMaps(t.Context(), noTLSGateway))
+
+		unownedGateway := gateway.DeepCopy()
+		unownedGateway.Annotations = nil
+		require.Nil(t, model.indexGatewayByFrontendMTLSConfigMaps(t.Context(), unownedGateway))
+
+		invalidRefGateway := gateway.DeepCopy()
+		invalidRefGateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs = []gatewayv1.ObjectReference{{
+			Group: "example.com",
+			Kind:  "Secret",
+			Name:  gatewayv1.ObjectName("ignored-" + fakeData.Lorem().Word()),
+		}}
+		invalidRefGateway.Spec.TLS.Frontend.PerPort = nil
+		require.Empty(t, model.indexGatewayByFrontendMTLSConfigMaps(t.Context(), invalidRefGateway))
+		require.Nil(t, model.indexGatewayByFrontendMTLSConfigMaps(t.Context(), &corev1.ConfigMap{}))
+	})
+
+	t.Run("Gateway frontend mTLS ConfigMap watch list errors", func(t *testing.T) {
+		deps := makeMockDeps(t)
+		model := NewWatchesModel(deps)
+		mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		namespace := "ns-" + faker.New().Lorem().Word()
+		name := "ca-" + faker.New().Lorem().Word()
+		mockK8sClient.EXPECT().
+			List(t.Context(), &gatewayv1.GatewayList{}, client.MatchingFields{
+				gatewayFrontendMTLSCAConfigMapIndexKey: namespace + "/" + name,
+			}).
+			Return(errors.New("gateway list failed"))
+
+		require.Nil(t, model.MapConfigMapToGateway(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		}))
+	})
+
+	t.Run("Gateway frontend mTLS ReferenceGrant watches", func(t *testing.T) {
+		fakeData := faker.New()
+		namespace := "ns-" + fakeData.Lorem().Word()
+		crossNamespace := "cross-" + fakeData.Lorem().Word()
+		crossNamespaceRef := gatewayv1.Namespace(crossNamespace)
+		configMapName := "ca-" + fakeData.Lorem().Word()
+		gateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "gw-" + fakeData.Lorem().Word()},
+			Spec: gatewayv1.GatewaySpec{TLS: &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+						CACertificateRefs: []gatewayv1.ObjectReference{{
+							Group:     "",
+							Kind:      "ConfigMap",
+							Name:      gatewayv1.ObjectName(configMapName),
+							Namespace: &crossNamespaceRef,
+						}},
+					}},
+				},
+			}},
+		}
+		grant := &gatewayv1beta1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Namespace: crossNamespace, Name: "grant-" + fakeData.Lorem().Word()},
+			Spec: gatewayv1beta1.ReferenceGrantSpec{
+				From: []gatewayv1beta1.ReferenceGrantFrom{{
+					Group:     gatewayv1.Group(gatewayAPIGroup),
+					Kind:      gatewayv1.Kind("Gateway"),
+					Namespace: gatewayv1.Namespace(namespace),
+				}},
+				To: []gatewayv1beta1.ReferenceGrantTo{{
+					Group: "",
+					Kind:  gatewayv1.Kind("ConfigMap"),
+				}},
+			},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(gateway).
+			Build()
+		model := NewWatchesModel(WatchesModelDeps{
+			K8sClient: k8sClient,
+			Logger:    diag.RootTestLogger(),
+		})
+
+		require.True(t, gatewayFrontendMTLSReferencesGrantedConfigMap(*gateway, *grant))
+		require.ElementsMatch(t, []reconcile.Request{{
+			NamespacedName: apitypes.NamespacedName{Namespace: namespace, Name: gateway.Name},
+		}}, model.MapReferenceGrantToGatewayFrontendMTLS(t.Context(), grant))
+		require.Nil(t, model.MapReferenceGrantToGatewayFrontendMTLS(t.Context(), &corev1.Service{}))
+		require.False(t, gatewayFrontendMTLSReferencesGrantedConfigMap(gatewayv1.Gateway{}, *grant))
+
+		wrongFromGrant := grant.DeepCopy()
+		wrongFromGrant.Spec.From[0].Namespace = gatewayv1.Namespace("other-" + fakeData.Lorem().Word())
+		require.False(t, gatewayFrontendMTLSReferencesGrantedConfigMap(*gateway, *wrongFromGrant))
+
+		wrongToGrant := grant.DeepCopy()
+		wrongToGrant.Spec.To[0].Kind = gatewayv1.Kind("Secret")
+		require.False(t, gatewayFrontendMTLSReferencesGrantedConfigMap(*gateway, *wrongToGrant))
+
+		perPortGateway := gateway.DeepCopy()
+		perPortGateway.Spec.TLS.Frontend.Default.Validation = nil
+		perPortGateway.Spec.TLS.Frontend.PerPort = []gatewayv1.TLSPortConfig{{
+			Port: 8443,
+			TLS: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
+				CACertificateRefs: []gatewayv1.ObjectReference{{
+					Group:     "",
+					Kind:      "ConfigMap",
+					Name:      gatewayv1.ObjectName(configMapName),
+					Namespace: &crossNamespaceRef,
+				}},
+			}},
+		}}
+		require.True(t, gatewayFrontendMTLSReferencesGrantedConfigMap(*perPortGateway, *grant))
 	})
 }

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -3591,7 +3591,13 @@ func TestWatchesModel(t *testing.T) {
 		crossNamespaceRef := gatewayv1.Namespace(crossNamespace)
 		configMapName := "ca-" + fakeData.Lorem().Word()
 		gateway := &gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "gw-" + fakeData.Lorem().Word()},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "gw-" + fakeData.Lorem().Word(),
+				Annotations: map[string]string{
+					ControllerClassName: "true",
+				},
+			},
 			Spec: gatewayv1.GatewaySpec{TLS: &gatewayv1.GatewayTLSConfig{
 				Frontend: &gatewayv1.FrontendTLSConfig{
 					Default: gatewayv1.TLSConfig{Validation: &gatewayv1.FrontendTLSValidation{
@@ -3605,6 +3611,9 @@ func TestWatchesModel(t *testing.T) {
 				},
 			}},
 		}
+		unownedGateway := gateway.DeepCopy()
+		unownedGateway.Name = "unowned-" + fakeData.Lorem().Word()
+		unownedGateway.Annotations = nil
 		grant := &gatewayv1beta1.ReferenceGrant{
 			ObjectMeta: metav1.ObjectMeta{Namespace: crossNamespace, Name: "grant-" + fakeData.Lorem().Word()},
 			Spec: gatewayv1beta1.ReferenceGrantSpec{
@@ -3621,7 +3630,7 @@ func TestWatchesModel(t *testing.T) {
 		}
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(newL4TestScheme(t)).
-			WithObjects(gateway).
+			WithObjects(gateway, unownedGateway).
 			Build()
 		model := NewWatchesModel(WatchesModelDeps{
 			K8sClient: k8sClient,

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -405,6 +405,15 @@ func setupGatewayController(
 			&configtypes.GatewayConfig{},
 			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapGatewayConfigToGateway),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapConfigMapToGateway),
+		).
+		Watches(
+			&gatewayv1beta1.ReferenceGrant{},
+			handler.EnqueueRequestsFromMapFunc(deps.WatchesModel.MapReferenceGrantToGatewayFrontendMTLS),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		)
 	controllerBuilder = watchListenerSetGatewayObjects(controllerBuilder, deps, listenerSetAvailable)
 	return controllerBuilder.Complete(wireupReconciler(deps.GatewayCtrl, middlewares...))
@@ -714,10 +723,11 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error {
 	}
 
 	if err := deps.WatchesModel.RegisterFieldIndexers(ctx, mgr.GetFieldIndexer(), app.RegisterFieldIndexersOptions{
-		EnableTCPRoute:    experimentalRoutes.reconcileTCPRoute,
-		EnableUDPRoute:    experimentalRoutes.reconcileUDPRoute,
-		EnableTLSRoute:    experimentalRoutes.reconcileTLSRoute,
-		EnableListenerSet: experimentalRoutes.listenerSetAvailable,
+		EnableTCPRoute:     experimentalRoutes.reconcileTCPRoute,
+		EnableUDPRoute:     experimentalRoutes.reconcileUDPRoute,
+		EnableTLSRoute:     experimentalRoutes.reconcileTLSRoute,
+		EnableListenerSet:  experimentalRoutes.listenerSetAvailable,
+		EnableFrontendMTLS: true,
 	}); err != nil {
 		return fmt.Errorf("failed to register field indexers: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds frontend mutual TLS support for OCI Load Balancer Gateway listeners using the Gateway API `Gateway.spec.tls.frontend` configuration.

This allows users to require client certificates on HTTPS listeners by referencing Kubernetes `ConfigMap` CA bundles. The controller programs OCI Load Balancer listener SSL configuration with peer certificate
verification enabled, supports per-port mTLS policy, watches CA bundle changes, and reconciles listener/certificate drift.

Closes #75.

### Example: Gateway Listener mTLS

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: client-ca-bundle
  namespace: example
data:
  ca.crt: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: example-gateway
  namespace: example
spec:
  gatewayClassName: oke-alb
  tls:
    frontend:
      perPort:
      - port: 443
        validation:
          caCertificateRefs:
          - group: ""
            kind: ConfigMap
            name: client-ca-bundle
          mode: AllowValidOnly
  listeners:
  - name: https
    protocol: HTTPS
    port: 443
    hostname: api.example.com
    tls:
      mode: Terminate
      certificateRefs:
      - name: server-tls
    allowedRoutes:
      namespaces:
        from: Same
```

### Example: ListenerSet mTLS

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: ListenerSet
metadata:
  name: mtls-listener
  namespace: example
spec:
  parentRef:
    name: example-gateway
  listeners:
  - name: https-mtls
    protocol: HTTPS
    port: 8443
    hostname: mtls.example.com
    tls:
      mode: Terminate
      certificateRefs:
      - name: server-tls
```