### PR TITLE
Fix e2e test regressions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 go_version=$(grep "^go " go.mod | awk '{print $2}')
 
-gobrew use ${go_version}@latest
+gobrew use ${go_version}
 
 # We store common go related files (caches, common tools e.t.c) in the parent directory
 # This may be unexpected but it's a better option than polutting global

--- a/e2e/.envrc
+++ b/e2e/.envrc
@@ -1,7 +1,7 @@
 repo_root=$(expand_path "$PWD/..")
 go_version=$(grep "^go " "$repo_root/go.mod" | awk '{print $2}')
 
-gobrew use ${go_version}@latest
+gobrew use ${go_version}
 
 export GOPATH=$(expand_path "$repo_root/../go/${go_version}")
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -19,7 +19,7 @@ preflight:
 	go run ./internal/cmd/e2e-check
 
 run-e2e-tests:
-	@$(MAKE) -C .. dist/bin
+	@$(MAKE) -B -C .. dist/bin
 	@$(MAKE) preflight
 	go test -v -count=1 -timeout 30m .
 

--- a/e2e/http_cleanup_test.go
+++ b/e2e/http_cleanup_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/jaswdr/faker/v2"
@@ -12,6 +13,52 @@ import (
 
 	"github.com/gemyago/oke-gateway-api/e2e/internal/e2ek8s"
 )
