### PR TITLE
Resolve L7 backend target ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,26 @@ Examples:
 - `deploy`: Helm chart and example manifests
 - `docs/https.md`: HTTPS-specific behavior
 
-## Coding Conventions
+## Project Rules and Conventions
 
+AI must always follow the rules and conventions defined in this section. This section defines a project specific rules and conventions. Module level rules and conventions must also be followed.
+
+The rules are:
+- **DO NOT** over engineer or over-complicate. Address problems present now or explicitly requested.
+- Never go outside of the project root
+- Store temp files in a project scoped tmp directory (e.g ${PWD}/tmp/...)
+- Update project rules and conventions when user corrects the behavior of AI.
+- Each rule must aim to be a simple and clear one line (50-80 characters)
+- Avoid markdown tables, prefer lists or other formatting. Tables are hard to read by humans. Use tables only when user explicitly requests it.
+- Do not run `git diff --check` as a routine verification step.
+
+## Golang
+
+- **Always** load and use gopher skill when working with Go code. Gopher skill must be used prior to **writing** any Go code, or **planning** go code changes.
+- viper should only be used for config wireup, it should never leak into the codebase outside of the entrypoints or wireup paths.
+- system must have reasonable logging that allows to troubleshoot problems and understand the flow of the system.
+- when logging attributes, use camelCase for keys
+- required component dependencies must be enforced in constructor, not in methods that use them
 - Keep changes idiomatic and gofmt-compatible
 - Linting is strict; avoid adding `//nolint` unless it is justified
 - Wrap errors with context, usually `fmt.Errorf("...: %w", err)`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ The rules are:
 - Each rule must aim to be a simple and clear one line (50-80 characters)
 - Randomize non-constant test data and test one behavior per case.
 - Reuse one faker instance throughout each top-level test function.
+- Run lint with a fresh project-scoped cache before pushing changes.
 - Avoid markdown tables, prefer lists or other formatting. Tables are hard to read by humans. Use tables only when user explicitly requests it.
 - Do not run `git diff --check` as a routine verification step.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,8 @@ The rules are:
 - Store temp files in a project scoped tmp directory (e.g ${PWD}/tmp/...)
 - Update project rules and conventions when user corrects the behavior of AI.
 - Each rule must aim to be a simple and clear one line (50-80 characters)
+- Randomize non-constant test data and test one behavior per case.
+- Reuse one faker instance throughout each top-level test function.
 - Avoid markdown tables, prefer lists or other formatting. Tables are hard to read by humans. Use tables only when user explicitly requests it.
 - Do not run `git diff --check` as a routine verification step.
 

--- a/internal/app/backend_service_port.go
+++ b/internal/app/backend_service_port.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func servicePortForBackendRef(
+	service corev1.Service,
+	backendRef gatewayv1.BackendRef,
+) (*corev1.ServicePort, error) {
+	if backendRef.BackendObjectReference.Port == nil {
+		return nil, fmt.Errorf("backendRef %s is missing port", backendRef.BackendObjectReference.Name)
+	}
+	for i := range service.Spec.Ports {
+		if service.Spec.Ports[i].Port == *backendRef.BackendObjectReference.Port {
+			return &service.Spec.Ports[i], nil
+		}
+	}
+	return nil, fmt.Errorf(
+		"backendRef service %s has no port %d",
+		backendRef.BackendObjectReference.Name,
+		*backendRef.BackendObjectReference.Port,
+	)
+}
+
+func endpointPortForServicePort(
+	servicePort corev1.ServicePort,
+	endpointSlice discoveryv1.EndpointSlice,
+) (int, bool) {
+	if servicePort.TargetPort.Type == 0 || servicePort.TargetPort.IntVal != 0 {
+		port := servicePort.TargetPort.IntValue()
+		if port == 0 {
+			port = int(servicePort.Port)
+		}
+		return port, true
+	}
+
+	for _, endpointPort := range endpointSlice.Ports {
+		if endpointPort.Port == nil {
+			continue
+		}
+		if endpointPort.Name != nil && *endpointPort.Name == servicePort.Name {
+			return int(*endpointPort.Port), true
+		}
+	}
+	return 0, false
+}

--- a/internal/app/backend_service_port_test.go
+++ b/internal/app/backend_service_port_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/jaswdr/faker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestServicePortForBackendRef(t *testing.T) {
+	fake := faker.New()
+
+	t.Run("returns referenced service port", func(t *testing.T) {
+		referencedPort := rand.Int32N(65534) + 1
+		otherPort := referencedPort%65535 + 1
+		expected := corev1.ServicePort{
+			Name:       "referenced-" + fake.Lorem().Word(),
+			Port:       referencedPort,
+			TargetPort: intstr.FromInt32(rand.Int32N(65534) + 1),
+		}
+		service := corev1.Service{Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
+			{
+				Name:       "other-" + fake.Lorem().Word(),
+				Port:       otherPort,
+				TargetPort: intstr.FromInt32(rand.Int32N(65534) + 1),
+			},
+			expected,
+		}}}
+
+		actual, err := servicePortForBackendRef(service, gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName("backend-" + fake.Lorem().Word()),
+				Port: new(referencedPort),
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, actual)
+		assert.Equal(t, expected, *actual)
+	})
+
+	t.Run("rejects backend ref without port", func(t *testing.T) {
+		_, err := servicePortForBackendRef(corev1.Service{}, gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName("backend-" + fake.Lorem().Word()),
+			},
+		})
+
+		require.ErrorContains(t, err, "missing port")
+	})
+
+	t.Run("rejects port absent from service", func(t *testing.T) {
+		servicePort := rand.Int32N(65534) + 1
+		backendPort := servicePort%65535 + 1
+		_, err := servicePortForBackendRef(
+			corev1.Service{Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: servicePort}}}},
+			gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName("backend-" + fake.Lorem().Word()),
+				Port: new(backendPort),
+			}},
+		)
+
+		require.ErrorContains(t, err, "has no port")
+	})
+}
+
+func TestEndpointPortForServicePort(t *testing.T) {
+	fake := faker.New()
+
+	t.Run("falls back to service port when target port is omitted", func(t *testing.T) {
+		servicePort := rand.Int32N(65534) + 1
+
+		actual, ok := endpointPortForServicePort(
+			corev1.ServicePort{Port: servicePort},
+			discoveryv1.EndpointSlice{},
+		)
+
+		assert.True(t, ok)
+		assert.Equal(t, int(servicePort), actual)
+	})
+
+	t.Run("returns numeric target port", func(t *testing.T) {
+		targetPort := rand.Int32N(65534) + 1
+
+		actual, ok := endpointPortForServicePort(
+			corev1.ServicePort{
+				Port:       targetPort%65535 + 1,
+				TargetPort: intstr.FromInt32(targetPort),
+			},
+			discoveryv1.EndpointSlice{},
+		)
+
+		assert.True(t, ok)
+		assert.Equal(t, int(targetPort), actual)
+	})
+
+	t.Run("returns named endpoint port", func(t *testing.T) {
+		servicePortName := "service-" + fake.Lorem().Word()
+		endpointPort := rand.Int32N(65534) + 1
+
+		actual, ok := endpointPortForServicePort(
+			corev1.ServicePort{
+				Name:       servicePortName,
+				Port:       rand.Int32N(65534) + 1,
+				TargetPort: intstr.FromString("target-" + fake.Lorem().Word()),
+			},
+			discoveryv1.EndpointSlice{Ports: []discoveryv1.EndpointPort{{
+				Name: &servicePortName,
+				Port: &endpointPort,
+			}}},
+		)
+
+		assert.True(t, ok)
+		assert.Equal(t, int(endpointPort), actual)
+	})
+
+	t.Run("rejects endpoint slice without matching named port", func(t *testing.T) {
+		servicePortName := "service-" + fake.Lorem().Word()
+		otherPortName := "other-" + fake.Lorem().Word()
+		endpointPort := rand.Int32N(65534) + 1
+
+		_, ok := endpointPortForServicePort(
+			corev1.ServicePort{
+				Name:       servicePortName,
+				Port:       rand.Int32N(65534) + 1,
+				TargetPort: intstr.FromString("target-" + fake.Lorem().Word()),
+			},
+			discoveryv1.EndpointSlice{Ports: []discoveryv1.EndpointPort{{
+				Name: &otherPortName,
+				Port: &endpointPort,
+			}}},
+		)
+
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects named endpoint port without value", func(t *testing.T) {
+		servicePortName := "service-" + fake.Lorem().Word()
+
+		_, ok := endpointPortForServicePort(
+			corev1.ServicePort{
+				Name:       servicePortName,
+				Port:       rand.Int32N(65534) + 1,
+				TargetPort: intstr.FromString("target-" + fake.Lorem().Word()),
+			},
+			discoveryv1.EndpointSlice{Ports: []discoveryv1.EndpointPort{{
+				Name: &servicePortName,
+			}}},
+		)
+
+		assert.False(t, ok)
+	})
+}

--- a/internal/app/httpbackend_model.go
+++ b/internal/app/httpbackend_model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/samber/lo"
 	"go.uber.org/dig"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -43,7 +44,7 @@ type syncRouteBackendRefEndpointsParams struct {
 }
 
 type identifyBackendsToUpdateParams struct {
-	endpointPort    int32
+	servicePort     corev1.ServicePort
 	currentBackends []loadbalancer.Backend
 	endpointSlices  []discoveryv1.EndpointSlice
 }
@@ -170,30 +171,17 @@ func (m *httpBackendModelImpl) identifyBackendsToUpdate(
 	var drainingCount int
 
 	for _, slice := range params.endpointSlices {
-		for _, endpoint := range slice.Endpoints {
-			if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
-				continue
-			}
-			if len(endpoint.Addresses) == 0 {
-				m.logger.WarnContext(ctx, "Endpoint has no addresses", slog.Any("endpoint", endpoint))
-				continue
-			}
-			ipAddress := endpoint.Addresses[0]
-			isDraining := endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating
-
-			if isDraining {
-				drainingCount++
-			}
-
+		endpointPort, ok := endpointPortForServicePort(params.servicePort, slice)
+		if !ok {
+			continue
+		}
+		sliceBackends, sliceDrainingCount := m.l7BackendsForSlice(ctx, slice, endpointPort)
+		drainingCount += sliceDrainingCount
+		for _, backend := range sliceBackends {
 			desiredBackendsMap[httpBackendAddressKey{
-				ipAddress: ipAddress,
-				port:      int(params.endpointPort),
-			}] = loadbalancer.BackendDetails{
-				Port:      new(int(params.endpointPort)),
-				IpAddress: &ipAddress,
-				Drain:     new(isDraining),
-				// Weight, MaxConnections, Backup, Offline are not managed here
-			}
+				ipAddress: *backend.IpAddress,
+				port:      endpointPort,
+			}] = backend
 		}
 	}
 