+
+func TestProgrammedPolicyRuleNames(t *testing.T) {
+	t.Run("extracts rule names from listener scoped and legacy annotations", func(t *testing.T) {
+		fake := faker.New()
+		listenerName := "listener-" + fake.Lorem().Word()
+		scopedRuleName := "scoped-" + fake.Lorem().Word()
+		legacyRuleName := "legacy-" + fake.Lorem().Word()
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-" + fake.UUID().V4(),
+				Namespace: "namespace-" + fake.UUID().V4(),
+				Annotations: map[string]string{
+					httpRouteProgrammedPolicyRulesAnnotation: fmt.Sprintf(
+						" %s/%s , %s ",
+						listenerName,
+						scopedRuleName,
+						legacyRuleName,
+					),
+				},
+			},
+		}
+
+		got, err := programmedPolicyRuleNames(route)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{scopedRuleName, legacyRuleName}, got)
+	})
+
+	t.Run("ignores malformed listener scoped annotations", func(t *testing.T) {
+		fake := faker.New()
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-" + fake.UUID().V4(),
+				Namespace: "namespace-" + fake.UUID().V4(),
+				Annotations: map[string]string{
+					httpRouteProgrammedPolicyRulesAnnotation: "/,listener/",
+				},
+			},
+		}
+
+		got, err := programmedPolicyRuleNames(route)
+
+		require.Error(t, err)
+		require.Empty(t, got)
+	})
+}
 
 func TestDeleteNamespaceHTTPRoutes(t *testing.T) {
 	t.Run("deletes only routes in the target namespace", func(t *testing.T) {

--- a/e2e/http_test.go
+++ b/e2e/http_test.go
@@ -509,6 +509,14 @@ func programmedPolicyRuleNames(route *gatewayv1.HTTPRoute) ([]string, error) {
 			continue
 		}
 
+		listenerName, scopedRuleName, scoped := strings.Cut(part, "/")
+		if scoped {
+			if listenerName == "" || scopedRuleName == "" {
+				continue
+			}
+			part = scopedRuleName
+		}
+
 		ruleNames = append(ruleNames, part)
 	}
 

--- a/e2e/internal/e2ek8s/fixtures.go
+++ b/e2e/internal/e2ek8s/fixtures.go
@@ -417,7 +417,7 @@ func NewHTTPRoute(opts HTTPRouteOptions) *gatewayv1.HTTPRoute {
 		servicePort = DefaultEchoPort
 	}
 
-	portNumber := gatewayv1.PortNumber(servicePort)
+	portNumber := servicePort
 	pathMatch := cloneHTTPPathMatch(opts.PathMatch)
 	if pathMatch == nil && !opts.OmitPathMatch {
 		pathPrefix := opts.PathPrefix

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -60,12 +60,14 @@ type StartManagerDeps struct {
 type experimentalRouteCapabilities struct {
 	TCPRoute         bool
 	UDPRoute         bool
+	TLSRoute         bool
 	BackendTLSPolicy bool
 }
 
 type resolvedExperimentalRouteCapabilities struct {
 	reconcileTCPRoute         bool
 	reconcileUDPRoute         bool
+	reconcileTLSRoute         bool
 	reconcileBackendTLSPolicy bool
 	backendTLSPolicyAvailable bool
 }
@@ -119,7 +121,6 @@ func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRo
 	tcpRouteAvailable, err := resourceKindAvailable(
 		mapper,
 		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "TCPRoute"},
-		"v1",
 	)
 	if err != nil {
 		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect TCPRoute availability: %w", err)
@@ -128,15 +129,20 @@ func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRo
 	udpRouteAvailable, err := resourceKindAvailable(
 		mapper,
 		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "UDPRoute"},
-		"v1",
 	)
 	if err != nil {
 		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect UDPRoute availability: %w", err)
 	}
+	tlsRouteAvailable, err := resourceKindAvailable(
+		mapper,
+		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "TLSRoute"},
+	)
+	if err != nil {
+		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect TLSRoute availability: %w", err)
+	}
 	backendTLSPolicyAvailable, err := resourceKindAvailable(
 		mapper,
 		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "BackendTLSPolicy"},
-		"v1",
 	)
 	if err != nil {
 		return experimentalRouteCapabilities{}, fmt.Errorf("failed to detect BackendTLSPolicy availability: %w", err)
@@ -145,12 +151,13 @@ func detectExperimentalRouteCapabilities(mapper meta.RESTMapper) (experimentalRo
 	return experimentalRouteCapabilities{
 		TCPRoute:         tcpRouteAvailable,
 		UDPRoute:         udpRouteAvailable,
+		TLSRoute:         tlsRouteAvailable,
 		BackendTLSPolicy: backendTLSPolicyAvailable,
 	}, nil
 }
 
-func resourceKindAvailable(mapper meta.RESTMapper, groupKind schema.GroupKind, version string) (bool, error) {
-	if _, err := mapper.RESTMapping(groupKind, version); err != nil {
+func resourceKindAvailable(mapper meta.RESTMapper, groupKind schema.GroupKind) (bool, error) {
+	if _, err := mapper.RESTMapping(groupKind, gatewayv1.GroupVersion.Version); err != nil {
 		if meta.IsNoMatchError(err) {
 			return false, nil
 		}
@@ -188,6 +195,9 @@ func resolveExperimentalRouteCapabilities(
 	if deps.ReconcileUDPRoute && !experimentalRouteCRDs.UDPRoute {
 		logger.InfoContext(ctx, "UDPRoute CRD is not installed; UDPRoute support is disabled")
 	}
+	if deps.ReconcileTLSRoute && !experimentalRouteCRDs.TLSRoute {
+		logger.InfoContext(ctx, "TLSRoute CRD is not installed; TLSRoute support is disabled")
+	}
 	if deps.ReconcileBackendTLSPolicy && !experimentalRouteCRDs.BackendTLSPolicy {
 		logger.InfoContext(ctx, "BackendTLSPolicy CRD is not installed; BackendTLSPolicy support is disabled")
 	}
@@ -195,6 +205,7 @@ func resolveExperimentalRouteCapabilities(
 	return resolvedExperimentalRouteCapabilities{
 		reconcileTCPRoute:         deps.ReconcileTCPRoute && experimentalRouteCRDs.TCPRoute,
 		reconcileUDPRoute:         deps.ReconcileUDPRoute && experimentalRouteCRDs.UDPRoute,
+		reconcileTLSRoute:         deps.ReconcileTLSRoute && experimentalRouteCRDs.TLSRoute,
 		reconcileBackendTLSPolicy: deps.ReconcileBackendTLSPolicy && experimentalRouteCRDs.BackendTLSPolicy,
 		backendTLSPolicyAvailable: experimentalRouteCRDs.BackendTLSPolicy,
 	}, nil
@@ -348,7 +359,7 @@ func l7AndTLSControllerSetupTasks(
 			},
 		},
 		{
-			enabled:     deps.ReconcileTLSRoute,
+			enabled:     experimentalRoutes.reconcileTLSRoute,
 			disabledLog: "TLSRoute controller is disabled",
 			setupErr:    "failed to setup TLSRoute controller: %w",
 			setup: func() error {
@@ -538,7 +549,7 @@ func StartManager(ctx context.Context, deps StartManagerDeps) error {
 	if err := deps.WatchesModel.RegisterFieldIndexers(ctx, mgr.GetFieldIndexer(), app.RegisterFieldIndexersOptions{
 		EnableTCPRoute: experimentalRoutes.reconcileTCPRoute,
 		EnableUDPRoute: experimentalRoutes.reconcileUDPRoute,
-		EnableTLSRoute: deps.ReconcileTLSRoute,
+		EnableTLSRoute: experimentalRoutes.reconcileTLSRoute,
 	}); err != nil {
 		return fmt.Errorf("failed to register field indexers: %w", err)
 	}

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -118,26 +118,24 @@ func TestL4RouteObjectPredicate(t *testing.T) {
 }
 
 func TestDetectExperimentalRouteCapabilities(t *testing.T) {
-	t.Run("detects TCPRoute and UDPRoute", func(t *testing.T) {
+	t.Run("detects TCPRoute, UDPRoute, and TLSRoute", func(t *testing.T) {
 		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
 			{Group: gatewayv1.GroupName, Version: "v1"},
 		})
-		mapper.Add(schema.GroupVersionKind{
-			Group:   gatewayv1.GroupName,
-			Version: "v1",
-			Kind:    "TCPRoute",
-		}, meta.RESTScopeNamespace)
-		mapper.Add(schema.GroupVersionKind{
-			Group:   gatewayv1.GroupName,
-			Version: "v1",
-			Kind:    "UDPRoute",
-		}, meta.RESTScopeNamespace)
+		for _, kind := range []string{"TCPRoute", "UDPRoute", "TLSRoute"} {
+			mapper.Add(schema.GroupVersionKind{
+				Group:   gatewayv1.GroupName,
+				Version: "v1",
+				Kind:    kind,
+			}, meta.RESTScopeNamespace)
+		}
 
 		got, err := detectExperimentalRouteCapabilities(mapper)
 
 		require.NoError(t, err)
 		assert.True(t, got.TCPRoute)
 		assert.True(t, got.UDPRoute)
+		assert.True(t, got.TLSRoute)
 	})
 
 	t.Run("treats missing routes as unavailable", func(t *testing.T) {
@@ -150,6 +148,7 @@ func TestDetectExperimentalRouteCapabilities(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, got.TCPRoute)
 		assert.False(t, got.UDPRoute)
+		assert.False(t, got.TLSRoute)
 	})
 
 	t.Run("returns non discovery errors", func(t *testing.T) {
@@ -160,6 +159,7 @@ func TestDetectExperimentalRouteCapabilities(t *testing.T) {
 		require.ErrorIs(t, err, wantErr)
 		assert.False(t, got.TCPRoute)
 		assert.False(t, got.UDPRoute)
+		assert.False(t, got.TLSRoute)
 	})
 }
 
@@ -189,12 +189,35 @@ func TestResolveExperimentalRouteCapabilities(t *testing.T) {
 			StartManagerDeps{
 				ReconcileTCPRoute: true,
 				ReconcileUDPRoute: true,
+				ReconcileTLSRoute: true,
 			},
 		)
 
 		require.NoError(t, err)
 		assert.False(t, got.reconcileTCPRoute)
 		assert.False(t, got.reconcileUDPRoute)
+		assert.False(t, got.reconcileTLSRoute)
+	})
+
+	t.Run("enables TLSRoute only when configured and installed", func(t *testing.T) {
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+			{Group: gatewayv1.GroupName, Version: "v1"},
+		})
+		mapper.Add(schema.GroupVersionKind{
+			Group:   gatewayv1.GroupName,
+			Version: "v1",
+			Kind:    "TLSRoute",
+		}, meta.RESTScopeNamespace)
+
+		got, err := resolveExperimentalRouteCapabilities(
+			t.Context(),
+			diag.RootTestLogger(),
+			mapper,
+			StartManagerDeps{ReconcileTLSRoute: true},
+		)
+
+		require.NoError(t, err)
+		assert.True(t, got.reconcileTLSRoute)
 	})
 
 	t.Run("keeps BackendTLSPolicy controller available for cleanup when feature is disabled", func(t *testing.T) {


### PR DESCRIPTION
- Pin gobrew to the exact Go version declared in `go.mod`.
- Force live e2e runs to rebuild the controller from current sources.
- Disable TLSRoute setup when its CRD is unavailable.
- Support listener-scoped routing-policy annotations and add regression coverage.
- Validate with root lint/tests, e2e lint/compile/tests, and the complete live suite.