@@ -231,6 +219,35 @@ func (m *httpBackendModelImpl) identifyBackendsToUpdate(
 	}, nil
 }
 
+func (m *httpBackendModelImpl) l7BackendsForSlice(
+	ctx context.Context,
+	slice discoveryv1.EndpointSlice,
+	endpointPort int,
+) ([]loadbalancer.BackendDetails, int) {
+	backends := make([]loadbalancer.BackendDetails, 0, len(slice.Endpoints))
+	drainingCount := 0
+	for _, endpoint := range slice.Endpoints {
+		if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
+			continue
+		}
+		if len(endpoint.Addresses) == 0 {
+			m.logger.WarnContext(ctx, "Endpoint has no addresses", slog.Any("endpoint", endpoint))
+			continue
+		}
+		isDraining := endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating
+		if isDraining {
+			drainingCount++
+		}
+		backends = append(backends, loadbalancer.BackendDetails{
+			Port:      new(endpointPort),
+			IpAddress: new(endpoint.Addresses[0]),
+			Drain:     new(isDraining),
+			// Weight, MaxConnections, Backup, Offline are not managed here
+		})
+	}
+	return backends, drainingCount
+}
+
 func (m *httpBackendModelImpl) syncRouteBackendRefEndpoints(
 	ctx context.Context,
 	params syncRouteBackendRefEndpointsParams,
@@ -255,8 +272,6 @@ func (m *httpBackendModelImpl) syncRouteBackendRefEndpoints(
 	}
 	existingBackendSet := getResp.BackendSet
 
-	backendPort := lo.FromPtr(params.backendRef.BackendObjectReference.Port)
-
 	var endpointSlices discoveryv1.EndpointSliceList
 
 	if err = m.k8sClient.List(ctx, &endpointSlices,
@@ -272,8 +287,13 @@ func (m *httpBackendModelImpl) syncRouteBackendRefEndpoints(
 		)
 	}
 
+	servicePort, err := m.resolveL7ServicePort(ctx, backendRefNamespace, backendRef)
+	if err != nil {
+		return err
+	}
+
 	backendsToUpdate, err := m.self.identifyBackendsToUpdate(ctx, identifyBackendsToUpdateParams{
-		endpointPort:    backendPort,
+		servicePort:     *servicePort,
 		currentBackends: existingBackendSet.Backends,
 		endpointSlices:  endpointSlices.Items,
 	})
@@ -320,6 +340,25 @@ func (m *httpBackendModelImpl) syncRouteBackendRefEndpoints(
 		return fmt.Errorf("failed to wait for backend set %s to be updated: %w", backendSetName, err)
 	}
 	return nil
+}
+
+func (m *httpBackendModelImpl) resolveL7ServicePort(
+	ctx context.Context,
+	namespace string,
+	backendRef gatewayv1.BackendRef,
+) (*corev1.ServicePort, error) {
+	var service corev1.Service
+	if err := m.k8sClient.Get(ctx, client.ObjectKey{
+		Name:      string(backendRef.Name),
+		Namespace: namespace,
+	}, &service); err != nil {
+		return nil, fmt.Errorf("failed to get service for backend %s: %w", backendRef.Name, err)
+	}
+	servicePort, err := servicePortForBackendRef(service, backendRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve service port for backend %s: %w", backendRef.Name, err)
+	}
+	return servicePort, nil
 }
 
 func makeUpdateOciBackendSetDetails(

--- a/internal/app/httpbackend_model.go
+++ b/internal/app/httpbackend_model.go
@@ -324,9 +324,12 @@ func (m *httpBackendModelImpl) syncRouteBackendRefEndpoints(
 	)
 
 	ociUpdateResp, err := m.ociClient.UpdateBackendSet(ctx, loadbalancer.UpdateBackendSetRequest{
-		LoadBalancerId:          &params.config.Spec.LoadBalancerID,
-		BackendSetName:          &backendSetName,
-		UpdateBackendSetDetails: makeUpdateOciBackendSetDetails(existingBackendSet, backendsToUpdate.updatedBackends),
+		LoadBalancerId: &params.config.Spec.LoadBalancerID,
+		BackendSetName: &backendSetName,
+		UpdateBackendSetDetails: makeUpdateOciBackendSetDetails(
+			existingBackendSet,
+			backendsToUpdate.updatedBackends,
+		),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update backend set %s: %w", backendSetName, err)
@@ -374,10 +377,14 @@ func makeUpdateOciBackendSetDetails(
 	}
 
 	if existingBackendSet.HealthChecker != nil {
+		healthCheckerPort := existingBackendSet.HealthChecker.Port
+		if len(newBackends) > 0 {
+			healthCheckerPort = newBackends[0].Port
+		}
 		updateDetails.HealthChecker = &loadbalancer.HealthCheckerDetails{
 			Protocol:          existingBackendSet.HealthChecker.Protocol,
 			UrlPath:           existingBackendSet.HealthChecker.UrlPath,
-			Port:              existingBackendSet.HealthChecker.Port,
+			Port:              healthCheckerPort,
 			ReturnCode:        existingBackendSet.HealthChecker.ReturnCode,
 			Retries:           existingBackendSet.HealthChecker.Retries,
 			TimeoutInMillis:   existingBackendSet.HealthChecker.TimeoutInMillis,

--- a/internal/app/httpbackend_model_test.go
+++ b/internal/app/httpbackend_model_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -31,6 +33,38 @@ func TestHTTPBackendModel(t *testing.T) {
 			WorkRequestsWatcher:   NewMockworkRequestsWatcher(t),
 			self:                  NewMockhttpBackendModel(t),
 		}
+	}
+	expectBackendService := func(
+		t *testing.T,
+		deps httpBackendModelDeps,
+		routeNamespace string,
+		backendRef gatewayv1.BackendRef,
+		targetPort int32,
+	) {
+		namespace := routeNamespace
+		if backendRef.Namespace != nil {
+			namespace = string(*backendRef.Namespace)
+		}
+		servicePort := lo.FromPtr(backendRef.Port)
+		mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockK8sClient.EXPECT().Get(
+			t.Context(),
+			client.ObjectKey{Name: string(backendRef.Name), Namespace: namespace},
+			mock.AnythingOfType("*v1.Service"),
+		).RunAndReturn(func(
+			_ context.Context,
+			_ client.ObjectKey,
+			obj client.Object,
+			_ ...client.GetOption,
+		) error {
+			service, ok := obj.(*corev1.Service)
+			require.True(t, ok)
+			service.Spec.Ports = []corev1.ServicePort{{
+				Port:       servicePort,
+				TargetPort: intstr.FromInt32(targetPort),
+			}}
+			return nil
+		}).Once()
 	}
 
 	t.Run("syncRouteBackendRefsEndpoints", func(t *testing.T) {
@@ -321,12 +355,15 @@ func TestHTTPBackendModel(t *testing.T) {
 			)
 
 			backendRefPort := *backendRef.BackendObjectReference.Port
+			expectBackendService(t, deps, httpRoute.Namespace, backendRef.BackendRef, backendRefPort)
 
 			mockSelf, _ := deps.self.(*MockhttpBackendModel)
 			mockSelf.EXPECT().identifyBackendsToUpdate(
 				t.Context(),
 				mock.MatchedBy(func(params identifyBackendsToUpdateParams) bool {
-					return assert.Equal(t, backendRefPort, params.endpointPort) &&
+					resolvedPort, ok := endpointPortForServicePort(params.servicePort, endpointSlice)
+					return assert.True(t, ok) &&
+						assert.Equal(t, int(backendRefPort), resolvedPort) &&
 						assert.ElementsMatch(t, currentBackends, params.currentBackends) &&
 						assert.ElementsMatch(t, []discoveryv1.EndpointSlice{endpointSlice}, params.endpointSlices)
 				}),
@@ -466,6 +503,13 @@ func TestHTTPBackendModel(t *testing.T) {
 
 			mockWorkRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
 			mockWorkRequestsWatcher.EXPECT().WaitFor(t.Context(), wantOperationID).Return(nil).Once()
+			expectBackendService(
+				t,
+				deps,
+				httpRoute.Namespace,
+				backendRef.BackendRef,
+				*backendRef.BackendObjectReference.Port,
+			)
 
 			err := model.syncRouteBackendRefEndpoints(t.Context(), syncRouteBackendRefEndpointsParams{
 				routeKind:  "HTTPRoute",
@@ -522,12 +566,16 @@ func TestHTTPBackendModel(t *testing.T) {
 			).Return(loadbalancer.GetBackendSetResponse{BackendSet: sampleBackendSet}, nil).Once()
 
 			backendRefPort := *backendRef.BackendObjectReference.Port
+			expectBackendService(t, deps, httpRoute.Namespace, backendRef.BackendRef, backendRefPort)
 
 			mockSelf, _ := deps.self.(*MockhttpBackendModel)
 			mockSelf.EXPECT().identifyBackendsToUpdate(
 				t.Context(),
 				identifyBackendsToUpdateParams{
-					endpointPort:    backendRefPort,
+					servicePort: corev1.ServicePort{
+						Port:       backendRefPort,
+						TargetPort: intstr.FromInt32(backendRefPort),
+					},
 					currentBackends: currentBackends,
 					endpointSlices:  []discoveryv1.EndpointSlice{endpointSlice},
 				},
@@ -594,6 +642,22 @@ func TestHTTPBackendModel(t *testing.T) {
 						},
 						client.InNamespace(string(lo.FromPtr(backendRef.BackendObjectReference.Namespace))),
 					).Return(wantErr)
+				},
+				"get service": func(
+					deps httpBackendModelDeps,
+					_ types.GatewayConfig,
+					_ gatewayv1.HTTPRoute,
+					_ gatewayv1.HTTPBackendRef,
+					backendSet loadbalancer.BackendSet,
+					wantErr error,
+				) {
+					mockOciClient, _ := deps.OciLoadBalancerClient.(*MockociLoadBalancerClient)
+					mockOciClient.EXPECT().GetBackendSet(t.Context(), mock.Anything).
+						Return(loadbalancer.GetBackendSetResponse{BackendSet: backendSet}, nil)
+					mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+					mockK8sClient.EXPECT().List(t.Context(), mock.Anything, mock.Anything, mock.Anything).
+						Return(nil)
+					mockK8sClient.EXPECT().Get(t.Context(), mock.Anything, mock.Anything).Return(wantErr)
 				},
 				"identify updates": func(
 					deps httpBackendModelDeps,
@@ -721,6 +785,15 @@ func TestHTTPBackendModel(t *testing.T) {
 					)
 					wantErr := errors.New(faker.New().Lorem().Sentence(10))
 					setup(deps, config, httpRoute, backendRef, backendSet, wantErr)
+					if name != "get backend set" && name != "list endpoint slices" && name != "get service" {
+						expectBackendService(
+							t,
+							deps,
+							httpRoute.Namespace,
+							backendRef.BackendRef,
+							*backendRef.Port,
+						)
+					}
 
 					err := model.syncRouteBackendRefEndpoints(t.Context(), syncRouteBackendRefEndpointsParams{
 						routeKind:  "HTTPRoute",
@@ -741,6 +814,49 @@ func TestHTTPBackendModel(t *testing.T) {
 	})
 
 	t.Run("identifyBackendsToUpdate", func(t *testing.T) {
+		t.Run("resolves named service target ports per endpoint slice", func(t *testing.T) {
+			model := newHTTPBackendModel(newMockDeps(t))
+			portName := "backend-" + faker.New().Lorem().Word()
+			firstPort := rand.Int32N(65534) + 1
+			secondPort := rand.Int32N(65534) + 1
+			firstEndpoint := makeRandomEndpoint(randomEndpointWithConditionsOpt(new(true), new(false)))
+			secondEndpoint := makeRandomEndpoint(randomEndpointWithConditionsOpt(new(true), new(false)))
+
+			result, err := model.identifyBackendsToUpdate(t.Context(), identifyBackendsToUpdateParams{
+				servicePort: corev1.ServicePort{
+					Name:       portName,
+					Port:       rand.Int32N(65534) + 1,
+					TargetPort: intstr.FromString(portName),
+				},
+				endpointSlices: []discoveryv1.EndpointSlice{
+					{
+						Ports:     []discoveryv1.EndpointPort{{Name: &portName, Port: &firstPort}},
+						Endpoints: []discoveryv1.Endpoint{firstEndpoint},
+					},
+					{
+						Ports:     []discoveryv1.EndpointPort{{Name: &portName, Port: &secondPort}},
+						Endpoints: []discoveryv1.Endpoint{secondEndpoint},
+					},
+					{
+						Ports: []discoveryv1.EndpointPort{{
+							Name: new("other-" + faker.New().Lorem().Word()),
+							Port: new(rand.Int32N(65534) + 1),
+						}},
+						Endpoints: []discoveryv1.Endpoint{
+							makeRandomEndpoint(randomEndpointWithConditionsOpt(new(true), new(false))),
+						},
+					},
+				},
+			})
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []loadbalancer.BackendDetails{
+				{IpAddress: &firstEndpoint.Addresses[0], Port: new(int(firstPort)), Drain: new(false)},
+				{IpAddress: &secondEndpoint.Addresses[0], Port: new(int(secondPort)), Drain: new(false)},
+			}, result.updatedBackends)
+			assert.True(t, result.updateRequired)
+		})
+
 		t.Run("happy path - add new backends", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newHTTPBackendModel(deps)
@@ -768,7 +884,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			endpointSlices := []discoveryv1.EndpointSlice{slice1, slice2}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -824,7 +940,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -872,7 +988,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -916,7 +1032,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			}
 
 			result, err := model.identifyBackendsToUpdate(t.Context(), identifyBackendsToUpdateParams{
-				endpointPort:    desiredPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(desiredPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			})
@@ -954,7 +1070,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -1000,7 +1116,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -1047,7 +1163,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			endpointSlices := []discoveryv1.EndpointSlice{}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -1088,7 +1204,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -1114,7 +1230,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			endpointSlices := []discoveryv1.EndpointSlice{}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}
@@ -1147,7 +1263,7 @@ func TestHTTPBackendModel(t *testing.T) {
 			}
 
 			params := identifyBackendsToUpdateParams{
-				endpointPort:    refPort,
+				servicePort:     corev1.ServicePort{TargetPort: intstr.FromInt32(refPort)},
 				currentBackends: currentBackends,
 				endpointSlices:  endpointSlices,
 			}

--- a/internal/app/httpbackend_model_test.go
+++ b/internal/app/httpbackend_model_test.go
@@ -394,7 +394,7 @@ func TestHTTPBackendModel(t *testing.T) {
 							assert.ElementsMatch(t, wantUpdatedBackends, req.Backends),
 							assert.Equal(t, sampleBackendSet.Policy, req.Policy),
 							assert.Equal(t, sampleBackendSet.HealthChecker.Protocol, req.HealthChecker.Protocol),
-							assert.Equal(t, sampleBackendSet.HealthChecker.Port, req.HealthChecker.Port),
+							assert.Equal(t, wantUpdatedBackends[0].Port, req.HealthChecker.Port),
 							assert.Equal(t, sampleBackendSet.HealthChecker.UrlPath, req.HealthChecker.UrlPath),
 							assert.Equal(t, sampleBackendSet.HealthChecker.ReturnCode, req.HealthChecker.ReturnCode),
 							assert.Equal(

--- a/internal/app/l4route_policy.go
+++ b/internal/app/l4route_policy.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -179,46 +178,4 @@ func l4BackendRefWeight(backendRef gatewayv1.BackendRef) int {
 		return 1
 	}
 	return int(*backendRef.Weight)
-}
-
-func l4ServicePortForBackendRef(
-	service corev1.Service,
-	backendRef gatewayv1.BackendRef,
-) (*corev1.ServicePort, error) {
-	if backendRef.BackendObjectReference.Port == nil {
-		return nil, fmt.Errorf("backendRef %s is missing port", backendRef.BackendObjectReference.Name)
-	}
-	for i := range service.Spec.Ports {
-		if service.Spec.Ports[i].Port == *backendRef.BackendObjectReference.Port {
-			return &service.Spec.Ports[i], nil
-		}
-	}
-	return nil, fmt.Errorf(
-		"backendRef service %s has no port %d",
-		backendRef.BackendObjectReference.Name,
-		*backendRef.BackendObjectReference.Port,
-	)
-}
-
-func l4EndpointPortForServicePort(
-	servicePort corev1.ServicePort,
-	endpointSlice discoveryv1.EndpointSlice,
-) (int, bool) {
-	if servicePort.TargetPort.Type == 0 || servicePort.TargetPort.IntVal != 0 {
-		port := servicePort.TargetPort.IntValue()
-		if port == 0 {
-			port = int(servicePort.Port)
-		}
-		return port, true
-	}
-
-	for _, endpointPort := range endpointSlice.Ports {
-		if endpointPort.Port == nil {
-			continue
-		}
-		if endpointPort.Name != nil && *endpointPort.Name == servicePort.Name {
-			return int(*endpointPort.Port), true
-		}
-	}
-	return 0, false
 }

--- a/internal/app/l4route_policy_test.go
+++ b/internal/app/l4route_policy_test.go
@@ -9,11 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -235,67 +232,6 @@ func TestL4RoutePolicy(t *testing.T) {
 		}))
 		assert.Equal(t, 1, l4BackendRefWeight(gatewayv1.BackendRef{}))
 		assert.Equal(t, 5, l4BackendRefWeight(gatewayv1.BackendRef{Weight: new(int32(5))}))
-	})
-
-	t.Run("resolves service backend ports to endpoint target ports", func(t *testing.T) {
-		service := corev1.Service{Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
-			{Name: "rtmp", Port: 1935},
-			{Name: "api", Port: 8443, TargetPort: intstr.FromInt(9443)},
-			{Name: "named", Port: 9000, TargetPort: intstr.FromString("traffic")},
-		}}}
-
-		servicePort, err := l4ServicePortForBackendRef(service, gatewayv1.BackendRef{
-			BackendObjectReference: gatewayv1.BackendObjectReference{
-				Name: "backend",
-				Port: lo.ToPtr(gatewayv1.PortNumber(1935)),
-			},
-		})
-		require.NoError(t, err)
-		port, ok := l4EndpointPortForServicePort(*servicePort, discoveryv1.EndpointSlice{})
-		assert.True(t, ok)
-		assert.Equal(t, 1935, port)
-
-		servicePort, err = l4ServicePortForBackendRef(service, gatewayv1.BackendRef{
-			BackendObjectReference: gatewayv1.BackendObjectReference{
-				Name: "backend",
-				Port: lo.ToPtr(gatewayv1.PortNumber(8443)),
-			},
-		})
-		require.NoError(t, err)
-		port, ok = l4EndpointPortForServicePort(*servicePort, discoveryv1.EndpointSlice{})
-		assert.True(t, ok)
-		assert.Equal(t, 9443, port)
-
-		servicePort, err = l4ServicePortForBackendRef(service, gatewayv1.BackendRef{
-			BackendObjectReference: gatewayv1.BackendObjectReference{
-				Name: "backend",
-				Port: lo.ToPtr(gatewayv1.PortNumber(9000)),
-			},
-		})
-		require.NoError(t, err)
-		port, ok = l4EndpointPortForServicePort(*servicePort, discoveryv1.EndpointSlice{
-			Ports: []discoveryv1.EndpointPort{
-				{Name: new("other"), Port: new(int32(1111))},
-				{Name: new("named"), Port: nil},
-				{Name: new("named"), Port: new(int32(10000))},
-			},
-		})
-		assert.True(t, ok)
-		assert.Equal(t, 10000, port)
-
-		_, err = l4ServicePortForBackendRef(service, gatewayv1.BackendRef{
-			BackendObjectReference: gatewayv1.BackendObjectReference{Name: "backend"},
-		})
-		require.ErrorContains(t, err, "missing port")
-		_, err = l4ServicePortForBackendRef(service, gatewayv1.BackendRef{
-			BackendObjectReference: gatewayv1.BackendObjectReference{
-				Name: "backend",
-				Port: lo.ToPtr(gatewayv1.PortNumber(1234)),
-			},
-		})
-		require.ErrorContains(t, err, "has no port")
-		_, ok = l4EndpointPortForServicePort(*servicePort, discoveryv1.EndpointSlice{})
-		assert.False(t, ok)
 	})
 
 	t.Run("parentRefTargetsGateway applies Gateway API defaults", func(t *testing.T) {

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -1025,15 +1025,7 @@ func (m *ociLoadBalancerModelImpl) reconcileBackendSet(
 	params reconcileBackendSetParams,
 ) error {
 	backendSetName := ociBackendSetNameFromBackendObjectRef(params.routeNS, params.backendRef.BackendObjectReference)
-	healthCheckerPort := int(lo.FromPtr(params.backendRef.BackendObjectReference.Port))
-	if healthCheckerPort == 0 && len(params.service.Spec.Ports) > 0 {
-		healthCheckerPort = params.service.Spec.Ports[0].TargetPort.IntValue()
-	}
-	if healthCheckerPort == 0 {
-		// Not the best option. Potentially have to be refactored to use
-		// port from the backend ref. Some research is needed.
-		healthCheckerPort = int(params.service.Spec.Ports[0].Port)
-	}
+	healthCheckerPort := healthCheckerPortForBackendRef(params.service, params.backendRef)
 	desiredPolicy := "ROUND_ROBIN"
 	desiredHealthChecker := loadBalancerBackendSetHealthChecker(healthCheckerPort)
 
@@ -1087,6 +1079,27 @@ func (m *ociLoadBalancerModelImpl) reconcileBackendSet(
 	}
 
 	return nil
+}
+
+func healthCheckerPortForBackendRef(
+	service corev1.Service,
+	backendRef gatewayv1.BackendRef,
+) int {
+	servicePort, err := servicePortForBackendRef(service, backendRef)
+	if err == nil {
+		if targetPort := servicePort.TargetPort.IntValue(); targetPort != 0 {
+			return targetPort
+		}
+		return int(servicePort.Port)
+	}
+
+	if len(service.Spec.Ports) == 0 {
+		return 0
+	}
+	if targetPort := service.Spec.Ports[0].TargetPort.IntValue(); targetPort != 0 {
+		return targetPort
+	}
+	return int(service.Spec.Ports[0].Port)
 }
 
 func (m *ociLoadBalancerModelImpl) deprovisionBackendSet(

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -1987,7 +1987,11 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 						assert.Equal(t, wantBsName, *req.BackendSetName) &&
 						assert.Equal(t, "ROUND_ROBIN", *req.Policy) &&
 						assert.Equal(t, "TCP", *req.HealthChecker.Protocol) &&
-						assert.Equal(t, healthCheckerPortForBackendRef(params.service, params.backendRef), *req.HealthChecker.Port)
+						assert.Equal(
+							t,
+							healthCheckerPortForBackendRef(params.service, params.backendRef),
+							*req.HealthChecker.Port,
+						)
 				}),
 			).Return(loadbalancer.UpdateBackendSetResponse{
 				OpcWorkRequestId: &workRequestID,
@@ -2036,7 +2040,11 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				t.Context(),
 				mock.MatchedBy(func(req loadbalancer.UpdateBackendSetRequest) bool {
 					return assert.Equal(t, "TCP", lo.FromPtr(req.HealthChecker.Protocol)) &&
-						assert.Equal(t, healthCheckerPortForBackendRef(params.service, params.backendRef), lo.FromPtr(req.HealthChecker.Port)) &&
+						assert.Equal(
+							t,
+							healthCheckerPortForBackendRef(params.service, params.backendRef),
+							lo.FromPtr(req.HealthChecker.Port),
+						) &&
 						assert.Equal(t, verifyDepth, lo.FromPtr(req.SslConfiguration.VerifyDepth))
 				}),
 			).Return(loadbalancer.UpdateBackendSetResponse{

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -1792,7 +1792,29 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 	})
 
 	t.Run("reconcileBackendSet", func(t *testing.T) {
+		t.Run("resolves health checker port from backend target port", func(t *testing.T) {
+			service := makeRandomService()
+			servicePort := service.Spec.Ports[0].Port
+			targetPort := servicePort%65535 + 1
+			service.Spec.Ports[0].TargetPort = intstr.FromInt(int(targetPort))
+			backendRef := gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: gatewayv1.ObjectName(service.Name),
+				Port: &servicePort,
+			}}
+
+			assert.Equal(t, int(targetPort), healthCheckerPortForBackendRef(service, backendRef))
+
+			service.Spec.Ports[0].TargetPort = intstr.FromInt(0)
+			assert.Equal(t, int(servicePort), healthCheckerPortForBackendRef(service, backendRef))
+
+			backendRef.Port = nil
+			service.Spec.Ports[0].TargetPort = intstr.FromInt(int(targetPort))
+			assert.Equal(t, int(targetPort), healthCheckerPortForBackendRef(service, backendRef))
+			assert.Equal(t, 0, healthCheckerPortForBackendRef(corev1.Service{}, gatewayv1.BackendRef{}))
+		})
+
 		makeParams := func(service corev1.Service, loadBalancerID string) reconcileBackendSetParams {
+			service.Spec.Ports[0].TargetPort = intstr.FromInt(int(service.Spec.Ports[0].Port))
 			namespace := gatewayv1.Namespace(service.Namespace)
 			return reconcileBackendSetParams{
 				loadBalancerID: loadBalancerID,
@@ -1814,13 +1836,16 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			)
 		}
 
-		t.Run("create new backend set", func(t *testing.T) {
+		t.Run("create new backend set uses service target port", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
 			service := makeRandomService()
 
 			params := makeParams(service, fake.UUID().V4())
+			params.service.Spec.Ports[0].TargetPort = intstr.FromInt(
+				int(params.service.Spec.Ports[0].Port%65535 + 1),
+			)
 
 			wantBsName := backendSetNameFromParams(params)
 
@@ -1843,7 +1868,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					Name: &wantBsName,
 					HealthChecker: &loadbalancer.HealthCheckerDetails{
 						Protocol: new("TCP"),
-						Port:     new(int(lo.FromPtr(params.backendRef.Port))),
+						Port:     new(healthCheckerPortForBackendRef(params.service, params.backendRef)),
 					},
 					Policy: new("ROUND_ROBIN"),
 				},
@@ -1917,7 +1942,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				bs.Policy = new("ROUND_ROBIN")
 				bs.HealthChecker = &loadbalancer.HealthChecker{
 					Protocol: new("TCP"),
-					Port:     new(int(lo.FromPtr(params.backendRef.Port))),
+					Port:     new(healthCheckerPortForBackendRef(params.service, params.backendRef)),
 				}
 			})
 
@@ -1962,7 +1987,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 						assert.Equal(t, wantBsName, *req.BackendSetName) &&
 						assert.Equal(t, "ROUND_ROBIN", *req.Policy) &&
 						assert.Equal(t, "TCP", *req.HealthChecker.Protocol) &&
-						assert.Equal(t, int(lo.FromPtr(params.backendRef.Port)), *req.HealthChecker.Port)
+						assert.Equal(t, healthCheckerPortForBackendRef(params.service, params.backendRef), *req.HealthChecker.Port)
 				}),
 			).Return(loadbalancer.UpdateBackendSetResponse{
 				OpcWorkRequestId: &workRequestID,
@@ -1992,7 +2017,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				bs.Policy = new("ROUND_ROBIN")
 				bs.HealthChecker = &loadbalancer.HealthChecker{
 					Protocol: new("TCP"),
-					Port:     new(int(lo.FromPtr(params.backendRef.Port))),
+					Port:     new(healthCheckerPortForBackendRef(params.service, params.backendRef)),
 				}
 				bs.SslConfiguration = nil
 			})
@@ -2011,7 +2036,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				t.Context(),
 				mock.MatchedBy(func(req loadbalancer.UpdateBackendSetRequest) bool {
 					return assert.Equal(t, "TCP", lo.FromPtr(req.HealthChecker.Protocol)) &&
-						assert.Equal(t, int(lo.FromPtr(params.backendRef.Port)), lo.FromPtr(req.HealthChecker.Port)) &&
+						assert.Equal(t, healthCheckerPortForBackendRef(params.service, params.backendRef), lo.FromPtr(req.HealthChecker.Port)) &&
 						assert.Equal(t, verifyDepth, lo.FromPtr(req.SslConfiguration.VerifyDepth))
 				}),
 			).Return(loadbalancer.UpdateBackendSetResponse{
@@ -2086,7 +2111,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					Name: &wantBsName,
 					HealthChecker: &loadbalancer.HealthCheckerDetails{
 						Protocol: new("TCP"),
-						Port:     new(int(lo.FromPtr(params.backendRef.Port))),
+						Port:     new(healthCheckerPortForBackendRef(params.service, params.backendRef)),
 					},
 					Policy: new("ROUND_ROBIN"),
 				},
@@ -2119,7 +2144,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					Name: &wantBsName,
 					HealthChecker: &loadbalancer.HealthCheckerDetails{
 						Protocol: new("TCP"),
-						Port:     new(int(lo.FromPtr(params.backendRef.Port))),
+						Port:     new(healthCheckerPortForBackendRef(params.service, params.backendRef)),
 					},
 					Policy: new("ROUND_ROBIN"),
 				},
@@ -2155,7 +2180,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					Name: &wantBsName,
 					HealthChecker: &loadbalancer.HealthCheckerDetails{
 						Protocol: new("TCP"),
-						Port:     new(int(lo.FromPtr(params.backendRef.Port))),
+						Port:     new(healthCheckerPortForBackendRef(params.service, params.backendRef)),
 					},
 					Policy: new("ROUND_ROBIN"),
 				},

--- a/internal/app/tcproute_model.go
+++ b/internal/app/tcproute_model.go
@@ -483,7 +483,7 @@ func resolveL4BackendRefServicePort(
 		return apitypes.NamespacedName{}, nil, fmt.Errorf("failed to get service %s: %w", fullName.String(), getErr)
 	}
 
-	servicePort, err := l4ServicePortForBackendRef(service, backendRef)
+	servicePort, err := servicePortForBackendRef(service, backendRef)
 	if err != nil {
 		return apitypes.NamespacedName{}, nil, statusErr(
 			gatewayv1.RouteReasonInvalidKind,
@@ -500,7 +500,7 @@ func endpointBackendsForSlices(
 ) []networkloadbalancer.BackendDetails {
 	backends := make([]networkloadbalancer.BackendDetails, 0)
 	for _, slice := range endpointSlices {
-		port, ok := l4EndpointPortForServicePort(servicePort, slice)
+		port, ok := endpointPortForServicePort(servicePort, slice)
 		if !ok {
 			continue
 		}

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -834,7 +834,7 @@ func (m *tlsRouteModelImpl) backendRefHealthCheckPort(
 		return 0, fmt.Errorf("failed to list endpoint slices for backend %s: %w", fullName.String(), err)
 	}
 	for _, slice := range endpointSlices.Items {
-		if port, ok := l4EndpointPortForServicePort(*servicePort, slice); ok {
+		if port, ok := endpointPortForServicePort(*servicePort, slice); ok {
 			return port, nil
 		}
 	}


### PR DESCRIPTION
Resolve L7 backend references through the matching Kubernetes ServicePort.
Resolve numeric and named target ports per EndpointSlice for HTTP/GRPC backends.
Refactor shared port resolvers and improve focused randomized test coverage.