### PR TITLE
Fix shared load balancer cleanup ownership

### DIFF
--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -19,6 +19,15 @@ const (
 	// GatewayProgrammedCertificatesAnnotation stores OCI certificate names programmed by the controller.
 	GatewayProgrammedCertificatesAnnotation = "oke-gateway-api.gemyago.github.io/gateway-programmed-certificates"
 
+	// LoadBalancerGatewayProgrammedListenersAnnotation tracks ALB listeners programmed by a Gateway.
+	LoadBalancerGatewayProgrammedListenersAnnotation = "oke-gateway-api.gemyago.github.io/alb-gateway-listeners"
+
+	// LoadBalancerGatewayProgrammedFinalizer indicates the Gateway has provisioned OCI ALB resources.
+	LoadBalancerGatewayProgrammedFinalizer = "oke-gateway-api.gemyago.github.io/alb-gateway-programmed"
+
+	// LoadBalancerGatewayIDAnnotation stores the OCI Load Balancer OCID programmed by the controller.
+	LoadBalancerGatewayIDAnnotation = "oke-gateway-api.gemyago.github.io/alb-id"
+
 	// GatewayFrontendMTLSConfigMapsAnnotation stores frontend mTLS CA ConfigMap revisions.
 	GatewayFrontendMTLSConfigMapsAnnotation = "frontend-mtls-configmaps.oke-gateway-api.gemyago.github.io"
 
@@ -113,13 +122,21 @@ const (
 
 	// NetworkLoadBalancerGatewayProgrammingRevisionValue is the value for the L4 gateway programming revision.
 	// Incremented when the NLB controller programming steps are changed.
-	NetworkLoadBalancerGatewayProgrammingRevisionValue = "1"
+	NetworkLoadBalancerGatewayProgrammingRevisionValue = "2"
 
 	// NetworkLoadBalancerGatewayProgrammedFinalizer indicates the L4 Gateway has provisioned OCI NLB resources.
 	NetworkLoadBalancerGatewayProgrammedFinalizer = "oke-gateway-api.gemyago.github.io/nlb-gateway-programmed"
 
 	// NetworkLoadBalancerGatewayIDAnnotation stores the OCI NLB OCID programmed by the controller.
 	NetworkLoadBalancerGatewayIDAnnotation = "oke-gateway-api.gemyago.github.io/nlb-id"
+
+	// NetworkLoadBalancerGatewayProgrammedListenersAnnotation tracks NLB listeners programmed by a Gateway.
+	NetworkLoadBalancerGatewayProgrammedListenersAnnotation = "oke-gateway-api.gemyago.github.io/" +
+		"nlb-gateway-listeners"
+
+	// NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation tracks NLB backend sets programmed by a Gateway.
+	NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation = "oke-gateway-api.gemyago.github.io/" +
+		"nlb-gateway-backendsets"
 
 	// L4RouteProgrammedNetworkLoadBalancerIDAnnotation tracks the OCI Network Load Balancer used by L4 routes.
 	L4RouteProgrammedNetworkLoadBalancerIDAnnotation = "oke-gateway-api.gemyago.github.io/" +

--- a/internal/app/gateway_controller.go
+++ b/internal/app/gateway_controller.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/dig"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -104,6 +105,16 @@ func (r *GatewayController) Reconcile(ctx context.Context, req reconcile.Request
 		slog.String("resourceVersion", data.gateway.ResourceVersion),
 		slog.Int64("generation", data.gateway.Generation),
 	)
+
+	if data.gateway.DeletionTimestamp != nil {
+		if !controllerutil.ContainsFinalizer(&data.gateway, LoadBalancerGatewayProgrammedFinalizer) {
+			return reconcile.Result{}, nil
+		}
+		if err = r.gatewayModel.deprovisionGateway(ctx, &data); err != nil {
+			return r.processResourceError(ctx, err, &data.gateway)
+		}
+		return reconcile.Result{}, nil
+	}
 
 	if !isGatewayAccepted(&data.gateway) {
 		if err = r.resourcesModel.setCondition(ctx, setConditionParams{

--- a/internal/app/gateway_controller.go
+++ b/internal/app/gateway_controller.go
@@ -147,6 +147,27 @@ func (r *GatewayController) Reconcile(ctx context.Context, req reconcile.Request
 			slog.String("loadBalancerID", data.config.Spec.LoadBalancerID),
 		)
 
+		if err = r.resourcesModel.setCondition(ctx, setConditionParams{
+			resource:      &data.gateway,
+			conditions:    &data.gateway.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayConditionProgrammed),
+			status:        v1.ConditionUnknown,
+			reason:        string(gatewayv1.GatewayReasonPending),
+			message: fmt.Sprintf(
+				"Gateway %s programming by %s is in progress",
+				data.gateway.Name,
+				ControllerClassName,
+			),
+			annotations: loadBalancerGatewayProtectionAnnotations(&data),
+			finalizer:   LoadBalancerGatewayProgrammedFinalizer,
+		}); err != nil {
+			return reconcile.Result{}, fmt.Errorf(
+				"failed to persist programming protection for Gateway %s: %w",
+				req.NamespacedName,
+				err,
+			)
+		}
+
 		if err = r.gatewayModel.programGateway(ctx, &data); err != nil {
 			return r.processResourceError(ctx, err, &data.gateway)
 		}
@@ -171,4 +192,17 @@ func (r *GatewayController) Reconcile(ctx context.Context, req reconcile.Request
 	}
 
 	return driftRequeue(r.driftInterval), nil
+}
+
+func loadBalancerGatewayProtectionAnnotations(data *resolvedGatewayDetails) map[string]string {
+	loadBalancerID := data.config.Spec.LoadBalancerID
+	if loadBalancerID == "" {
+		loadBalancerID = data.gateway.Annotations[LoadBalancerGatewayIDAnnotation]
+	}
+	if loadBalancerID == "" {
+		return nil
+	}
+	return map[string]string{
+		LoadBalancerGatewayIDAnnotation: loadBalancerID,
+	}
 }

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -44,6 +44,22 @@ func TestGatewayController(t *testing.T) {
 			LastTransitionTime: metav1.Now(),
 		})
 	}
+	expectGatewayProgrammingProtection := func(
+		mockResourcesModel *MockresourcesModel,
+		gateway *gatewayv1.Gateway,
+		annotations map[string]string,
+	) {
+		mockResourcesModel.EXPECT().
+			setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+				return params.resource.GetName() == gateway.Name &&
+					params.conditionType == string(gatewayv1.GatewayConditionProgrammed) &&
+					params.status == metav1.ConditionUnknown &&
+					params.reason == string(gatewayv1.GatewayReasonPending) &&
+					params.finalizer == LoadBalancerGatewayProgrammedFinalizer &&
+					assert.Equal(t, annotations, params.annotations)
+			})).
+			Return(nil).Once()
+	}
 
 	t.Run("SetListenerSetEnabled", func(t *testing.T) {
 		model := &gatewayModelImpl{}
@@ -103,6 +119,8 @@ func TestGatewayController(t *testing.T) {
 				}).
 				Return(false).Once()
 
+			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
+
 			mockGatewayModel.EXPECT().
 				programGateway(t.Context(), &resolvedGatewayDetails{
 					gateway: *gateway,
@@ -113,6 +131,63 @@ func TestGatewayController(t *testing.T) {
 				setProgrammed(t.Context(), &resolvedGatewayDetails{
 					gateway: *gateway,
 				}).
+				Return(nil).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("persists finalizer and load balancer identity before programming gateway", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: gateway.Namespace,
+					Name:      gateway.Name,
+				},
+			}
+
+			deps := newMockDeps(t)
+			controller := NewGatewayController(deps)
+
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			expectedData := &resolvedGatewayDetails{
+				gateway: *gateway,
+				config: types.GatewayConfig{
+					Spec: types.GatewayConfigSpec{
+						LoadBalancerID: loadBalancerID,
+					},
+				},
+			}
+
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					*receiver = *expectedData
+					return true
+				})).
+				Return(true, nil).Once()
+			mockGatewayModel.EXPECT().
+				isProgrammed(t.Context(), expectedData).
+				Return(false).Once()
+			mockResourcesModel.EXPECT().
+				setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+					return params.resource.GetName() == gateway.Name &&
+						params.conditionType == string(gatewayv1.GatewayConditionProgrammed) &&
+						params.finalizer == LoadBalancerGatewayProgrammedFinalizer &&
+						params.annotations[LoadBalancerGatewayIDAnnotation] == loadBalancerID
+				})).
+				Return(nil).Once()
+			mockGatewayModel.EXPECT().
+				programGateway(t.Context(), expectedData).
+				Return(nil).Once()
+			mockGatewayModel.EXPECT().
+				setProgrammed(t.Context(), expectedData).
 				Return(nil).Once()
 
 			result, err := controller.Reconcile(t.Context(), req)
@@ -414,6 +489,7 @@ func TestGatewayController(t *testing.T) {
 			deps := newMockDeps(t)
 			controller := NewGatewayController(deps)
 
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
 
 			mockGatewayModel.EXPECT().
@@ -430,6 +506,8 @@ func TestGatewayController(t *testing.T) {
 				Return(false).Once()
 
 			wantErr := errors.New(fake.Lorem().Sentence(10))
+
+			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
 
 			mockGatewayModel.EXPECT().
 				programGateway(t.Context(), mock.Anything).
@@ -479,6 +557,8 @@ func TestGatewayController(t *testing.T) {
 				reason:        fake.Lorem().Word(),
 				message:       fake.Lorem().Sentence(10),
 			}
+
+			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
 
 			mockGatewayModel.EXPECT().
 				programGateway(t.Context(), mock.Anything).
@@ -540,6 +620,8 @@ func TestGatewayController(t *testing.T) {
 				message:       fake.Lorem().Sentence(10),
 			}
 
+			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
+
 			mockGatewayModel.EXPECT().
 				programGateway(t.Context(), mock.Anything).
 				Return(wantErr).Once()
@@ -576,6 +658,7 @@ func TestGatewayController(t *testing.T) {
 			deps := newMockDeps(t)
 			controller := NewGatewayController(deps)
 
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
 
 			mockGatewayModel.EXPECT().
@@ -592,6 +675,8 @@ func TestGatewayController(t *testing.T) {
 				Return(false).Once()
 
 			wantErr := errors.New(fake.Lorem().Sentence(10))
+
+			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
 
 			mockGatewayModel.EXPECT().
 				programGateway(t.Context(), mock.Anything).
@@ -661,6 +746,7 @@ func TestGatewayController(t *testing.T) {
 			deps.DriftInterval = driftInterval
 			controller := NewGatewayController(deps)
 
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
 
 			mockGatewayModel.EXPECT().
@@ -675,6 +761,8 @@ func TestGatewayController(t *testing.T) {
 					gateway: *gateway,
 				}).
 				Return(true).Once()
+
+			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
 
 			mockGatewayModel.EXPECT().
 				programGateway(t.Context(), &resolvedGatewayDetails{

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -199,6 +199,124 @@ func TestGatewayController(t *testing.T) {
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 
+		t.Run("ignores deleting gateway without programmed finalizer", func(t *testing.T) {
+			gateway := newRandomGateway()
+			deletionTime := metav1.Now()
+			gateway.DeletionTimestamp = &deletionTime
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(gateway)}
+			deps := newMockDeps(t)
+			controller := NewGatewayController(deps)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("deprovisions deleting gateway with programmed finalizer", func(t *testing.T) {
+			gateway := newRandomGateway()
+			deletionTime := metav1.Now()
+			gateway.DeletionTimestamp = &deletionTime
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(gateway)}
+			deps := newMockDeps(t)
+			controller := NewGatewayController(deps)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			expectedData := &resolvedGatewayDetails{gateway: *gateway}
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).Once()
+			mockGatewayModel.EXPECT().
+				deprovisionGateway(t.Context(), expectedData).
+				Return(nil).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("handles deleting gateway deprovision status errors", func(t *testing.T) {
+			fake := faker.New()
+			gateway := newRandomGateway()
+			deletionTime := metav1.Now()
+			gateway.DeletionTimestamp = &deletionTime
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(gateway)}
+			deps := newMockDeps(t)
+			controller := NewGatewayController(deps)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			wantErr := &resourceStatusError{
+				conditionType: string(gatewayv1.GatewayConditionProgrammed),
+				reason:        fake.Lorem().Word(),
+				message:       fake.Lorem().Sentence(10),
+			}
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).Once()
+			mockGatewayModel.EXPECT().
+				deprovisionGateway(t.Context(), &resolvedGatewayDetails{gateway: *gateway}).
+				Return(wantErr).Once()
+			mockResourcesModel.EXPECT().
+				setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+					gotGateway, ok := params.resource.(*gatewayv1.Gateway)
+					return ok &&
+						gotGateway.Namespace == gateway.Namespace &&
+						gotGateway.Name == gateway.Name &&
+						params.conditionType == wantErr.conditionType &&
+						params.reason == wantErr.reason &&
+						params.message == wantErr.message
+				})).
+				Return(nil).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("returns deleting gateway deprovision regular errors", func(t *testing.T) {
+			fake := faker.New()
+			gateway := newRandomGateway()
+			deletionTime := metav1.Now()
+			gateway.DeletionTimestamp = &deletionTime
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(gateway)}
+			deps := newMockDeps(t)
+			controller := NewGatewayController(deps)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).Once()
+			mockGatewayModel.EXPECT().
+				deprovisionGateway(t.Context(), &resolvedGatewayDetails{gateway: *gateway}).
+				Return(wantErr).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to program Gateway")
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
 		t.Run("returns error when accepted condition update fails", func(t *testing.T) {
 			gateway := newRandomGateway()
 
@@ -627,6 +745,7 @@ func TestGatewayController(t *testing.T) {
 				},
 			}
 			gateway.Annotations = map[string]string{
+				LoadBalancerGatewayIDAnnotation:                              loadBalancerID,
 				GatewayProgrammingRevisionAnnotation:                         GatewayProgrammingRevisionValue,
 				GatewayUsedSecretsAnnotationPrefix + "/" + string(secretUID): secretResourceVersion,
 				GatewayProgrammedCertificatesAnnotation: fmt.Sprintf(
@@ -635,7 +754,9 @@ func TestGatewayController(t *testing.T) {
 					secretName,
 					secretResourceVersion,
 				),
+				LoadBalancerGatewayProgrammedListenersAnnotation: "https",
 			}
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
 
 			gatewayClass := newRandomGatewayClass(
 				randomGatewayClassWithControllerNameOpt(ControllerClassName),

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -801,15 +801,16 @@ func (m *gatewayModelImpl) deprovisionGatewayLoadBalancerResources(
 	}
 
 	data.loadBalancer = &response.LoadBalancer
+	cleanupListenerNames := gatewayCleanupListenerNames(
+		data.gateway,
+		gatewayManagedOCIListenersForLoadBalancer(data),
+	)
 	if err = m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
 		loadBalancerID:       loadBalancerID,
 		knownListeners:       response.LoadBalancer.Listeners,
 		knownRoutingPolicies: response.LoadBalancer.RoutingPolicies,
-		cleanupListenerNames: gatewayCleanupListenerNames(
-			data.gateway,
-			gatewayManagedOCIListenersForLoadBalancer(data),
-		),
-		gatewayListeners: nil,
+		cleanupListenerNames: cleanupListenerNames,
+		gatewayListeners:     nil,
 	}); err != nil {
 		return fmt.Errorf("failed to remove Gateway listeners: %w", err)
 	}
@@ -819,8 +820,11 @@ func (m *gatewayModelImpl) deprovisionGatewayLoadBalancerResources(
 		previouslyProgrammedCertificates: parseProgrammedGatewayCertificatesAnnotation(
 			data.gateway.Annotations[GatewayProgrammedCertificatesAnnotation],
 		),
-		desiredCertificates: nil,
-		knownCertificates:   response.LoadBalancer.Certificates,
+		desiredCertificates: loadBalancerListenerCertificatesOutsideCleanup(
+			response.LoadBalancer,
+			cleanupListenerNames,
+		),
+		knownCertificates: response.LoadBalancer.Certificates,
 	}); err != nil {
 		return fmt.Errorf("failed to remove Gateway certificates: %w", err)
 	}
@@ -849,6 +853,26 @@ func gatewayCleanupListenerNames(gateway gatewayv1.Gateway, desiredListeners []g
 		annotatedResourceNames(gateway, LoadBalancerGatewayProgrammedListenersAnnotation),
 		listenerNamesSet(desiredListeners),
 	)
+}
+
+func loadBalancerListenerCertificatesOutsideCleanup(
+	loadBalancer loadbalancer.LoadBalancer,
+	cleanupListenerNames map[string]struct{},
+) []string {
+	certNames := map[string]struct{}{}
+	for listenerName, listener := range loadBalancer.Listeners {
+		if _, cleanup := cleanupListenerNames[listenerName]; cleanup {
+			continue
+		}
+		if listener.SslConfiguration == nil || listener.SslConfiguration.CertificateName == nil {
+			continue
+		}
+		certNames[*listener.SslConfiguration.CertificateName] = struct{}{}
+	}
+
+	names := lo.Keys(certNames)
+	sort.Strings(names)
+	return names
 }
 
 func listenerNamesSet(listeners []gatewayv1.Listener) map[string]struct{} {

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -805,8 +805,11 @@ func (m *gatewayModelImpl) deprovisionGatewayLoadBalancerResources(
 		loadBalancerID:       loadBalancerID,
 		knownListeners:       response.LoadBalancer.Listeners,
 		knownRoutingPolicies: response.LoadBalancer.RoutingPolicies,
-		cleanupListenerNames: gatewayCleanupListenerNames(data.gateway, nil),
-		gatewayListeners:     nil,
+		cleanupListenerNames: gatewayCleanupListenerNames(
+			data.gateway,
+			gatewayManagedOCIListenersForLoadBalancer(data),
+		),
+		gatewayListeners: nil,
 	}); err != nil {
 		return fmt.Errorf("failed to remove Gateway listeners: %w", err)
 	}

--- a/internal/app/gateway_model.go
+++ b/internal/app/gateway_model.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -124,6 +125,8 @@ type gatewayModel interface {
 
 	programGateway(ctx context.Context, data *resolvedGatewayDetails) error
 
+	deprovisionGateway(ctx context.Context, data *resolvedGatewayDetails) error
+
 	isProgrammed(ctx context.Context, data *resolvedGatewayDetails) bool
 
 	setProgrammed(ctx context.Context, data *resolvedGatewayDetails) error
@@ -173,7 +176,47 @@ func (m *gatewayModelImpl) resolveReconcileRequest(
 		return false, nil
 	}
 
+	configResolved, configErr := m.resolveGatewayConfig(ctx, receiver)
+	if configErr != nil || !configResolved {
+		return false, configErr
+	}
+
+	if m.listenerSetEnabled {
+		if err := populateAttachedListenerSets(ctx, m.client, receiver); err != nil {
+			return false, err
+		}
+	}
+
+	if receiver.gateway.DeletionTimestamp != nil &&
+		controllerutil.ContainsFinalizer(&receiver.gateway, LoadBalancerGatewayProgrammedFinalizer) {
+		return true, nil
+	}
+
+	if err := validateGatewayCertificateOptions(receiver.gateway); err != nil {
+		return false, err
+	}
+
+	if err := m.populateGatewaySecrets(ctx, receiver); err != nil {
+		return false, err
+	}
+	if err := m.populateGatewayFrontendMTLSDependencies(ctx, receiver); err != nil {
+		return false, err
+	}
+
+	// TODO: Make sure config is complete
+
+	return true, nil
+}
+
+func (m *gatewayModelImpl) resolveGatewayConfig(
+	ctx context.Context,
+	receiver *resolvedGatewayDetails,
+) (bool, error) {
 	if receiver.gateway.Spec.Infrastructure == nil || receiver.gateway.Spec.Infrastructure.ParametersRef == nil {
+		if loadBalancerGatewayCanFinalizeWithoutConfig(receiver.gateway) {
+			receiver.config.Spec.LoadBalancerID = receiver.gateway.Annotations[LoadBalancerGatewayIDAnnotation]
+			return true, nil
+		}
 		return false, &resourceStatusError{
 			conditionType: string(gatewayv1.GatewayConditionAccepted),
 			reason:        string(gatewayv1.GatewayReasonInvalidParameters),
@@ -188,6 +231,10 @@ func (m *gatewayModelImpl) resolveReconcileRequest(
 
 	if err := m.client.Get(ctx, configName, &receiver.config); err != nil {
 		if apierrors.IsNotFound(err) {
+			if loadBalancerGatewayCanFinalizeWithoutConfig(receiver.gateway) {
+				receiver.config.Spec.LoadBalancerID = receiver.gateway.Annotations[LoadBalancerGatewayIDAnnotation]
+				return true, nil
+			}
 			return false, &resourceStatusError{
 				conditionType: string(gatewayv1.GatewayConditionAccepted),
 				reason:        string(gatewayv1.GatewayReasonInvalidParameters),
@@ -196,26 +243,13 @@ func (m *gatewayModelImpl) resolveReconcileRequest(
 		}
 		return false, fmt.Errorf("failed to get GatewayConfig %s: %w", configName, err)
 	}
-
-	if err := validateGatewayCertificateOptions(receiver.gateway); err != nil {
-		return false, err
-	}
-
-	if m.listenerSetEnabled {
-		if err := populateAttachedListenerSets(ctx, m.client, receiver); err != nil {
-			return false, err
-		}
-	}
-	if err := m.populateGatewaySecrets(ctx, receiver); err != nil {
-		return false, err
-	}
-	if err := m.populateGatewayFrontendMTLSDependencies(ctx, receiver); err != nil {
-		return false, err
-	}
-
-	// TODO: Make sure config is complete
-
 	return true, nil
+}
+
+func loadBalancerGatewayCanFinalizeWithoutConfig(gateway gatewayv1.Gateway) bool {
+	return gateway.DeletionTimestamp != nil &&
+		controllerutil.ContainsFinalizer(&gateway, LoadBalancerGatewayProgrammedFinalizer) &&
+		gateway.Annotations[LoadBalancerGatewayIDAnnotation] != ""
 }
 
 func (m *gatewayModelImpl) populateGatewayFrontendMTLSDependencies(
@@ -571,6 +605,15 @@ func programmedGatewayCertificatesAnnotation(certNames []string) string {
 	return strings.Join(normalizeProgrammedCertificateNames(certNames), ",")
 }
 
+func programmedGatewayListenersAnnotation(listeners []gatewayv1.Listener) string {
+	listenerNames := make([]string, 0, len(listeners))
+	for _, listener := range listeners {
+		listenerNames = append(listenerNames, string(listener.Name))
+	}
+	sort.Strings(listenerNames)
+	return strings.Join(listenerNames, ",")
+}
+
 func parseProgrammedGatewayCertificatesAnnotation(annotationValue string) []string {
 	if annotationValue == "" {
 		return nil
@@ -670,7 +713,13 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 		}
 	}
 
-	if err = m.removeMissingGatewayListeners(ctx, loadBalancerID, response.LoadBalancer, gatewayListeners); err != nil {
+	if err = m.removeMissingGatewayListeners(
+		ctx,
+		data,
+		gatewayManagedListeners,
+		response.LoadBalancer,
+		gatewayListeners,
+	); err != nil {
 		return err
 	}
 
@@ -692,6 +741,123 @@ func (m *gatewayModelImpl) programGateway(ctx context.Context, data *resolvedGat
 	}
 
 	return nil
+}
+
+func (m *gatewayModelImpl) deprovisionGateway(ctx context.Context, data *resolvedGatewayDetails) error {
+	loadBalancerID := data.config.Spec.LoadBalancerID
+	if loadBalancerID == "" {
+		loadBalancerID = data.gateway.Annotations[LoadBalancerGatewayIDAnnotation]
+	}
+	if loadBalancerID != "" {
+		if err := m.deprovisionGatewayLoadBalancerResources(ctx, data, loadBalancerID); err != nil {
+			return err
+		}
+	}
+
+	gatewayToUpdate := data.gateway.DeepCopy()
+	controllerutil.RemoveFinalizer(gatewayToUpdate, LoadBalancerGatewayProgrammedFinalizer)
+	annotations := gatewayToUpdate.GetAnnotations()
+	delete(annotations, LoadBalancerGatewayIDAnnotation)
+	delete(annotations, GatewayProgrammingRevisionAnnotation)
+	delete(annotations, GatewayProgrammedCertificatesAnnotation)
+	delete(annotations, LoadBalancerGatewayProgrammedListenersAnnotation)
+	delete(annotations, GatewayFrontendMTLSCABundleCompartmentsAnnotation)
+	for key := range annotations {
+		if strings.HasPrefix(key, GatewayUsedSecretsAnnotationPrefix+"/") {
+			delete(annotations, key)
+		}
+	}
+	gatewayToUpdate.SetAnnotations(annotations)
+	if updateErr := m.client.Update(ctx, gatewayToUpdate); updateErr != nil {
+		if apierrors.IsNotFound(updateErr) {
+			m.logger.InfoContext(ctx, "Gateway already deleted while removing finalizer",
+				slog.String("gateway", client.ObjectKeyFromObject(gatewayToUpdate).String()),
+			)
+			return nil
+		}
+		return fmt.Errorf("failed to remove finalizer from Gateway %s/%s: %w",
+			gatewayToUpdate.Namespace,
+			gatewayToUpdate.Name,
+			updateErr,
+		)
+	}
+	return nil
+}
+
+func (m *gatewayModelImpl) deprovisionGatewayLoadBalancerResources(
+	ctx context.Context,
+	data *resolvedGatewayDetails,
+	loadBalancerID string,
+) error {
+	response, err := m.ociClient.GetLoadBalancer(ctx, loadbalancer.GetLoadBalancerRequest{
+		LoadBalancerId: &loadBalancerID,
+	})
+	if err != nil {
+		if serviceErr, ok := common.IsServiceError(err); ok &&
+			serviceErr.GetHTTPStatusCode() == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("failed to get OCI Load Balancer %s for Gateway deprovision: %w", loadBalancerID, err)
+	}
+
+	data.loadBalancer = &response.LoadBalancer
+	if err = m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
+		loadBalancerID:       loadBalancerID,
+		knownListeners:       response.LoadBalancer.Listeners,
+		knownRoutingPolicies: response.LoadBalancer.RoutingPolicies,
+		cleanupListenerNames: gatewayCleanupListenerNames(data.gateway, nil),
+		gatewayListeners:     nil,
+	}); err != nil {
+		return fmt.Errorf("failed to remove Gateway listeners: %w", err)
+	}
+
+	if err = m.ociLoadBalancerModel.removeUnusedCertificates(ctx, removeUnusedCertificatesParams{
+		loadBalancerID: loadBalancerID,
+		previouslyProgrammedCertificates: parseProgrammedGatewayCertificatesAnnotation(
+			data.gateway.Annotations[GatewayProgrammedCertificatesAnnotation],
+		),
+		desiredCertificates: nil,
+		knownCertificates:   response.LoadBalancer.Certificates,
+	}); err != nil {
+		return fmt.Errorf("failed to remove Gateway certificates: %w", err)
+	}
+
+	if err = m.ociLoadBalancerModel.cleanupFrontendMTLSCABundles(ctx, cleanupFrontendMTLSCABundlesParams{
+		gateway:            &data.gateway,
+		compartmentID:      lo.FromPtr(response.LoadBalancer.CompartmentId),
+		desiredBundleNames: map[string]struct{}{},
+	}); err != nil {
+		return fmt.Errorf("failed to clean up frontend mTLS CA bundles: %w", err)
+	}
+
+	if err = m.ociLoadBalancerModel.deprovisionBackendSetByName(
+		ctx,
+		loadBalancerID,
+		gatewayDefaultBackendSetName(data.gateway),
+	); err != nil {
+		return fmt.Errorf("failed to remove Gateway default backend set: %w", err)
+	}
+
+	return nil
+}
+
+func gatewayCleanupListenerNames(gateway gatewayv1.Gateway, desiredListeners []gatewayv1.Listener) map[string]struct{} {
+	return mergeNameSets(
+		annotatedResourceNames(gateway, LoadBalancerGatewayProgrammedListenersAnnotation),
+		listenerNamesSet(desiredListeners),
+	)
+}
+
+func listenerNamesSet(listeners []gatewayv1.Listener) map[string]struct{} {
+	listenerNames := make(map[string]struct{}, len(listeners))
+	for _, listener := range listeners {
+		listenerNames[string(listener.Name)] = struct{}{}
+	}
+	return listenerNames
+}
+
+func gatewayDefaultBackendSetName(gateway gatewayv1.Gateway) string {
+	return gateway.Name + "-default"
 }
 
 func (m *gatewayModelImpl) reconcileGatewayListenerCertificates(
@@ -724,14 +890,16 @@ func (m *gatewayModelImpl) reconcileGatewayListenerCertificates(
 
 func (m *gatewayModelImpl) removeMissingGatewayListeners(
 	ctx context.Context,
-	loadBalancerID string,
+	data *resolvedGatewayDetails,
+	gatewayManagedListeners []gatewayv1.Listener,
 	loadBalancer loadbalancer.LoadBalancer,
 	gatewayListeners []gatewayv1.Listener,
 ) error {
 	if err := m.ociLoadBalancerModel.removeMissingListeners(ctx, removeMissingListenersParams{
-		loadBalancerID:       loadBalancerID,
+		loadBalancerID:       data.config.Spec.LoadBalancerID,
 		knownListeners:       loadBalancer.Listeners,
 		knownRoutingPolicies: loadBalancer.RoutingPolicies,
+		cleanupListenerNames: gatewayCleanupListenerNames(data.gateway, gatewayManagedListeners),
 		gatewayListeners:     gatewayListeners,
 	}); err != nil {
 		return fmt.Errorf("failed to remove missing listeners: %w", err)
@@ -749,7 +917,11 @@ func (m *gatewayModelImpl) failClosedFrontendMTLSListeners(
 		loadBalancerID:       data.config.Spec.LoadBalancerID,
 		knownListeners:       loadBalancer.Listeners,
 		knownRoutingPolicies: loadBalancer.RoutingPolicies,
-		gatewayListeners:     gatewayListenersWithoutFrontendMTLS(data.gateway, gatewayListeners),
+		cleanupListenerNames: gatewayCleanupListenerNames(
+			data.gateway,
+			gatewayListenersWithoutFrontendMTLS(data.gateway, gatewayListeners),
+		),
+		gatewayListeners: gatewayListenersWithoutFrontendMTLS(data.gateway, gatewayListeners),
 	}); err != nil {
 		return fmt.Errorf("failed to fail closed frontend mTLS listeners: %w", err)
 	}
@@ -890,6 +1062,7 @@ func (m *gatewayModelImpl) setProgrammed(ctx context.Context, data *resolvedGate
 		message:           fmt.Sprintf("Gateway %s programmed by %s", data.gateway.Name, ControllerClassName),
 		annotations:       annotations,
 		removeAnnotations: staleProgrammedGatewayAnnotations(annotations),
+		finalizer:         LoadBalancerGatewayProgrammedFinalizer,
 	}); err != nil {
 		return fmt.Errorf("failed to set programmed condition for Gateway %s: %w", data.gateway.Name, err)
 	}
@@ -910,6 +1083,12 @@ func programmedGatewayAnnotations(data *resolvedGatewayDetails) map[string]strin
 		GatewayProgrammedCertificatesAnnotation: programmedGatewayCertificatesAnnotation(
 			programmedCertificateNamesFromSecrets(data.gatewaySecrets),
 		),
+		LoadBalancerGatewayProgrammedListenersAnnotation: programmedGatewayListenersAnnotation(
+			gatewayManagedOCIListenersForLoadBalancer(data),
+		),
+	}
+	if data.config.Spec.LoadBalancerID != "" {
+		annotations[LoadBalancerGatewayIDAnnotation] = data.config.Spec.LoadBalancerID
 	}
 
 	if len(data.gatewaySecrets) > 0 {

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -2501,6 +2501,81 @@ func TestGatewayModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("preserves certificate used by another listener during deprovision", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			listenerName := "https-" + fake.Lorem().Word()
+			sharedListenerName := "shared-" + fake.Lorem().Word()
+			routingPolicyName := listenerPolicyName(listenerName)
+			certName := "cert-" + fake.Lorem().Word()
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(gatewayv1.Listener{
+				Name:     gatewayv1.SectionName(listenerName),
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Port:     443,
+			}))
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			gateway.Annotations = map[string]string{
+				LoadBalancerGatewayIDAnnotation:                  loadBalancerID,
+				GatewayProgrammedCertificatesAnnotation:          certName,
+				LoadBalancerGatewayProgrammedListenersAnnotation: listenerName,
+			}
+			data := &resolvedGatewayDetails{
+				gateway: *gateway,
+				config: types.GatewayConfig{
+					Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID},
+				},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{
+						Listeners: map[string]loadbalancer.Listener{
+							listenerName: {
+								Name:                  new(listenerName),
+								RoutingPolicyName:     new(routingPolicyName),
+								DefaultBackendSetName: new(gatewayDefaultBackendSetName(data.gateway)),
+								SslConfiguration:      &loadbalancer.SslConfiguration{CertificateName: new(certName)},
+							},
+							sharedListenerName: {
+								Name:                  new(sharedListenerName),
+								DefaultBackendSetName: new("other-" + fake.Lorem().Word()),
+								SslConfiguration:      &loadbalancer.SslConfiguration{CertificateName: new(certName)},
+							},
+						},
+						RoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+							routingPolicyName: {Name: new(routingPolicyName)},
+						},
+						Certificates: map[string]loadbalancer.Certificate{
+							certName: {CertificateName: new(certName)},
+						},
+					},
+				}, nil)
+
+			mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			mockLBModel.EXPECT().removeMissingListeners(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().
+				removeUnusedCertificates(t.Context(), mock.MatchedBy(func(params removeUnusedCertificatesParams) bool {
+					return params.loadBalancerID == loadBalancerID &&
+						assert.ObjectsAreEqual([]string{certName}, params.previouslyProgrammedCertificates) &&
+						assert.ObjectsAreEqual([]string{certName}, params.desiredCertificates)
+				})).
+				Return(nil)
+			mockLBModel.EXPECT().cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, gatewayDefaultBackendSetName(data.gateway)).
+				Return(nil)
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(nil)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+
 		t.Run("removes desired OCI listeners when ownership annotation is missing", func(t *testing.T) {
 			fake := faker.New()
 			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -233,6 +234,132 @@ func TestGatewayModelImpl(t *testing.T) {
 			require.Len(t, receiver.listenerSets, 1)
 			require.Len(t, receiver.effectiveListeners, 1+len(gateway.Spec.Listeners))
 			assert.Contains(t, receiver.gatewaySecrets, secret.Namespace+"/"+secret.Name)
+		})
+
+		t.Run("deleting gateway can finalize without infrastructure", func(t *testing.T) {
+			fakeData := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fakeData.UUID().V4()
+			gatewayClass := newRandomGatewayClass(randomGatewayClassWithControllerNameOpt(ControllerClassName))
+			gateway := newRandomGateway()
+			deletionTime := metav1.Now()
+			gateway.DeletionTimestamp = &deletionTime
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			gateway.Annotations = map[string]string{LoadBalancerGatewayIDAnnotation: loadBalancerID}
+			gateway.Spec.GatewayClassName = gatewayv1.ObjectName(gatewayClass.Name)
+			gateway.Spec.Infrastructure = nil
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(gateway, gatewayClass).
+				Build()
+			model := newGatewayModel(gatewayModelDeps{
+				K8sClient:            k8sClient,
+				ResourcesModel:       NewMockresourcesModel(t),
+				RootLogger:           diag.RootTestLogger(),
+				OciClient:            NewMockociLoadBalancerClient(t),
+				OciLoadBalancerModel: NewMockociLoadBalancerModel(t),
+			})
+
+			var receiver resolvedGatewayDetails
+			relevant, err := model.resolveReconcileRequest(t.Context(), reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(gateway),
+			}, &receiver)
+
+			require.NoError(t, err)
+			assert.True(t, relevant)
+			assert.Equal(t, loadBalancerID, receiver.config.Spec.LoadBalancerID)
+		})
+
+		t.Run("deleting gateway can finalize without GatewayConfig", func(t *testing.T) {
+			fakeData := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fakeData.UUID().V4()
+			configName := "config-" + fakeData.Lorem().Word()
+			gatewayClass := newRandomGatewayClass(randomGatewayClassWithControllerNameOpt(ControllerClassName))
+			gateway := newRandomGateway()
+			deletionTime := metav1.Now()
+			gateway.DeletionTimestamp = &deletionTime
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			gateway.Annotations = map[string]string{LoadBalancerGatewayIDAnnotation: loadBalancerID}
+			gateway.Spec.GatewayClassName = gatewayv1.ObjectName(gatewayClass.Name)
+			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{
+					Group: ConfigRefGroup,
+					Kind:  ConfigRefKind,
+					Name:  configName,
+				},
+			}
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(gateway, gatewayClass).
+				Build()
+			model := newGatewayModel(gatewayModelDeps{
+				K8sClient:            k8sClient,
+				ResourcesModel:       NewMockresourcesModel(t),
+				RootLogger:           diag.RootTestLogger(),
+				OciClient:            NewMockociLoadBalancerClient(t),
+				OciLoadBalancerModel: NewMockociLoadBalancerModel(t),
+			})
+
+			var receiver resolvedGatewayDetails
+			relevant, err := model.resolveReconcileRequest(t.Context(), reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(gateway),
+			}, &receiver)
+
+			require.NoError(t, err)
+			assert.True(t, relevant)
+			assert.Equal(t, loadBalancerID, receiver.config.Spec.LoadBalancerID)
+		})
+
+		t.Run("deleting gateway skips missing TLS secret resolution", func(t *testing.T) {
+			fakeData := faker.New()
+			configName := "config-" + fakeData.Lorem().Word()
+			gatewayClass := newRandomGatewayClass(randomGatewayClassWithControllerNameOpt(ControllerClassName))
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(gatewayv1.Listener{
+				Name:     "https",
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Port:     443,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{{
+						Name: gatewayv1.ObjectName("missing-" + fakeData.Lorem().Word()),
+					}},
+				},
+			}))
+			deletionTime := metav1.Now()
+			gateway.DeletionTimestamp = &deletionTime
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			gateway.Spec.GatewayClassName = gatewayv1.ObjectName(gatewayClass.Name)
+			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{
+					Group: ConfigRefGroup,
+					Kind:  ConfigRefKind,
+					Name:  configName,
+				},
+			}
+			gatewayConfig := &types.GatewayConfig{
+				ObjectMeta: metav1.ObjectMeta{Namespace: gateway.Namespace, Name: configName},
+				Spec: types.GatewayConfigSpec{
+					LoadBalancerID: "ocid1.loadbalancer.oc1.." + fakeData.UUID().V4(),
+				},
+			}
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithObjects(gateway, gatewayClass, gatewayConfig).
+				Build()
+			model := newGatewayModel(gatewayModelDeps{
+				K8sClient:            k8sClient,
+				ResourcesModel:       NewMockresourcesModel(t),
+				RootLogger:           diag.RootTestLogger(),
+				OciClient:            NewMockociLoadBalancerClient(t),
+				OciLoadBalancerModel: NewMockociLoadBalancerModel(t),
+			})
+
+			var receiver resolvedGatewayDetails
+			relevant, err := model.resolveReconcileRequest(t.Context(), reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(gateway),
+			}, &receiver)
+
+			require.NoError(t, err)
+			assert.True(t, relevant)
+			assert.Empty(t, receiver.gatewaySecrets)
 		})
 
 		t.Run("returns invalid certificate option errors", func(t *testing.T) {
@@ -1114,6 +1241,7 @@ func TestGatewayModelImpl(t *testing.T) {
 					loadBalancerID:       config.Spec.LoadBalancerID,
 					knownListeners:       loadBalancer.Listeners,
 					knownRoutingPolicies: loadBalancer.RoutingPolicies,
+					cleanupListenerNames: listenerNamesSet(gateway.Spec.Listeners),
 					gatewayListeners:     gateway.Spec.Listeners,
 				}).
 				Return(nil)
@@ -1135,6 +1263,93 @@ func TestGatewayModelImpl(t *testing.T) {
 
 			require.NoError(t, err)
 		})
+
+		t.Run("does not cleanup another gateway listener when its default backend set drifts", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			config := makeRandomGatewayConfig()
+			ownedListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+				randomListenerWithNameOpt(gatewayv1.SectionName("owned-"+fake.Lorem().Word())),
+			)
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(ownedListener))
+			defaultBackendSet := makeRandomOCIBackendSet(func(backendSet *loadbalancer.BackendSet) {
+				backendSet.Name = new(gatewayDefaultBackendSetName(*gateway))
+			})
+			ownedOCIListener := makeRandomOCIListener(func(listener *loadbalancer.Listener) {
+				listener.Name = new(string(ownedListener.Name))
+				listener.DefaultBackendSetName = defaultBackendSet.Name
+			})
+			otherGatewayListenerName := "other-" + fake.Lorem().Word()
+			otherGatewayOCIListener := makeRandomOCIListener(func(listener *loadbalancer.Listener) {
+				listener.Name = &otherGatewayListenerName
+				listener.DefaultBackendSetName = defaultBackendSet.Name
+				listener.RoutingPolicyName = new(listenerPolicyName(otherGatewayListenerName))
+			})
+			loadBalancer := makeRandomOCILoadBalancer(
+				randomOCILoadBalancerWithRandomBackendSetsOpt(),
+				randomOCILoadBalancerWithRandomPoliciesOpt(),
+				randomOCILoadBalancerWithRandomCertificatesOpt(),
+			)
+			loadBalancer.Listeners = map[string]loadbalancer.Listener{
+				*ownedOCIListener.Name:        ownedOCIListener,
+				*otherGatewayOCIListener.Name: otherGatewayOCIListener,
+			}
+
+			mockOciClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOciClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: &config.Spec.LoadBalancerID,
+				}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadBalancer}, nil)
+
+			loadBalancerModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			loadBalancerModel.EXPECT().
+				reconcileDefaultBackendSet(t.Context(), reconcileDefaultBackendParams{
+					loadBalancerID:   config.Spec.LoadBalancerID,
+					knownBackendSets: loadBalancer.BackendSets,
+					gateway:          gateway,
+				}).
+				Return(defaultBackendSet, nil)
+			reconcileCertificatesCall := loadBalancerModel.EXPECT().
+				reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+					loadBalancerID:    config.Spec.LoadBalancerID,
+					gateway:           gateway,
+					gatewayListeners:  gateway.Spec.Listeners,
+					knownCertificates: loadBalancer.Certificates,
+				}).
+				Return(reconcileListenersCertificatesResult{}, nil)
+			loadBalancerModel.EXPECT().
+				reconcileHTTPListener(t.Context(), mock.MatchedBy(func(params reconcileHTTPListenerParams) bool {
+					return params.loadBalancerID == config.Spec.LoadBalancerID &&
+						params.defaultBackendSetName == *defaultBackendSet.Name &&
+						params.listenerSpec != nil &&
+						params.listenerSpec.Name == ownedListener.Name
+				})).
+				Return(nil).
+				NotBefore(reconcileCertificatesCall.Call)
+			removeCall := loadBalancerModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
+					_, hasOwned := params.cleanupListenerNames[*ownedOCIListener.Name]
+					_, hasOtherGateway := params.cleanupListenerNames[*otherGatewayOCIListener.Name]
+					return hasOwned && !hasOtherGateway
+				})).
+				Return(nil)
+			loadBalancerModel.EXPECT().
+				removeUnusedCertificates(t.Context(), mock.Anything).
+				Return(nil).
+				NotBefore(removeCall.Call)
+
+			err := model.programGateway(t.Context(), &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  config,
+			})
+
+			require.NoError(t, err)
+		})
+
 		t.Run("programs frontend mTLS listener params and cleanup", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newGatewayModel(deps)
@@ -1397,6 +1612,7 @@ func TestGatewayModelImpl(t *testing.T) {
 					loadBalancerID:       config.Spec.LoadBalancerID,
 					knownListeners:       loadBalancer.Listeners,
 					knownRoutingPolicies: loadBalancer.RoutingPolicies,
+					cleanupListenerNames: listenerNamesSet(gatewayListeners),
 					gatewayListeners:     gatewayListeners,
 				}).
 				Return(nil)
@@ -1532,6 +1748,7 @@ func TestGatewayModelImpl(t *testing.T) {
 					loadBalancerID:       config.Spec.LoadBalancerID,
 					knownListeners:       loadBalancer.Listeners,
 					knownRoutingPolicies: loadBalancer.RoutingPolicies,
+					cleanupListenerNames: map[string]struct{}{},
 					gatewayListeners:     nil,
 				}).
 				Return(nil).
@@ -1897,11 +2114,15 @@ func TestGatewayModelImpl(t *testing.T) {
 					annotations: map[string]string{
 						GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
 						GatewayProgrammedCertificatesAnnotation: "",
+						LoadBalancerGatewayProgrammedListenersAnnotation: programmedGatewayListenersAnnotation(
+							gatewayManagedOCIListenersForLoadBalancer(data),
+						),
 					},
 					removeAnnotations: []string{
 						GatewayFrontendMTLSConfigMapsAnnotation,
 						GatewayFrontendMTLSReferenceGrantsAnnotation,
 					},
+					finalizer: LoadBalancerGatewayProgrammedFinalizer,
 				},
 			).Return(nil)
 
@@ -1941,6 +2162,8 @@ func TestGatewayModelImpl(t *testing.T) {
 				gateway:        *gateway,
 				gatewaySecrets: gatewaySecretsMap,
 			}
+			expectedAnnotations[LoadBalancerGatewayProgrammedListenersAnnotation] =
+				programmedGatewayListenersAnnotation(gatewayManagedOCIListenersForLoadBalancer(data))
 
 			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockResourcesModel.EXPECT().setCondition(
@@ -1957,6 +2180,7 @@ func TestGatewayModelImpl(t *testing.T) {
 						GatewayFrontendMTLSConfigMapsAnnotation,
 						GatewayFrontendMTLSReferenceGrantsAnnotation,
 					},
+					finalizer: LoadBalancerGatewayProgrammedFinalizer,
 				},
 			).Return(nil)
 
@@ -1992,6 +2216,486 @@ func TestGatewayModelImpl(t *testing.T) {
 		})
 	})
 
+	t.Run("deprovisionGateway", func(t *testing.T) {
+		t.Run("uses annotated load balancer id when config is empty", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			gateway := newRandomGateway()
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			gateway.Annotations = map[string]string{LoadBalancerGatewayIDAnnotation: loadBalancerID}
+			data := &resolvedGatewayDetails{gateway: *gateway}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{
+						Listeners:       map[string]loadbalancer.Listener{},
+						RoutingPolicies: map[string]loadbalancer.RoutingPolicy{},
+						Certificates:    map[string]loadbalancer.Certificate{},
+					},
+				}, nil)
+			mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			mockLBModel.EXPECT().removeMissingListeners(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, gatewayDefaultBackendSetName(data.gateway)).
+				Return(nil)
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(nil)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("removes finalizer when load balancer is already gone", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			gateway := newRandomGateway()
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			data := &resolvedGatewayDetails{
+				gateway: *gateway,
+				config:  types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID}},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{},
+					ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(nil)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("keeps finalizer when load balancer lookup fails", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			data := &resolvedGatewayDetails{
+				gateway: *newRandomGateway(),
+				config:  types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID}},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{}, wantErr)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("keeps finalizer when listener cleanup fails", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			data := &resolvedGatewayDetails{
+				gateway: *newRandomGateway(),
+				config:  types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID}},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadbalancer.LoadBalancer{}}, nil)
+			mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			mockLBModel.EXPECT().removeMissingListeners(t.Context(), mock.Anything).Return(wantErr)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("keeps finalizer when later OCI cleanup fails", func(t *testing.T) {
+			fake := faker.New()
+			for name, setup := range map[string]func(*MockociLoadBalancerModel, error){
+				"certificates": func(mockLBModel *MockociLoadBalancerModel, wantErr error) {
+					mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(wantErr)
+				},
+				"frontend mTLS CA bundles": func(mockLBModel *MockociLoadBalancerModel, wantErr error) {
+					mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)
+					mockLBModel.EXPECT().cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).Return(wantErr)
+				},
+				"default backend set": func(mockLBModel *MockociLoadBalancerModel, wantErr error) {
+					mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)
+					mockLBModel.EXPECT().cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).Return(nil)
+					mockLBModel.EXPECT().
+						deprovisionBackendSetByName(t.Context(), mock.Anything, mock.Anything).
+						Return(wantErr)
+				},
+			} {
+				t.Run(name, func(t *testing.T) {
+					loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+					wantErr := errors.New(fake.Lorem().Sentence(10))
+					data := &resolvedGatewayDetails{
+						gateway: *newRandomGateway(),
+						config:  types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID}},
+					}
+					deps := newMockDeps(t)
+					model := newGatewayModel(deps)
+					mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+					mockOCIClient.EXPECT().
+						GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+						Return(loadbalancer.GetLoadBalancerResponse{LoadBalancer: loadbalancer.LoadBalancer{}}, nil)
+					mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+					mockLBModel.EXPECT().removeMissingListeners(t.Context(), mock.Anything).Return(nil)
+					setup(mockLBModel, wantErr)
+
+					err := model.deprovisionGateway(t.Context(), data)
+
+					require.ErrorIs(t, err, wantErr)
+				})
+			}
+		})
+
+		t.Run("wraps finalizer update errors", func(t *testing.T) {
+			fake := faker.New()
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			data := &resolvedGatewayDetails{gateway: *newRandomGateway()}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(wantErr)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to remove finalizer from Gateway")
+		})
+
+		t.Run("ignores finalizer update not found after namespace deletion", func(t *testing.T) {
+			gateway := newRandomGateway()
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			data := &resolvedGatewayDetails{gateway: *gateway}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).
+				Return(apierrors.NewNotFound(gatewayv1.Resource("gateways"), gateway.Name))
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("removes owned OCI resources and preserves unrelated listeners", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			listenerName := "https-" + fake.Lorem().Word()
+			unrelatedListenerName := "manual-" + fake.Lorem().Word()
+			routingPolicyName := listenerPolicyName(listenerName)
+			certName := "cert-" + fake.Lorem().Word()
+			compartmentID := "ocid1.compartment.oc1.." + fake.UUID().V4()
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(gatewayv1.Listener{
+				Name:     gatewayv1.SectionName(listenerName),
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Port:     443,
+			}))
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			gateway.Annotations = map[string]string{
+				LoadBalancerGatewayIDAnnotation:                             loadBalancerID,
+				GatewayProgrammingRevisionAnnotation:                        GatewayProgrammingRevisionValue,
+				GatewayProgrammedCertificatesAnnotation:                     certName,
+				LoadBalancerGatewayProgrammedListenersAnnotation:            listenerName,
+				GatewayFrontendMTLSCABundleCompartmentsAnnotation:           compartmentID,
+				GatewayUsedSecretsAnnotationPrefix + "/" + fake.UUID().V4(): fake.UUID().V4(),
+			}
+			data := &resolvedGatewayDetails{
+				gateway: *gateway,
+				config: types.GatewayConfig{
+					Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID},
+				},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{
+						CompartmentId: &compartmentID,
+						Listeners: map[string]loadbalancer.Listener{
+							listenerName: {
+								Name:                  new(listenerName),
+								RoutingPolicyName:     new(routingPolicyName),
+								DefaultBackendSetName: new(gatewayDefaultBackendSetName(data.gateway)),
+							},
+							unrelatedListenerName: {
+								Name:                  new(unrelatedListenerName),
+								DefaultBackendSetName: new("other-" + fake.Lorem().Word()),
+							},
+						},
+						RoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+							routingPolicyName: {Name: new(routingPolicyName)},
+						},
+						Certificates: map[string]loadbalancer.Certificate{
+							certName: {CertificateName: new(certName)},
+						},
+					},
+				}, nil)
+
+			mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			mockLBModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
+					_, hasOwned := params.knownListeners[listenerName]
+					_, hasUnrelated := params.knownListeners[unrelatedListenerName]
+					return params.loadBalancerID == loadBalancerID &&
+						hasOwned &&
+						hasUnrelated &&
+						assert.ObjectsAreEqual(
+							map[string]struct{}{listenerName: {}},
+							params.cleanupListenerNames,
+						) &&
+						len(params.gatewayListeners) == 0
+				})).
+				Return(nil)
+			mockLBModel.EXPECT().
+				removeUnusedCertificates(t.Context(), mock.MatchedBy(func(params removeUnusedCertificatesParams) bool {
+					return params.loadBalancerID == loadBalancerID &&
+						assert.ObjectsAreEqual([]string{certName}, params.previouslyProgrammedCertificates) &&
+						len(params.desiredCertificates) == 0
+				})).
+				Return(nil)
+			mockLBModel.EXPECT().
+				cleanupFrontendMTLSCABundles(t.Context(), mock.MatchedBy(func(params cleanupFrontendMTLSCABundlesParams) bool {
+					return params.gateway == &data.gateway &&
+						params.compartmentID == compartmentID &&
+						len(params.desiredBundleNames) == 0
+				})).
+				Return(nil)
+			mockLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, gatewayDefaultBackendSetName(data.gateway)).
+				Return(nil)
+
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().
+				Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).
+				RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+					assert.NotContains(t, obj.GetFinalizers(), LoadBalancerGatewayProgrammedFinalizer)
+					assert.NotContains(t, obj.GetAnnotations(), LoadBalancerGatewayIDAnnotation)
+					assert.NotContains(t, obj.GetAnnotations(), GatewayProgrammingRevisionAnnotation)
+					assert.NotContains(t, obj.GetAnnotations(), GatewayProgrammedCertificatesAnnotation)
+					assert.NotContains(t, obj.GetAnnotations(), LoadBalancerGatewayProgrammedListenersAnnotation)
+					assert.NotContains(t, obj.GetAnnotations(), GatewayFrontendMTLSCABundleCompartmentsAnnotation)
+					for key := range obj.GetAnnotations() {
+						assert.NotContains(t, key, GatewayUsedSecretsAnnotationPrefix+"/")
+					}
+					return nil
+				})
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("removes ListenerSet derived OCI listeners", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			gateway := newRandomGateway()
+			gateway.Namespace = "infra-" + fake.Lorem().Word()
+			gateway.Name = "edge-" + fake.Lorem().Word()
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps-" + fake.Lorem().Word(),
+					Name:      "media-" + fake.Lorem().Word(),
+				},
+			}
+			listener := gatewayv1.Listener{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443}
+			ownedListenerName := listenerSetOCIListenerName(*gateway, listenerSet, listener)
+			gateway.Annotations = map[string]string{
+				LoadBalancerGatewayProgrammedListenersAnnotation: ownedListenerName,
+			}
+			routingPolicyName := listenerPolicyName(ownedListenerName)
+			otherGateway := *gateway.DeepCopy()
+			otherGateway.Name = "other-" + fake.Lorem().Word()
+			otherGatewayOwnedListenerName := listenerSetOCIListenerName(otherGateway, listenerSet, listener)
+			data := &resolvedGatewayDetails{
+				gateway:      *gateway,
+				listenerSets: []gatewayv1.ListenerSet{listenerSet},
+				effectiveListeners: []effectiveListener{{
+					sourceKind:      effectiveListenerSourceListenerSet,
+					sourceNamespace: listenerSet.Namespace,
+					sourceName:      listenerSet.Name,
+					listener:        listener,
+					ociName:         ownedListenerName,
+				}},
+				config: types.GatewayConfig{
+					Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID},
+				},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{
+						Listeners: map[string]loadbalancer.Listener{
+							ownedListenerName: {
+								Name:                  new(ownedListenerName),
+								RoutingPolicyName:     new(routingPolicyName),
+								DefaultBackendSetName: new(gatewayDefaultBackendSetName(data.gateway)),
+							},
+							otherGatewayOwnedListenerName: {
+								Name:                  new(otherGatewayOwnedListenerName),
+								DefaultBackendSetName: new("other-" + fake.Lorem().Word()),
+							},
+						},
+						RoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+							routingPolicyName: {Name: new(routingPolicyName)},
+						},
+						Certificates: map[string]loadbalancer.Certificate{},
+					},
+				}, nil)
+			mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			mockLBModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
+					_, hasOwned := params.knownListeners[ownedListenerName]
+					_, hasOtherGateway := params.knownListeners[otherGatewayOwnedListenerName]
+					return hasOwned &&
+						hasOtherGateway &&
+						assert.ObjectsAreEqual(
+							map[string]struct{}{ownedListenerName: {}},
+							params.cleanupListenerNames,
+						)
+				})).
+				Return(nil)
+			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, gatewayDefaultBackendSetName(data.gateway)).
+				Return(nil)
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(nil)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("removes ListenerSet listeners after ListenerSet is deleted", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			gateway := newRandomGateway()
+			gateway.Namespace = "infra-" + fake.Lorem().Word()
+			gateway.Name = "edge-" + fake.Lorem().Word()
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			listenerSet := gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "apps-" + fake.Lorem().Word(),
+					Name:      "media-" + fake.Lorem().Word(),
+				},
+			}
+			listener := gatewayv1.Listener{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443}
+			vanishedListenerSetListenerName := listenerSetOCIListenerName(*gateway, listenerSet, listener)
+			gateway.Annotations = map[string]string{
+				LoadBalancerGatewayProgrammedListenersAnnotation: vanishedListenerSetListenerName,
+			}
+			routingPolicyName := listenerPolicyName(vanishedListenerSetListenerName)
+			data := &resolvedGatewayDetails{
+				gateway: *gateway,
+				config: types.GatewayConfig{
+					Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID},
+				},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{
+						Listeners: map[string]loadbalancer.Listener{
+							vanishedListenerSetListenerName: {
+								Name:                  new(vanishedListenerSetListenerName),
+								RoutingPolicyName:     new(routingPolicyName),
+								DefaultBackendSetName: new(gatewayDefaultBackendSetName(data.gateway)),
+							},
+						},
+						RoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+							routingPolicyName: {Name: new(routingPolicyName)},
+						},
+						Certificates: map[string]loadbalancer.Certificate{},
+					},
+				}, nil)
+			mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			mockLBModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
+					_, hasListenerSetListener := params.knownListeners[vanishedListenerSetListenerName]
+					return hasListenerSetListener &&
+						assert.ObjectsAreEqual(
+							map[string]struct{}{vanishedListenerSetListenerName: {}},
+							params.cleanupListenerNames,
+						)
+				})).
+				Return(nil)
+			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, gatewayDefaultBackendSetName(data.gateway)).
+				Return(nil)
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(nil)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("gatewayCleanupListenerNames", func(t *testing.T) {
+		t.Run("returns desired and previously programmed listeners", func(t *testing.T) {
+			fake := faker.New()
+			desiredListenerName := gatewayv1.SectionName("desired-" + fake.Lorem().Word())
+			previousListenerName := "previous-" + fake.Lorem().Word()
+			gateway := newRandomGateway()
+			gateway.Annotations = map[string]string{
+				LoadBalancerGatewayProgrammedListenersAnnotation: previousListenerName,
+			}
+
+			result := gatewayCleanupListenerNames(*gateway, []gatewayv1.Listener{{
+				Name: desiredListenerName,
+			}})
+
+			assert.Equal(t, map[string]struct{}{
+				string(desiredListenerName): {},
+				previousListenerName:        {},
+			}, result)
+		})
+
+		t.Run("returns empty cleanup scope without desired or previously programmed listeners", func(t *testing.T) {
+			gateway := newRandomGateway()
+
+			result := gatewayCleanupListenerNames(*gateway, nil)
+
+			require.Empty(t, result)
+			require.NotNil(t, result)
+		})
+
+		t.Run("does not claim another gateway listener only because default backend set drifted", func(t *testing.T) {
+			gateway := newRandomGateway()
+
+			result := gatewayCleanupListenerNames(*gateway, nil)
+
+			require.Empty(t, result)
+			require.NotNil(t, result)
+		})
+	})
+
 	t.Run("isProgrammed", func(t *testing.T) {
 		t.Run("should return true when programmed condition is set with correct annotation", func(t *testing.T) {
 			deps := newMockDeps(t)
@@ -2011,6 +2715,9 @@ func TestGatewayModelImpl(t *testing.T) {
 					annotations: map[string]string{
 						GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
 						GatewayProgrammedCertificatesAnnotation: "",
+						LoadBalancerGatewayProgrammedListenersAnnotation: programmedGatewayListenersAnnotation(
+							gatewayManagedOCIListenersForLoadBalancer(data),
+						),
 					},
 				},
 			).Return(true)
@@ -2039,6 +2746,9 @@ func TestGatewayModelImpl(t *testing.T) {
 					annotations: map[string]string{
 						GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
 						GatewayProgrammedCertificatesAnnotation: "",
+						LoadBalancerGatewayProgrammedListenersAnnotation: programmedGatewayListenersAnnotation(
+							gatewayManagedOCIListenersForLoadBalancer(data),
+						),
 					},
 				},
 			).Return(false)
@@ -2074,6 +2784,8 @@ func TestGatewayModelImpl(t *testing.T) {
 				gateway:        *gateway,
 				gatewaySecrets: gatewaySecretsMap,
 			}
+			expectedAnnotations[LoadBalancerGatewayProgrammedListenersAnnotation] =
+				programmedGatewayListenersAnnotation(gatewayManagedOCIListenersForLoadBalancer(data))
 
 			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
 			mockResourcesModel.EXPECT().isConditionSet(
@@ -2138,6 +2850,9 @@ func TestGatewayModelImpl(t *testing.T) {
 						annotations: map[string]string{
 							GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
 							GatewayProgrammedCertificatesAnnotation: "",
+							LoadBalancerGatewayProgrammedListenersAnnotation: programmedGatewayListenersAnnotation(
+								gatewayManagedOCIListenersForLoadBalancer(data),
+							),
 							GatewayFrontendMTLSConfigMapsAnnotation: gateway.Namespace + "/" + configMapName +
 								"=" + string(configMapUID) + "/" + configMapResourceVersion,
 						},
@@ -2214,6 +2929,9 @@ func TestGatewayModelImpl(t *testing.T) {
 						annotations: map[string]string{
 							GatewayProgrammingRevisionAnnotation:    GatewayProgrammingRevisionValue,
 							GatewayProgrammedCertificatesAnnotation: "",
+							LoadBalancerGatewayProgrammedListenersAnnotation: programmedGatewayListenersAnnotation(
+								gatewayManagedOCIListenersForLoadBalancer(data),
+							),
 							GatewayFrontendMTLSConfigMapsAnnotation: configMapNamespace + "/" + configMapName +
 								"=" + string(configMapUID) + "/" + configMapResourceVersion,
 							GatewayFrontendMTLSReferenceGrantsAnnotation: configMapNamespace + "/" + grantName +

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -2501,6 +2501,80 @@ func TestGatewayModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("removes desired OCI listeners when ownership annotation is missing", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			listenerName := gatewayv1.SectionName("https-" + fake.Lorem().Word())
+			unrelatedListenerName := "manual-" + fake.Lorem().Word()
+			routingPolicyName := listenerPolicyName(string(listenerName))
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(gatewayv1.Listener{
+				Name:     listenerName,
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Port:     443,
+			}))
+			gateway.Finalizers = []string{LoadBalancerGatewayProgrammedFinalizer}
+			gateway.Annotations = map[string]string{
+				LoadBalancerGatewayIDAnnotation: loadBalancerID,
+			}
+			data := &resolvedGatewayDetails{
+				gateway: *gateway,
+				config: types.GatewayConfig{
+					Spec: types.GatewayConfigSpec{LoadBalancerID: loadBalancerID},
+				},
+			}
+			deps := newMockDeps(t)
+			model := newGatewayModel(deps)
+
+			mockOCIClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			mockOCIClient.EXPECT().
+				GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{LoadBalancerId: &loadBalancerID}).
+				Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{
+						Listeners: map[string]loadbalancer.Listener{
+							string(listenerName): {
+								Name:                  new(string(listenerName)),
+								RoutingPolicyName:     new(routingPolicyName),
+								DefaultBackendSetName: new(gatewayDefaultBackendSetName(data.gateway)),
+							},
+							unrelatedListenerName: {
+								Name:                  new(unrelatedListenerName),
+								DefaultBackendSetName: new("other-" + fake.Lorem().Word()),
+							},
+						},
+						RoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+							routingPolicyName: {Name: new(routingPolicyName)},
+						},
+						Certificates: map[string]loadbalancer.Certificate{},
+					},
+				}, nil)
+
+			mockLBModel, _ := deps.OciLoadBalancerModel.(*MockociLoadBalancerModel)
+			mockLBModel.EXPECT().
+				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
+					_, hasOwned := params.knownListeners[string(listenerName)]
+					_, hasUnrelated := params.knownListeners[unrelatedListenerName]
+					return params.loadBalancerID == loadBalancerID &&
+						hasOwned &&
+						hasUnrelated &&
+						assert.ObjectsAreEqual(
+							map[string]struct{}{string(listenerName): {}},
+							params.cleanupListenerNames,
+						)
+				})).
+				Return(nil)
+			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().cleanupFrontendMTLSCABundles(t.Context(), mock.Anything).Return(nil)
+			mockLBModel.EXPECT().
+				deprovisionBackendSetByName(t.Context(), loadBalancerID, gatewayDefaultBackendSetName(data.gateway)).
+				Return(nil)
+			mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(nil)
+
+			err := model.deprovisionGateway(t.Context(), data)
+
+			require.NoError(t, err)
+		})
+
 		t.Run("removes ListenerSet derived OCI listeners", func(t *testing.T) {
 			fake := faker.New()
 			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
@@ -2636,11 +2710,9 @@ func TestGatewayModelImpl(t *testing.T) {
 			mockLBModel.EXPECT().
 				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
 					_, hasListenerSetListener := params.knownListeners[vanishedListenerSetListenerName]
+					_, cleansListenerSetListener := params.cleanupListenerNames[vanishedListenerSetListenerName]
 					return hasListenerSetListener &&
-						assert.ObjectsAreEqual(
-							map[string]struct{}{vanishedListenerSetListenerName: {}},
-							params.cleanupListenerNames,
-						)
+						cleansListenerSetListener
 				})).
 				Return(nil)
 			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sort"
 	"strings"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/samber/lo"
 	"go.uber.org/dig"
@@ -375,6 +377,10 @@ func removeL7RoutePolicyRules(
 			prevPolicyRules: prevRulesByListener[listenerName],
 		})
 		if err != nil {
+			if serviceErr, ok := common.IsServiceError(err); ok &&
+				serviceErr.GetHTTPStatusCode() == http.StatusNotFound {
+				continue
+			}
 			return fmt.Errorf("failed to remove route policy rules for listener %s: %w", listenerName, err)
 		}
 	}

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
 	k8sapi "github.com/gemyago/oke-gateway-api/internal/services/k8sapi"
+	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
 )
 
 func TestHTTPRouteModelImpl(t *testing.T) {
@@ -171,6 +173,28 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			require.ErrorIs(t, err, wantErr)
 			require.ErrorContains(t, err, "failed to remove route policy rules for listener https")
+		})
+
+		t.Run("ignores missing routing policies during cleanup", func(t *testing.T) {
+			fake := faker.New()
+			loadBalancerID := "ocid1.loadbalancer.oc1.." + fake.UUID().V4()
+			listeners := []gatewayv1.Listener{{Name: "https"}}
+			notFoundErr := ociapi.NewRandomServiceError(
+				ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+				ociapi.RandomServiceErrorWithCode("NotFound"),
+				ociapi.RandomServiceErrorWithMessage(fake.Lorem().Sentence(10)),
+			)
+			ociLBModel := NewMockociLoadBalancerModel(t)
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    "https",
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{"old-rule"},
+			}).Return(notFoundErr).Once()
+
+			err := removeL7RoutePolicyRules(t.Context(), ociLBModel, loadBalancerID, listeners, "https/old-rule")
+
+			require.NoError(t, err)
 		})
 	})
 
@@ -3086,6 +3110,46 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			})).Return(nil)
 
 			err := model.deprovisionRoute(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("removes finalizer after last policy rule cleanup succeeds", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			config := makeRandomGatewayConfig()
+			listener := makeRandomListener()
+			previousRule := "rule-" + fake.Lorem().Word()
+			httpRoute := makeRandomHTTPRoute()
+			httpRoute.Finalizers = []string{HTTPRouteProgrammedFinalizer}
+			httpRoute.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation: fmt.Sprintf("%s/%s", listener.Name, previousRule),
+			}
+
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  config.Spec.LoadBalancerID,
+				listenerName:    string(listener.Name),
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{previousRule},
+			}).Return(nil).Once()
+
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			k8sClient.EXPECT().Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updatedRoute, ok := obj.(*gatewayv1.HTTPRoute)
+				return ok &&
+					updatedRoute.Name == httpRoute.Name &&
+					!controllerutil.ContainsFinalizer(updatedRoute, HTTPRouteProgrammedFinalizer)
+			})).Return(nil).Once()
+
+			err := model.deprovisionRoute(t.Context(), deprovisionRouteParams{
+				gateway:          *newRandomGateway(),
+				config:           config,
+				httpRoute:        httpRoute,
+				matchedListeners: []gatewayv1.Listener{listener},
+			})
+
 			require.NoError(t, err)
 		})
 

--- a/internal/app/l4_route_model_integration_test.go
+++ b/internal/app/l4_route_model_integration_test.go
@@ -154,11 +154,14 @@ func TestTCPRouteModelResolveAndProgram(t *testing.T) {
 	require.Len(t, nlbClient.updateBackendSetRequests, 1)
 	update := nlbClient.updateBackendSetRequests[0]
 	assert.Equal(t, "bs_rtmp", lo.FromPtr(update.BackendSetName))
-	require.Len(t, update.UpdateBackendSetDetails.Backends, 1)
+	assert.Empty(t, update.UpdateBackendSetDetails.Backends)
 	assert.False(t, lo.FromPtr(update.UpdateBackendSetDetails.IsPreserveSource))
-	assert.Equal(t, "10.0.0.10", lo.FromPtr(update.UpdateBackendSetDetails.Backends[0].IpAddress))
-	assert.Equal(t, 1935, lo.FromPtr(update.UpdateBackendSetDetails.Backends[0].Port))
 	assert.Nil(t, update.UpdateBackendSetDetails.HealthChecker.Port)
+	require.Len(t, nlbClient.createBackendRequests, 1)
+	createBackend := nlbClient.createBackendRequests[0]
+	assert.Equal(t, "bs_rtmp", lo.FromPtr(createBackend.BackendSetName))
+	assert.Equal(t, "10.0.0.10", lo.FromPtr(createBackend.IpAddress))
+	assert.Equal(t, 1935, lo.FromPtr(createBackend.Port))
 
 	err = model.setProgrammed(t.Context(), resolved[0])
 	require.NoError(t, err)
@@ -240,11 +243,14 @@ func TestUDPRouteModelResolveAndProgram(t *testing.T) {
 	require.Len(t, nlbClient.updateBackendSetRequests, 1)
 	update := nlbClient.updateBackendSetRequests[0]
 	assert.Equal(t, "bs_coap", lo.FromPtr(update.BackendSetName))
-	require.Len(t, update.UpdateBackendSetDetails.Backends, 1)
+	assert.Empty(t, update.UpdateBackendSetDetails.Backends)
 	assert.False(t, lo.FromPtr(update.UpdateBackendSetDetails.IsPreserveSource))
-	assert.Equal(t, "10.0.0.10", lo.FromPtr(update.UpdateBackendSetDetails.Backends[0].IpAddress))
-	assert.Equal(t, 5684, lo.FromPtr(update.UpdateBackendSetDetails.Backends[0].Port))
 	assert.Equal(t, 9000, lo.FromPtr(update.UpdateBackendSetDetails.HealthChecker.Port))
+	require.Len(t, nlbClient.createBackendRequests, 1)
+	createBackend := nlbClient.createBackendRequests[0]
+	assert.Equal(t, "bs_coap", lo.FromPtr(createBackend.BackendSetName))
+	assert.Equal(t, "10.0.0.10", lo.FromPtr(createBackend.IpAddress))
+	assert.Equal(t, 5684, lo.FromPtr(createBackend.Port))
 
 	err = model.setProgrammed(t.Context(), resolved[0])
 	require.NoError(t, err)
@@ -323,11 +329,14 @@ func TestTLSRouteModelResolveAndProgramNLBPassthrough(t *testing.T) {
 	require.Len(t, nlbClient.updateBackendSetRequests, 1)
 	update := nlbClient.updateBackendSetRequests[0]
 	assert.Equal(t, "bs_tls", lo.FromPtr(update.BackendSetName))
-	require.Len(t, update.UpdateBackendSetDetails.Backends, 1)
+	assert.Empty(t, update.UpdateBackendSetDetails.Backends)
 	assert.False(t, lo.FromPtr(update.UpdateBackendSetDetails.IsPreserveSource))
-	assert.Equal(t, "10.0.0.10", lo.FromPtr(update.UpdateBackendSetDetails.Backends[0].IpAddress))
-	assert.Equal(t, 443, lo.FromPtr(update.UpdateBackendSetDetails.Backends[0].Port))
 	assert.Equal(t, 443, lo.FromPtr(update.UpdateBackendSetDetails.HealthChecker.Port))
+	require.Len(t, nlbClient.createBackendRequests, 1)
+	createBackend := nlbClient.createBackendRequests[0]
+	assert.Equal(t, "bs_tls", lo.FromPtr(createBackend.BackendSetName))
+	assert.Equal(t, "10.0.0.10", lo.FromPtr(createBackend.IpAddress))
+	assert.Equal(t, 443, lo.FromPtr(createBackend.Port))
 
 	err = model.setProgrammed(t.Context(), resolved[0])
 	require.NoError(t, err)

--- a/internal/app/l4route_annotations.go
+++ b/internal/app/l4route_annotations.go
@@ -31,11 +31,15 @@ func setAnnotatedBackendSetNames(route client.Object, annotation string, names m
 		return
 	}
 
+	annotations[annotation] = joinedAnnotationNames(names)
+	route.SetAnnotations(annotations)
+}
+
+func joinedAnnotationNames(names map[string]struct{}) string {
 	sortedNames := make([]string, 0, len(names))
 	for name := range names {
 		sortedNames = append(sortedNames, name)
 	}
 	sort.Strings(sortedNames)
-	annotations[annotation] = strings.Join(sortedNames, ",")
-	route.SetAnnotations(annotations)
+	return strings.Join(sortedNames, ",")
 }

--- a/internal/app/mock_gateway_model.go
+++ b/internal/app/mock_gateway_model.go
@@ -24,6 +24,53 @@ func (_m *MockgatewayModel) EXPECT() *MockgatewayModel_Expecter {
 	return &MockgatewayModel_Expecter{mock: &_m.Mock}
 }
 
+// deprovisionGateway provides a mock function with given fields: ctx, data
+func (_m *MockgatewayModel) deprovisionGateway(ctx context.Context, data *resolvedGatewayDetails) error {
+	ret := _m.Called(ctx, data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for deprovisionGateway")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *resolvedGatewayDetails) error); ok {
+		r0 = rf(ctx, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockgatewayModel_deprovisionGateway_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deprovisionGateway'
+type MockgatewayModel_deprovisionGateway_Call struct {
+	*mock.Call
+}
+
+// deprovisionGateway is a helper method to define mock.On call
+//   - ctx context.Context
+//   - data *resolvedGatewayDetails
+func (_e *MockgatewayModel_Expecter) deprovisionGateway(ctx interface{}, data interface{}) *MockgatewayModel_deprovisionGateway_Call {
+	return &MockgatewayModel_deprovisionGateway_Call{Call: _e.mock.On("deprovisionGateway", ctx, data)}
+}
+
+func (_c *MockgatewayModel_deprovisionGateway_Call) Run(run func(ctx context.Context, data *resolvedGatewayDetails)) *MockgatewayModel_deprovisionGateway_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*resolvedGatewayDetails))
+	})
+	return _c
+}
+
+func (_c *MockgatewayModel_deprovisionGateway_Call) Return(_a0 error) *MockgatewayModel_deprovisionGateway_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockgatewayModel_deprovisionGateway_Call) RunAndReturn(run func(context.Context, *resolvedGatewayDetails) error) *MockgatewayModel_deprovisionGateway_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // isProgrammed provides a mock function with given fields: ctx, data
 func (_m *MockgatewayModel) isProgrammed(ctx context.Context, data *resolvedGatewayDetails) bool {
 	ret := _m.Called(ctx, data)

--- a/internal/app/network_load_balancer_gateway_controller.go
+++ b/internal/app/network_load_balancer_gateway_controller.go
@@ -136,6 +136,27 @@ func (r *NetworkLoadBalancerGatewayController) Reconcile(
 		return reconcile.Result{}, nil
 	}
 
+	if err = r.resourcesModel.setCondition(ctx, setConditionParams{
+		resource:      &data.gateway,
+		conditions:    &data.gateway.Status.Conditions,
+		conditionType: string(gatewayv1.GatewayConditionProgrammed),
+		status:        metav1.ConditionUnknown,
+		reason:        string(gatewayv1.GatewayReasonPending),
+		message: fmt.Sprintf(
+			"Gateway %s programming by %s is in progress",
+			data.gateway.Name,
+			NetworkLoadBalancerControllerClassName,
+		),
+		annotations: networkLoadBalancerGatewayProtectionAnnotations(&data),
+		finalizer:   NetworkLoadBalancerGatewayProgrammedFinalizer,
+	}); err != nil {
+		return reconcile.Result{}, fmt.Errorf(
+			"failed to persist programming protection for Gateway %s: %w",
+			req.NamespacedName,
+			err,
+		)
+	}
+
 	if err = r.gatewayModel.programGateway(ctx, &data); err != nil {
 		return r.processResourceError(ctx, err, &data.gateway)
 	}
@@ -151,4 +172,17 @@ func (r *NetworkLoadBalancerGatewayController) Reconcile(
 		return reconcile.Result{}, err
 	}
 	return driftRequeue(r.driftInterval), nil
+}
+
+func networkLoadBalancerGatewayProtectionAnnotations(data *resolvedGatewayDetails) map[string]string {
+	loadBalancerID := data.config.Spec.LoadBalancerID
+	if loadBalancerID == "" {
+		loadBalancerID = data.gateway.Annotations[NetworkLoadBalancerGatewayIDAnnotation]
+	}
+	if loadBalancerID == "" {
+		return nil
+	}
+	return map[string]string{
+		NetworkLoadBalancerGatewayIDAnnotation: loadBalancerID,
+	}
 }

--- a/internal/app/network_load_balancer_gateway_controller_test.go
+++ b/internal/app/network_load_balancer_gateway_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaswdr/faker/v2"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/types"
 )
 
 type stubNLBGatewayModel struct {
@@ -30,6 +32,7 @@ type stubNLBGatewayModel struct {
 	deprovisioned    bool
 	alreadyDone      bool
 	programmedNLB    *networkloadbalancer.NetworkLoadBalancer
+	onProgram        func()
 }
 
 func (s *stubNLBGatewayModel) resolveReconcileRequest(
@@ -56,6 +59,9 @@ func (s *stubNLBGatewayModel) getNetworkLoadBalancer(
 }
 
 func (s *stubNLBGatewayModel) programGateway(context.Context, *resolvedGatewayDetails) error {
+	if s.onProgram != nil {
+		s.onProgram()
+	}
 	s.programmedNow = true
 	return s.programErr
 }
@@ -83,10 +89,12 @@ type stubResourcesModel struct {
 	conditionSet bool
 	setCalled    bool
 	setErr       error
+	calls        []setConditionParams
 }
 
-func (s *stubResourcesModel) setCondition(context.Context, setConditionParams) error {
+func (s *stubResourcesModel) setCondition(_ context.Context, params setConditionParams) error {
 	s.setCalled = true
+	s.calls = append(s.calls, params)
 	return s.setErr
 }
 
@@ -132,6 +140,45 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 		assert.True(t, resourcesModel.setCalled)
 		assert.True(t, gatewayModel.programmedNow)
 		assert.Same(t, nlb, gatewayModel.programmedNLB)
+	})
+
+	t.Run("persists finalizer and network load balancer identity before programming gateway", func(t *testing.T) {
+		fake := faker.New()
+		loadBalancerID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		data := baseData
+		data.config = types.GatewayConfig{
+			Spec: types.GatewayConfigSpec{
+				LoadBalancerID: loadBalancerID,
+			},
+		}
+		nlb := &networkloadbalancer.NetworkLoadBalancer{Id: &loadBalancerID}
+		resourcesModel := &stubResourcesModel{conditionSet: true}
+		protectedBeforeProgram := false
+		gatewayModel := &stubNLBGatewayModel{
+			relevant: true,
+			data:     data,
+			nlb:      nlb,
+			onProgram: func() {
+				for _, call := range resourcesModel.calls {
+					if call.conditionType == string(gatewayv1.GatewayConditionProgrammed) &&
+						call.finalizer == NetworkLoadBalancerGatewayProgrammedFinalizer &&
+						call.annotations[NetworkLoadBalancerGatewayIDAnnotation] == loadBalancerID {
+						protectedBeforeProgram = true
+					}
+				}
+			},
+		}
+		controller := NewNetworkLoadBalancerGatewayController(NetworkLoadBalancerGatewayControllerDeps{
+			RootLogger:     diag.RootTestLogger(),
+			ResourcesModel: resourcesModel,
+			GatewayModel:   gatewayModel,
+		})
+
+		result, err := controller.Reconcile(t.Context(), req)
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+		assert.True(t, protectedBeforeProgram)
 	})
 
 	t.Run("ignores irrelevant gateway", func(t *testing.T) {
@@ -215,7 +262,7 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, networkLoadBalancerBusyRequeueAfter, result.RequeueAfter)
-		assert.False(t, resourcesModel.setCalled)
+		assert.True(t, resourcesModel.setCalled)
 		assert.True(t, gatewayModel.programmedNow)
 	})
 
@@ -261,7 +308,7 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, networkLoadBalancerBusyRequeueAfter, result.RequeueAfter)
-		assert.False(t, resourcesModel.setCalled)
+		assert.True(t, resourcesModel.setCalled)
 		assert.True(t, gatewayModel.programmedNow)
 	})
 

--- a/internal/app/network_load_balancer_gateway_model.go
+++ b/internal/app/network_load_balancer_gateway_model.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -333,12 +334,30 @@ func (m *networkLoadBalancerGatewayModelImpl) deprovisionGateway(
 	ctx context.Context,
 	data *resolvedGatewayDetails,
 ) error {
+	nlbID := data.config.Spec.LoadBalancerID
+	if nlbID == "" {
+		nlbID = data.gateway.Annotations[NetworkLoadBalancerGatewayIDAnnotation]
+	}
+	if nlbID != "" {
+		if err := m.deprovisionNetworkLoadBalancerGatewayResources(ctx, data, nlbID); err != nil {
+			return err
+		}
+	}
+
 	gatewayToUpdate := data.gateway.DeepCopy()
 	controllerutil.RemoveFinalizer(gatewayToUpdate, NetworkLoadBalancerGatewayProgrammedFinalizer)
 	annotations := gatewayToUpdate.GetAnnotations()
 	delete(annotations, NetworkLoadBalancerGatewayIDAnnotation)
+	delete(annotations, NetworkLoadBalancerGatewayProgrammedListenersAnnotation)
+	delete(annotations, NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation)
 	gatewayToUpdate.SetAnnotations(annotations)
 	if updateErr := m.client.Update(ctx, gatewayToUpdate); updateErr != nil {
+		if apierrors.IsNotFound(updateErr) {
+			m.logger.InfoContext(ctx, "Gateway already deleted while removing finalizer",
+				slog.String("gateway", client.ObjectKeyFromObject(gatewayToUpdate).String()),
+			)
+			return nil
+		}
 		return fmt.Errorf("failed to remove finalizer from Gateway %s/%s: %w",
 			gatewayToUpdate.Namespace,
 			gatewayToUpdate.Name,
@@ -346,6 +365,97 @@ func (m *networkLoadBalancerGatewayModelImpl) deprovisionGateway(
 		)
 	}
 	return nil
+}
+
+func (m *networkLoadBalancerGatewayModelImpl) deprovisionNetworkLoadBalancerGatewayResources(
+	ctx context.Context,
+	data *resolvedGatewayDetails,
+	nlbID string,
+) error {
+	nlb, err := m.getNetworkLoadBalancerByID(ctx, nlbID)
+	if err != nil {
+		var statusErr *resourceStatusError
+		if errors.As(err, &statusErr) &&
+			statusErr.reason == string(gatewayv1.GatewayReasonPending) {
+			return nil
+		}
+		return err
+	}
+	if nlb.Id == nil {
+		return errors.New("OCI Network Load Balancer id is empty")
+	}
+	if busyErr := networkLoadBalancerBusyErrorFromState(nlb); busyErr != nil {
+		return busyErr
+	}
+
+	return m.operationLocks.withLock(nlb.Id, func() error {
+		gatewayListeners := effectiveOCIListenersForGateway(data)
+		ownedListenerNames := mergeNameSets(
+			annotatedResourceNames(data.gateway, NetworkLoadBalancerGatewayProgrammedListenersAnnotation),
+			desiredNetworkLoadBalancerListenerNames(gatewayListeners),
+		)
+		ownedBackendSetNames := mergeNameSets(
+			annotatedResourceNames(data.gateway, NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation),
+			desiredNetworkLoadBalancerBackendSetNames(gatewayListeners),
+		)
+		scopedNLB := *nlb
+		scopedNLB.Listeners = namedNetworkLoadBalancerListeners(ownedListenerNames, nlb.Listeners)
+		scopedNLB.BackendSets = namedNetworkLoadBalancerBackendSets(ownedBackendSetNames, nlb.BackendSets)
+		if err = m.removeMissingListeners(ctx, scopedNLB, nil, nil); err != nil {
+			return err
+		}
+		if err = m.removeMissingBackendSets(ctx, scopedNLB, nil, nil); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func namedNetworkLoadBalancerListeners(
+	ownedNames map[string]struct{},
+	knownListeners map[string]networkloadbalancer.Listener,
+) map[string]networkloadbalancer.Listener {
+	ownedListeners := make(map[string]networkloadbalancer.Listener, len(ownedNames))
+	for listenerName, listener := range knownListeners {
+		if _, owned := ownedNames[listenerName]; owned {
+			ownedListeners[listenerName] = listener
+		}
+	}
+	return ownedListeners
+}
+
+func namedNetworkLoadBalancerBackendSets(
+	ownedNames map[string]struct{},
+	knownBackendSets map[string]networkloadbalancer.BackendSet,
+) map[string]networkloadbalancer.BackendSet {
+	ownedBackendSets := make(map[string]networkloadbalancer.BackendSet, len(ownedNames))
+	for backendSetName, backendSet := range knownBackendSets {
+		if _, owned := ownedNames[backendSetName]; owned {
+			ownedBackendSets[backendSetName] = backendSet
+		}
+	}
+	return ownedBackendSets
+}
+
+func annotatedResourceNames(gateway gatewayv1.Gateway, annotation string) map[string]struct{} {
+	names := make(map[string]struct{})
+	for name := range strings.SplitSeq(gateway.Annotations[annotation], ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func mergeNameSets(nameSets ...map[string]struct{}) map[string]struct{} {
+	merged := make(map[string]struct{})
+	for _, nameSet := range nameSets {
+		for name := range nameSet {
+			merged[name] = struct{}{}
+		}
+	}
+	return merged
 }
 
 func (m *networkLoadBalancerGatewayModelImpl) reconcileListenerBackendSet(
@@ -518,6 +628,7 @@ func (m *networkLoadBalancerGatewayModelImpl) removeMissingListeners(
 	ctx context.Context,
 	nlb networkloadbalancer.NetworkLoadBalancer,
 	gatewayListeners []gatewayv1.Listener,
+	cleanupCandidates map[string]struct{},
 ) error {
 	desiredListeners := desiredNetworkLoadBalancerListenerNames(gatewayListeners)
 	return removeMissingNetworkLoadBalancerResources(
@@ -527,6 +638,7 @@ func (m *networkLoadBalancerGatewayModelImpl) removeMissingListeners(
 		nlb.Id,
 		nlb.Listeners,
 		desiredListeners,
+		cleanupCandidates,
 		nlbResourceCleanup{
 			kind:       "listener",
 			logMessage: "Deleting stale OCI Network Load Balancer listener",
@@ -548,6 +660,7 @@ func (m *networkLoadBalancerGatewayModelImpl) removeMissingBackendSets(
 	ctx context.Context,
 	nlb networkloadbalancer.NetworkLoadBalancer,
 	gatewayListeners []gatewayv1.Listener,
+	cleanupCandidates map[string]struct{},
 ) error {
 	desiredBackendSets := desiredNetworkLoadBalancerBackendSetNames(gatewayListeners)
 	return removeMissingNetworkLoadBalancerResources(
@@ -557,6 +670,7 @@ func (m *networkLoadBalancerGatewayModelImpl) removeMissingBackendSets(
 		nlb.Id,
 		nlb.BackendSets,
 		desiredBackendSets,
+		cleanupCandidates,
 		nlbResourceCleanup{
 			kind:       "backend set",
 			logMessage: "Deleting stale OCI Network Load Balancer backend set",
@@ -587,11 +701,17 @@ func removeMissingNetworkLoadBalancerResources[T any](
 	networkLoadBalancerID *string,
 	current map[string]T,
 	desired map[string]struct{},
+	cleanupCandidates map[string]struct{},
 	cleanup nlbResourceCleanup,
 ) error {
 	for resourceName := range current {
 		if _, found := desired[resourceName]; found {
 			continue
+		}
+		if cleanupCandidates != nil {
+			if _, canCleanUp := cleanupCandidates[resourceName]; !canCleanUp {
+				continue
+			}
 		}
 
 		logger.InfoContext(ctx, cleanup.logMessage,
@@ -659,10 +779,20 @@ func (m *networkLoadBalancerGatewayModelImpl) programGateway(
 				return fmt.Errorf("failed to reconcile Network Load Balancer listener %s: %w", listener.Name, err)
 			}
 		}
-		if err = m.removeMissingListeners(ctx, *nlb, gatewayListeners); err != nil {
+		if err = m.removeMissingListeners(
+			ctx,
+			*nlb,
+			gatewayListeners,
+			annotatedResourceNames(data.gateway, NetworkLoadBalancerGatewayProgrammedListenersAnnotation),
+		); err != nil {
 			return err
 		}
-		if err = m.removeMissingBackendSets(ctx, *nlb, gatewayListeners); err != nil {
+		if err = m.removeMissingBackendSets(
+			ctx,
+			*nlb,
+			gatewayListeners,
+			annotatedResourceNames(data.gateway, NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation),
+		); err != nil {
 			return err
 		}
 		return nil
@@ -711,6 +841,11 @@ func (m *networkLoadBalancerGatewayModelImpl) isProgrammed(_ context.Context, da
 	if data.config.Spec.LoadBalancerID != "" {
 		annotations[NetworkLoadBalancerGatewayIDAnnotation] = data.config.Spec.LoadBalancerID
 	}
+	gatewayListeners := effectiveOCIListenersForGateway(data)
+	annotations[NetworkLoadBalancerGatewayProgrammedListenersAnnotation] =
+		joinedAnnotationNames(desiredNetworkLoadBalancerListenerNames(gatewayListeners))
+	annotations[NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation] =
+		joinedAnnotationNames(desiredNetworkLoadBalancerBackendSetNames(gatewayListeners))
 
 	return m.resourcesModel.isConditionSet(isConditionSetParams{
 		resource:      &data.gateway,
@@ -746,6 +881,11 @@ func (m *networkLoadBalancerGatewayModelImpl) setProgrammed(
 	if nlb != nil && nlb.Id != nil {
 		annotations[NetworkLoadBalancerGatewayIDAnnotation] = *nlb.Id
 	}
+	gatewayListeners := effectiveOCIListenersForGateway(data)
+	annotations[NetworkLoadBalancerGatewayProgrammedListenersAnnotation] =
+		joinedAnnotationNames(desiredNetworkLoadBalancerListenerNames(gatewayListeners))
+	annotations[NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation] =
+		joinedAnnotationNames(desiredNetworkLoadBalancerBackendSetNames(gatewayListeners))
 	if err := m.resourcesModel.setCondition(ctx, setConditionParams{
 		resource:      &data.gateway,
 		conditions:    &data.gateway.Status.Conditions,

--- a/internal/app/network_load_balancer_gateway_model_test.go
+++ b/internal/app/network_load_balancer_gateway_model_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +29,9 @@ import (
 type stubNetworkLoadBalancerClient struct {
 	createBackendSetRequests []networkloadbalancer.CreateBackendSetRequest
 	updateBackendSetRequests []networkloadbalancer.UpdateBackendSetRequest
+	createBackendRequests    []networkloadbalancer.CreateBackendRequest
+	updateBackendRequests    []networkloadbalancer.UpdateBackendRequest
+	deleteBackendRequests    []networkloadbalancer.DeleteBackendRequest
 	createListenerRequests   []networkloadbalancer.CreateListenerRequest
 	updateListenerRequests   []networkloadbalancer.UpdateListenerRequest
 	deleteListenerRequests   []networkloadbalancer.DeleteListenerRequest
@@ -36,12 +40,18 @@ type stubNetworkLoadBalancerClient struct {
 	getResponse              networkloadbalancer.GetNetworkLoadBalancerResponse
 	createBackendSetResponse networkloadbalancer.CreateBackendSetResponse
 	updateBackendSetResponse networkloadbalancer.UpdateBackendSetResponse
+	createBackendResponse    networkloadbalancer.CreateBackendResponse
+	updateBackendResponse    networkloadbalancer.UpdateBackendResponse
+	deleteBackendResponse    networkloadbalancer.DeleteBackendResponse
 	createListenerResponse   networkloadbalancer.CreateListenerResponse
 	updateListenerResponse   networkloadbalancer.UpdateListenerResponse
 	deleteListenerResponse   networkloadbalancer.DeleteListenerResponse
 	deleteBackendSetResponse networkloadbalancer.DeleteBackendSetResponse
 	createBackendSetErr      error
 	updateBackendSetErr      error
+	createBackendErr         error
+	updateBackendErr         error
+	deleteBackendErr         error
 	createListenerErr        error
 	updateListenerErr        error
 	deleteListenerErr        error
@@ -50,6 +60,9 @@ type stubNetworkLoadBalancerClient struct {
 
 	omitCreateBackendSetWorkRequest bool
 	omitUpdateBackendSetWorkRequest bool
+	omitCreateBackendWorkRequest    bool
+	omitUpdateBackendWorkRequest    bool
+	omitDeleteBackendWorkRequest    bool
 	omitCreateListenerWorkRequest   bool
 	omitUpdateListenerWorkRequest   bool
 	omitDeleteListenerWorkRequest   bool
@@ -139,15 +152,21 @@ func TestNetworkLoadBalancerGatewayModelIsProgrammedWithExistingNLB(t *testing.T
 		RootLogger:     diag.RootTestLogger(),
 		ResourcesModel: newResourcesModel(resourcesModelDeps{RootLogger: diag.RootTestLogger()}),
 	})
+	listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
 	gateway := gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "iot",
 			Name:       "edge",
 			Generation: 3,
 			Annotations: map[string]string{
-				NetworkLoadBalancerGatewayProgrammingRevisionAnnotation: NetworkLoadBalancerGatewayProgrammingRevisionValue,
-				NetworkLoadBalancerGatewayIDAnnotation:                  "ocid1.networkloadbalancer.oc1..old",
+				NetworkLoadBalancerGatewayProgrammingRevisionAnnotation:   NetworkLoadBalancerGatewayProgrammingRevisionValue,
+				NetworkLoadBalancerGatewayIDAnnotation:                    "ocid1.networkloadbalancer.oc1..old",
+				NetworkLoadBalancerGatewayProgrammedListenersAnnotation:   string(listener.Name),
+				NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation: networkLoadBalancerBackendSetName(listener),
 			},
+		},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{listener},
 		},
 		Status: gatewayv1.GatewayStatus{
 			Conditions: []metav1.Condition{{
@@ -480,24 +499,42 @@ func (s *stubNetworkLoadBalancerClient) DeleteBackendSet(
 }
 
 func (s *stubNetworkLoadBalancerClient) CreateBackend(
-	context.Context,
-	networkloadbalancer.CreateBackendRequest,
+	_ context.Context,
+	request networkloadbalancer.CreateBackendRequest,
 ) (networkloadbalancer.CreateBackendResponse, error) {
-	panic("unexpected CreateBackend call")
+	s.createBackendRequests = append(s.createBackendRequests, request)
+	if s.createBackendResponse.OpcWorkRequestId == nil &&
+		s.createBackendErr == nil &&
+		!s.omitCreateBackendWorkRequest {
+		s.createBackendResponse.OpcWorkRequestId = new("create-backend-work-request")
+	}
+	return s.createBackendResponse, s.createBackendErr
 }
 
 func (s *stubNetworkLoadBalancerClient) UpdateBackend(
-	context.Context,
-	networkloadbalancer.UpdateBackendRequest,
+	_ context.Context,
+	request networkloadbalancer.UpdateBackendRequest,
 ) (networkloadbalancer.UpdateBackendResponse, error) {
-	panic("unexpected UpdateBackend call")
+	s.updateBackendRequests = append(s.updateBackendRequests, request)
+	if s.updateBackendResponse.OpcWorkRequestId == nil &&
+		s.updateBackendErr == nil &&
+		!s.omitUpdateBackendWorkRequest {
+		s.updateBackendResponse.OpcWorkRequestId = new("update-backend-work-request")
+	}
+	return s.updateBackendResponse, s.updateBackendErr
 }
 
 func (s *stubNetworkLoadBalancerClient) DeleteBackend(
-	context.Context,
-	networkloadbalancer.DeleteBackendRequest,
+	_ context.Context,
+	request networkloadbalancer.DeleteBackendRequest,
 ) (networkloadbalancer.DeleteBackendResponse, error) {
-	panic("unexpected DeleteBackend call")
+	s.deleteBackendRequests = append(s.deleteBackendRequests, request)
+	if s.deleteBackendResponse.OpcWorkRequestId == nil &&
+		s.deleteBackendErr == nil &&
+		!s.omitDeleteBackendWorkRequest {
+		s.deleteBackendResponse.OpcWorkRequestId = new("delete-backend-work-request")
+	}
+	return s.deleteBackendResponse, s.deleteBackendErr
 }
 
 type stubWorkRequestsWatcher struct {
@@ -1109,6 +1146,9 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 	})
 
 	t.Run("removes stale listeners and backend sets", func(t *testing.T) {
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		listenerName := string(listener.Name)
+		backendSetName := networkLoadBalancerBackendSetName(listener)
 		watcher := &stubWorkRequestsWatcher{}
 		client := &stubNetworkLoadBalancerClient{
 			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
@@ -1116,16 +1156,16 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
 					DisplayName: new("shared-nlb"),
 					Listeners: map[string]networkloadbalancer.Listener{
-						"rtmp": {
-							Name: new("rtmp"),
+						listenerName: {
+							Name: new(listenerName),
 						},
 						"old": {
 							Name: new("old"),
 						},
 					},
 					BackendSets: map[string]networkloadbalancer.BackendSet{
-						"bs_rtmp": {
-							Name: new("bs_rtmp"),
+						backendSetName: {
+							Name: new(backendSetName),
 						},
 						"bs_old": {
 							Name: new("bs_old"),
@@ -1145,12 +1185,10 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		}
 		model := newModel(client, watcher)
 		details := newDetails()
-		details.gateway.Spec.Listeners = []gatewayv1.Listener{
-			{
-				Name:     "rtmp",
-				Protocol: gatewayv1.TCPProtocolType,
-				Port:     1935,
-			},
+		details.gateway.Spec.Listeners = []gatewayv1.Listener{listener}
+		details.gateway.Annotations = map[string]string{
+			NetworkLoadBalancerGatewayProgrammedListenersAnnotation:   listenerName + ",old",
+			NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation: backendSetName + ",bs_old",
 		}
 
 		err := model.programGateway(t.Context(), details)
@@ -1170,6 +1208,46 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		)
 	})
 
+	t.Run("keeps resources owned by other gateways on shared network load balancer", func(t *testing.T) {
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		listenerName := string(listener.Name)
+		backendSetName := networkLoadBalancerBackendSetName(listener)
+		otherListenerName := "srt"
+		otherBackendSetName := "bs_srt"
+		client := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("ocid1.networkloadbalancer.oc1..existing"),
+					DisplayName: new("shared-nlb"),
+					Listeners: map[string]networkloadbalancer.Listener{
+						listenerName:      {Name: new(listenerName)},
+						otherListenerName: {Name: new(otherListenerName)},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						backendSetName:      {Name: new(backendSetName)},
+						otherBackendSetName: {Name: new(otherBackendSetName)},
+					},
+				},
+			},
+			updateListenerResponse: networkloadbalancer.UpdateListenerResponse{
+				OpcWorkRequestId: new("update-listener-work-request"),
+			},
+		}
+		model := newModel(client, &stubWorkRequestsWatcher{})
+		details := newDetails()
+		details.gateway.Spec.Listeners = []gatewayv1.Listener{listener}
+		details.gateway.Annotations = map[string]string{
+			NetworkLoadBalancerGatewayProgrammedListenersAnnotation:   listenerName,
+			NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation: backendSetName,
+		}
+
+		err := model.programGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		assert.Empty(t, client.deleteListenerRequests)
+		assert.Empty(t, client.deleteBackendSetRequests)
+	})
+
 	t.Run("removes stale ListenerSet derived listeners and backend sets", func(t *testing.T) {
 		details := newDetails()
 		details.gateway.Spec.Listeners = nil
@@ -1182,6 +1260,10 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			Name:     gatewayv1.SectionName(staleListenerName),
 			Protocol: listener.Protocol,
 		})
+		details.gateway.Annotations = map[string]string{
+			NetworkLoadBalancerGatewayProgrammedListenersAnnotation:   staleListenerName,
+			NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation: staleBackendSetName,
+		}
 		watcher := &stubWorkRequestsWatcher{}
 		client := &stubNetworkLoadBalancerClient{
 			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
@@ -1241,8 +1323,13 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 					},
 				}
 				model := newModel(client, &stubWorkRequestsWatcher{})
+				details := newDetails()
+				details.gateway.Annotations = map[string]string{
+					NetworkLoadBalancerGatewayProgrammedListenersAnnotation:   "old",
+					NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation: "bs_old",
+				}
 
-				err := model.programGateway(t.Context(), newDetails())
+				err := model.programGateway(t.Context(), details)
 
 				require.Error(t, err)
 			})
@@ -1261,7 +1348,16 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 	})
 
 	t.Run("deprovisions gateway without deleting existing network load balancer", func(t *testing.T) {
-		nlbClient := &stubNetworkLoadBalancerClient{}
+		nlbID := "ocid1.networkloadbalancer.oc1..existing"
+		nlbClient := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new(nlbID),
+					Listeners:   map[string]networkloadbalancer.Listener{},
+					BackendSets: map[string]networkloadbalancer.BackendSet{},
+				},
+			},
+		}
 		k8sClient := NewMockk8sClient(t)
 		k8sClient.EXPECT().
 			Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).
@@ -1278,15 +1374,218 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		})
 		details := newDetails()
 		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
-		details.gateway.Annotations = map[string]string{NetworkLoadBalancerGatewayIDAnnotation: "nlb-id"}
+		details.gateway.Annotations = map[string]string{NetworkLoadBalancerGatewayIDAnnotation: nlbID}
+		details.config.Spec.LoadBalancerID = nlbID
 
 		err := model.deprovisionGateway(t.Context(), details)
 
 		require.NoError(t, err)
+		require.Len(t, nlbClient.getRequests, 1)
+	})
+
+	t.Run("deprovisions owned listeners and backend sets", func(t *testing.T) {
+		nlbID := "ocid1.networkloadbalancer.oc1..existing"
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		listenerName := string(listener.Name)
+		backendSetName := networkLoadBalancerBackendSetName(listener)
+		unrelatedListenerName := "manual"
+		unrelatedBackendSetName := "bs_manual"
+		watcher := &stubWorkRequestsWatcher{}
+		nlbClient := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new(nlbID),
+					Listeners: map[string]networkloadbalancer.Listener{
+						listenerName:          {Name: new(listenerName)},
+						unrelatedListenerName: {Name: new(unrelatedListenerName)},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						backendSetName:          {Name: new(backendSetName)},
+						unrelatedBackendSetName: {Name: new(unrelatedBackendSetName)},
+					},
+				},
+			},
+			deleteListenerResponse: networkloadbalancer.DeleteListenerResponse{
+				OpcWorkRequestId: new("delete-listener-work-request"),
+			},
+			deleteBackendSetResponse: networkloadbalancer.DeleteBackendSetResponse{
+				OpcWorkRequestId: new("delete-backend-set-work-request"),
+			},
+		}
+		k8sClient := NewMockk8sClient(t)
+		k8sClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				assert.NotContains(t, obj.GetFinalizers(), NetworkLoadBalancerGatewayProgrammedFinalizer)
+				assert.NotContains(t, obj.GetAnnotations(), NetworkLoadBalancerGatewayIDAnnotation)
+				return nil
+			})
+		model := newNetworkLoadBalancerGatewayModel(networkLoadBalancerGatewayModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			K8sClient:           k8sClient,
+			OciClient:           nlbClient,
+			WorkRequestsWatcher: watcher,
+		})
+		details := newDetails()
+		details.gateway.Spec.Listeners = []gatewayv1.Listener{listener}
+		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
+		details.gateway.Annotations = map[string]string{NetworkLoadBalancerGatewayIDAnnotation: nlbID}
+		details.config.Spec.LoadBalancerID = nlbID
+
+		err := model.deprovisionGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		require.Len(t, nlbClient.deleteListenerRequests, 1)
+		assert.Equal(t, listenerName, lo.FromPtr(nlbClient.deleteListenerRequests[0].ListenerName))
+		require.Len(t, nlbClient.deleteBackendSetRequests, 1)
+		assert.Equal(t, backendSetName, lo.FromPtr(nlbClient.deleteBackendSetRequests[0].BackendSetName))
+		assert.ElementsMatch(t,
+			[]string{"delete-listener-work-request", "delete-backend-set-work-request"},
+			watcher.waited,
+		)
+	})
+
+	t.Run("deprovisions ListenerSet derived listeners and backend sets", func(t *testing.T) {
+		nlbID := "ocid1.networkloadbalancer.oc1..existing"
+		gateway := newRandomGateway(func(g *gatewayv1.Gateway) {
+			g.Namespace = "iot"
+			g.Name = "edge"
+		})
+		listenerSet := gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "apps", Name: "media"},
+		}
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		ownedListenerName := listenerSetOCIListenerName(*gateway, listenerSet, listener)
+		ownedBackendSetName := networkLoadBalancerBackendSetName(gatewayv1.Listener{
+			Name:     gatewayv1.SectionName(ownedListenerName),
+			Protocol: listener.Protocol,
+		})
+		unrelatedListenerName := "manual"
+		unrelatedBackendSetName := "bs_manual"
+		watcher := &stubWorkRequestsWatcher{}
+		nlbClient := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new(nlbID),
+					Listeners: map[string]networkloadbalancer.Listener{
+						ownedListenerName:     {Name: new(ownedListenerName)},
+						unrelatedListenerName: {Name: new(unrelatedListenerName)},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{
+						ownedBackendSetName:     {Name: new(ownedBackendSetName)},
+						unrelatedBackendSetName: {Name: new(unrelatedBackendSetName)},
+					},
+				},
+			},
+			deleteListenerResponse: networkloadbalancer.DeleteListenerResponse{
+				OpcWorkRequestId: new("delete-listener-work-request"),
+			},
+			deleteBackendSetResponse: networkloadbalancer.DeleteBackendSetResponse{
+				OpcWorkRequestId: new("delete-backend-set-work-request"),
+			},
+		}
+		k8sClient := NewMockk8sClient(t)
+		k8sClient.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).Return(nil)
+		model := newNetworkLoadBalancerGatewayModel(networkLoadBalancerGatewayModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			K8sClient:           k8sClient,
+			OciClient:           nlbClient,
+			WorkRequestsWatcher: watcher,
+		})
+		details := newDetails()
+		details.gateway = *gateway
+		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
+		details.gateway.Annotations = map[string]string{NetworkLoadBalancerGatewayIDAnnotation: nlbID}
+		details.listenerSets = []gatewayv1.ListenerSet{listenerSet}
+		details.effectiveListeners = []effectiveListener{{
+			sourceKind:      effectiveListenerSourceListenerSet,
+			sourceNamespace: listenerSet.Namespace,
+			sourceName:      listenerSet.Name,
+			listener:        listener,
+			ociName:         ownedListenerName,
+		}}
+		details.config.Spec.LoadBalancerID = nlbID
+
+		err := model.deprovisionGateway(t.Context(), details)
+
+		require.NoError(t, err)
+		require.Len(t, nlbClient.deleteListenerRequests, 1)
+		assert.Equal(t, ownedListenerName, lo.FromPtr(nlbClient.deleteListenerRequests[0].ListenerName))
+		require.Len(t, nlbClient.deleteBackendSetRequests, 1)
+		assert.Equal(t, ownedBackendSetName, lo.FromPtr(nlbClient.deleteBackendSetRequests[0].BackendSetName))
+		assert.ElementsMatch(t,
+			[]string{"delete-listener-work-request", "delete-backend-set-work-request"},
+			watcher.waited,
+		)
+	})
+
+	t.Run("keeps finalizer when network load balancer cleanup fails", func(t *testing.T) {
+		nlbID := "ocid1.networkloadbalancer.oc1..existing"
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935}
+		listenerName := string(listener.Name)
+		wantErr := errors.New("delete listener failed")
+		nlbClient := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id: new(nlbID),
+					Listeners: map[string]networkloadbalancer.Listener{
+						listenerName: {Name: new(listenerName)},
+					},
+					BackendSets: map[string]networkloadbalancer.BackendSet{},
+				},
+			},
+			deleteListenerErr: wantErr,
+		}
+		model := newNetworkLoadBalancerGatewayModel(networkLoadBalancerGatewayModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			K8sClient:           NewMockk8sClient(t),
+			OciClient:           nlbClient,
+			WorkRequestsWatcher: &stubWorkRequestsWatcher{},
+		})
+		details := newDetails()
+		details.gateway.Spec.Listeners = []gatewayv1.Listener{listener}
+		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
+		details.gateway.Annotations = map[string]string{NetworkLoadBalancerGatewayIDAnnotation: nlbID}
+		details.config.Spec.LoadBalancerID = nlbID
+
+		err := model.deprovisionGateway(t.Context(), details)
+
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("keeps finalizer when network load balancer is busy", func(t *testing.T) {
+		nlbID := "ocid1.networkloadbalancer.oc1..existing"
+		nlbClient := &stubNetworkLoadBalancerClient{
+			getResponse: networkloadbalancer.GetNetworkLoadBalancerResponse{
+				NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:             new(nlbID),
+					LifecycleState: networkloadbalancer.LifecycleStateUpdating,
+				},
+			},
+		}
+		model := newNetworkLoadBalancerGatewayModel(networkLoadBalancerGatewayModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			K8sClient:           NewMockk8sClient(t),
+			OciClient:           nlbClient,
+			WorkRequestsWatcher: &stubWorkRequestsWatcher{},
+		})
+		details := newDetails()
+		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
+		details.gateway.Annotations = map[string]string{NetworkLoadBalancerGatewayIDAnnotation: nlbID}
+		details.config.Spec.LoadBalancerID = nlbID
+
+		err := model.deprovisionGateway(t.Context(), details)
+
+		require.Error(t, err)
+		var busyErr *networkLoadBalancerBusyError
+		require.ErrorAs(t, err, &busyErr)
 	})
 
 	t.Run("removes finalizer when network load balancer is already gone", func(t *testing.T) {
-		nlbClient := &stubNetworkLoadBalancerClient{}
+		nlbID := "ocid1.networkloadbalancer.oc1..deleted"
+		nlbClient := &stubNetworkLoadBalancerClient{
+			getErr: ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)),
+		}
 		k8sClient := NewMockk8sClient(t)
 		k8sClient.EXPECT().
 			Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).
@@ -1302,6 +1601,8 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		})
 		details := newDetails()
 		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
+		details.gateway.Annotations = map[string]string{NetworkLoadBalancerGatewayIDAnnotation: nlbID}
+		details.config.Spec.LoadBalancerID = nlbID
 
 		err := model.deprovisionGateway(t.Context(), details)
 
@@ -1314,6 +1615,27 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 			Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).
 			Return(errors.New("update failed"))
 		model := newNetworkLoadBalancerGatewayModel(networkLoadBalancerGatewayModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  k8sClient,
+			OciClient: &stubNetworkLoadBalancerClient{
+				getErr: ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)),
+			},
+			WorkRequestsWatcher: &stubWorkRequestsWatcher{},
+		})
+		details := newDetails()
+		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
+		details.config.Spec.LoadBalancerID = ""
+
+		err := model.deprovisionGateway(t.Context(), details)
+		require.ErrorContains(t, err, "failed to remove finalizer from Gateway")
+	})
+
+	t.Run("ignores finalizer update not found after namespace deletion", func(t *testing.T) {
+		k8sClient := NewMockk8sClient(t)
+		k8sClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.Gateway")).
+			Return(apierrors.NewNotFound(gatewayv1.Resource("gateways"), "deleted"))
+		model := newNetworkLoadBalancerGatewayModel(networkLoadBalancerGatewayModelDeps{
 			RootLogger:          diag.RootTestLogger(),
 			K8sClient:           k8sClient,
 			OciClient:           &stubNetworkLoadBalancerClient{},
@@ -1321,9 +1643,12 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		})
 		details := newDetails()
 		details.gateway.Finalizers = []string{NetworkLoadBalancerGatewayProgrammedFinalizer}
+		details.gateway.Annotations = nil
+		details.config.Spec.LoadBalancerID = ""
 
 		err := model.deprovisionGateway(t.Context(), details)
-		require.ErrorContains(t, err, "failed to remove finalizer from Gateway")
+
+		require.NoError(t, err)
 	})
 
 	t.Run("wraps listener and backend set reconcile errors", func(t *testing.T) {
@@ -1526,7 +1851,7 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		err := modelImpl.removeMissingListeners(t.Context(), networkloadbalancer.NetworkLoadBalancer{
 			Id:        new("nlb-id"),
 			Listeners: map[string]networkloadbalancer.Listener{"old": {Name: new("old")}},
-		}, nil)
+		}, nil, nil)
 		require.ErrorContains(t, err, "failed waiting for stale listener old deletion")
 
 		model = newModel(&stubNetworkLoadBalancerClient{
@@ -1538,7 +1863,7 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		err = modelImpl.removeMissingBackendSets(t.Context(), networkloadbalancer.NetworkLoadBalancer{
 			Id:          new("nlb-id"),
 			BackendSets: map[string]networkloadbalancer.BackendSet{"bs_old": {Name: new("bs_old")}},
-		}, nil)
+		}, nil, nil)
 		require.ErrorContains(t, err, "failed waiting for stale backend set bs_old deletion")
 
 		model = newModel(
@@ -1549,7 +1874,7 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		err = modelImpl.removeMissingListeners(t.Context(), networkloadbalancer.NetworkLoadBalancer{
 			Id:        new("nlb-id"),
 			Listeners: map[string]networkloadbalancer.Listener{"old": {Name: new("old")}},
-		}, nil)
+		}, nil, nil)
 		require.ErrorContains(t, err, "missing work request id")
 
 		model = newModel(
@@ -1560,7 +1885,7 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		err = modelImpl.removeMissingBackendSets(t.Context(), networkloadbalancer.NetworkLoadBalancer{
 			Id:          new("nlb-id"),
 			BackendSets: map[string]networkloadbalancer.BackendSet{"bs_old": {Name: new("bs_old")}},
-		}, nil)
+		}, nil, nil)
 		require.ErrorContains(t, err, "missing work request id")
 
 		model = newModel(
@@ -1571,7 +1896,7 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		err = modelImpl.removeMissingListeners(t.Context(), networkloadbalancer.NetworkLoadBalancer{
 			Id:        new("nlb-id"),
 			Listeners: map[string]networkloadbalancer.Listener{"old": {Name: new("old")}},
-		}, nil)
+		}, nil, nil)
 		var gotBusyErr *networkLoadBalancerBusyError
 		require.ErrorAs(t, err, &gotBusyErr)
 
@@ -1583,7 +1908,7 @@ func TestNetworkLoadBalancerGatewayModel(t *testing.T) {
 		err = modelImpl.removeMissingBackendSets(t.Context(), networkloadbalancer.NetworkLoadBalancer{
 			Id:          new("nlb-id"),
 			BackendSets: map[string]networkloadbalancer.BackendSet{"bs_old": {Name: new("bs_old")}},
-		}, nil)
+		}, nil, nil)
 		gotBusyErr = nil
 		require.ErrorAs(t, err, &gotBusyErr)
 

--- a/internal/app/network_load_balancer_retry.go
+++ b/internal/app/network_load_balancer_retry.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
+	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -46,6 +47,8 @@ func updateNetworkLoadBalancerBackendSet(
 	if busyErr := networkLoadBalancerBusyErrorFromState(nlb); busyErr != nil {
 		return busyErr
 	}
+	desiredBackends := normalizeNetworkLoadBalancerBackendDetails(details.Backends)
+	details.Backends = nil
 	response, err := ociClient.UpdateBackendSet(ctx, networkloadbalancer.UpdateBackendSetRequest{
 		NetworkLoadBalancerId:   nlb.Id,
 		BackendSetName:          new(backendSetName),
@@ -53,6 +56,9 @@ func updateNetworkLoadBalancerBackendSet(
 	})
 	if err != nil {
 		if busyErr := networkLoadBalancerBusyErrorFromOCI(nlb.Id, err); busyErr != nil {
+			return busyErr
+		}
+		if busyErr := networkLoadBalancerMissingBackendSetErrorFromOCI(nlb.Id, err); busyErr != nil {
 			return busyErr
 		}
 		return fmt.Errorf("failed to %s Network Load Balancer backend set %s: %w", operation, backendSetName, err)
@@ -66,6 +72,232 @@ func updateNetworkLoadBalancerBackendSet(
 	}
 	if err = workRequestsWatcher.WaitFor(ctx, *response.OpcWorkRequestId); err != nil {
 		return fmt.Errorf("failed waiting for backend set %s %s: %w", backendSetName, operation, err)
+	}
+	return syncNetworkLoadBalancerBackends(ctx, ociClient, workRequestsWatcher, nlb, backendSetName, desiredBackends)
+}
+
+func normalizeNetworkLoadBalancerBackendDetails(
+	backends []networkloadbalancer.BackendDetails,
+) []networkloadbalancer.BackendDetails {
+	normalized := make(map[string]networkloadbalancer.BackendDetails, len(backends))
+	for _, backend := range backends {
+		mergeNetworkLoadBalancerBackend(normalized, backend)
+	}
+	return lo.Values(normalized)
+}
+
+func syncNetworkLoadBalancerBackends(
+	ctx context.Context,
+	ociClient ociNetworkLoadBalancerClient,
+	workRequestsWatcher workRequestsWatcher,
+	nlb *networkloadbalancer.NetworkLoadBalancer,
+	backendSetName string,
+	desired []networkloadbalancer.BackendDetails,
+) error {
+	current := mapNetworkLoadBalancerBackends(nil)
+	if nlb.BackendSets != nil {
+		if backendSet, ok := nlb.BackendSets[backendSetName]; ok {
+			current = mapNetworkLoadBalancerBackends(backendSet.Backends)
+		}
+	}
+	desiredMap := lo.SliceToMap(desired, func(backend networkloadbalancer.BackendDetails) (
+		string,
+		networkloadbalancer.BackendDetails,
+	) {
+		return networkLoadBalancerBackendKey(backend), backend
+	})
+
+	for name, backend := range desiredMap {
+		currentBackend, found := current[name]
+		switch {
+		case !found:
+			if err := createNetworkLoadBalancerBackend(
+				ctx,
+				ociClient,
+				workRequestsWatcher,
+				nlb.Id,
+				backendSetName,
+				backend,
+			); err != nil {
+				return err
+			}
+		case !networkLoadBalancerBackendDetailsEqual(currentBackend, backend):
+			if err := updateNetworkLoadBalancerBackend(
+				ctx,
+				ociClient,
+				workRequestsWatcher,
+				nlb.Id,
+				backendSetName,
+				name,
+				backend,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	for name := range current {
+		if _, found := desiredMap[name]; found {
+			continue
+		}
+		if err := deleteNetworkLoadBalancerBackend(
+			ctx,
+			ociClient,
+			workRequestsWatcher,
+			nlb.Id,
+			backendSetName,
+			name,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mapNetworkLoadBalancerBackends(backends []networkloadbalancer.Backend) map[string]networkloadbalancer.Backend {
+	return lo.SliceToMap(backends, func(backend networkloadbalancer.Backend) (string, networkloadbalancer.Backend) {
+		return fmt.Sprintf("%s:%d", lo.FromPtr(backend.IpAddress), lo.FromPtr(backend.Port)), backend
+	})
+}
+
+func networkLoadBalancerBackendDetailsEqual(
+	current networkloadbalancer.Backend,
+	desired networkloadbalancer.BackendDetails,
+) bool {
+	return lo.FromPtr(current.Weight) == lo.FromPtr(desired.Weight) &&
+		lo.FromPtr(current.IsDrain) == lo.FromPtr(desired.IsDrain) &&
+		lo.FromPtr(current.IsBackup) == lo.FromPtr(desired.IsBackup) &&
+		lo.FromPtr(current.IsOffline) == lo.FromPtr(desired.IsOffline)
+}
+
+func createNetworkLoadBalancerBackend(
+	ctx context.Context,
+	ociClient ociNetworkLoadBalancerClient,
+	workRequestsWatcher workRequestsWatcher,
+	nlbID *string,
+	backendSetName string,
+	backend networkloadbalancer.BackendDetails,
+) error {
+	response, err := ociClient.CreateBackend(ctx, networkloadbalancer.CreateBackendRequest{
+		NetworkLoadBalancerId: nlbID,
+		BackendSetName:        new(backendSetName),
+		CreateBackendDetails: networkloadbalancer.CreateBackendDetails{
+			Name:      backend.Name,
+			IpAddress: backend.IpAddress,
+			TargetId:  backend.TargetId,
+			Port:      backend.Port,
+			Weight:    backend.Weight,
+			IsDrain:   backend.IsDrain,
+			IsBackup:  backend.IsBackup,
+			IsOffline: backend.IsOffline,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create Network Load Balancer backend %s: %w",
+			networkLoadBalancerBackendKey(backend),
+			err,
+		)
+	}
+	return waitForNetworkLoadBalancerBackendOperation(
+		ctx,
+		workRequestsWatcher,
+		response.OpcWorkRequestId,
+		"create",
+		backendSetName,
+		networkLoadBalancerBackendKey(backend),
+	)
+}
+
+func updateNetworkLoadBalancerBackend(
+	ctx context.Context,
+	ociClient ociNetworkLoadBalancerClient,
+	workRequestsWatcher workRequestsWatcher,
+	nlbID *string,
+	backendSetName string,
+	backendName string,
+	backend networkloadbalancer.BackendDetails,
+) error {
+	response, err := ociClient.UpdateBackend(ctx, networkloadbalancer.UpdateBackendRequest{
+		NetworkLoadBalancerId: nlbID,
+		BackendSetName:        new(backendSetName),
+		BackendName:           new(backendName),
+		UpdateBackendDetails: networkloadbalancer.UpdateBackendDetails{
+			Weight:    backend.Weight,
+			IsDrain:   backend.IsDrain,
+			IsBackup:  backend.IsBackup,
+			IsOffline: backend.IsOffline,
+		},
+	})
+	if err != nil {
+		if networkLoadBalancerBackendNotFound(err) {
+			return createNetworkLoadBalancerBackend(ctx, ociClient, workRequestsWatcher, nlbID, backendSetName, backend)
+		}
+		return fmt.Errorf("failed to update Network Load Balancer backend %s: %w", backendName, err)
+	}
+	return waitForNetworkLoadBalancerBackendOperation(
+		ctx,
+		workRequestsWatcher,
+		response.OpcWorkRequestId,
+		"update",
+		backendSetName,
+		backendName,
+	)
+}
+
+func deleteNetworkLoadBalancerBackend(
+	ctx context.Context,
+	ociClient ociNetworkLoadBalancerClient,
+	workRequestsWatcher workRequestsWatcher,
+	nlbID *string,
+	backendSetName string,
+	backendName string,
+) error {
+	response, err := ociClient.DeleteBackend(ctx, networkloadbalancer.DeleteBackendRequest{
+		NetworkLoadBalancerId: nlbID,
+		BackendSetName:        new(backendSetName),
+		BackendName:           new(backendName),
+	})
+	if err != nil {
+		if networkLoadBalancerBackendNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete Network Load Balancer backend %s: %w", backendName, err)
+	}
+	return waitForNetworkLoadBalancerBackendOperation(
+		ctx,
+		workRequestsWatcher,
+		response.OpcWorkRequestId,
+		"delete",
+		backendSetName,
+		backendName,
+	)
+}
+
+func waitForNetworkLoadBalancerBackendOperation(
+	ctx context.Context,
+	workRequestsWatcher workRequestsWatcher,
+	workRequestID *string,
+	operation string,
+	backendSetName string,
+	backendName string,
+) error {
+	if workRequestID == nil {
+		return fmt.Errorf(
+			"failed to %s Network Load Balancer backend %s in backend set %s: missing work request id",
+			operation,
+			backendName,
+			backendSetName,
+		)
+	}
+	if err := workRequestsWatcher.WaitFor(ctx, *workRequestID); err != nil {
+		return fmt.Errorf(
+			"failed waiting for backend %s in backend set %s %s: %w",
+			backendName,
+			backendSetName,
+			operation,
+			err,
+		)
 	}
 	return nil
 }
@@ -84,6 +316,13 @@ func networkLoadBalancerBusyErrorFromOCI(id *string, err error) *networkLoadBala
 	return &networkLoadBalancerBusyError{id: ptrString(id), cause: err}
 }
 
+func networkLoadBalancerMissingBackendSetErrorFromOCI(id *string, err error) *networkLoadBalancerBusyError {
+	if err == nil || !networkLoadBalancerBackendNotFound(err) {
+		return nil
+	}
+	return &networkLoadBalancerBusyError{id: ptrString(id), cause: err}
+}
+
 func isNetworkLoadBalancerBusyServiceError(err error) bool {
 	serviceErr, ok := common.IsServiceError(err)
 	if !ok || serviceErr.GetHTTPStatusCode() != http.StatusConflict {
@@ -94,6 +333,11 @@ func isNetworkLoadBalancerBusyServiceError(err error) bool {
 	return (strings.Contains(message, "invalid state transition") &&
 		strings.Contains(message, "updating")) ||
 		strings.Contains(code, "invalidstatetransition")
+}
+
+func networkLoadBalancerBackendNotFound(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound
 }
 
 func ptrString(value *string) string {

--- a/internal/app/network_load_balancer_retry_test.go
+++ b/internal/app/network_load_balancer_retry_test.go
@@ -2,11 +2,17 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/jaswdr/faker/v2"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
@@ -62,6 +68,21 @@ func TestNetworkLoadBalancerRetry(t *testing.T) {
 		assert.NotContains(t, err.Error(), "nlb-id")
 	})
 
+	t.Run("detects missing backend set as retryable OCI dependency", func(t *testing.T) {
+		fake := faker.New()
+		nlbID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		cause := ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+			ociapi.RandomServiceErrorWithCode("NotAuthorizedOrNotFound"),
+			ociapi.RandomServiceErrorWithMessage("Unknown resource BackendSet bs_"+fake.Lorem().Word()),
+		)
+
+		err := networkLoadBalancerMissingBackendSetErrorFromOCI(&nlbID, cause)
+
+		require.ErrorIs(t, err, cause)
+		assert.Contains(t, err.Error(), nlbID)
+	})
+
 	t.Run("ignores nil OCI errors", func(t *testing.T) {
 		require.Nil(t, networkLoadBalancerBusyErrorFromOCI(new(string), nil))
 	})
@@ -82,4 +103,333 @@ func TestNetworkLoadBalancerRetry(t *testing.T) {
 
 		require.Nil(t, err)
 	})
+
+	t.Run("normalizes duplicate backends before syncing members", func(t *testing.T) {
+		fake := faker.New()
+		nlbID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		updateWorkRequestID := fake.UUID().V4()
+		createBackendWorkRequestID := fake.UUID().V4()
+		ipAddress := fake.Internet().Ipv4()
+		port := fake.IntBetween(1024, 65535)
+		ociClient := NewMockociNetworkLoadBalancerClient(t)
+		workRequestsWatcher := NewMockworkRequestsWatcher(t)
+		ociClient.EXPECT().
+			UpdateBackendSet(t.Context(), mock.MatchedBy(func(request networkloadbalancer.UpdateBackendSetRequest) bool {
+				return lo.FromPtr(request.NetworkLoadBalancerId) == nlbID &&
+					lo.FromPtr(request.BackendSetName) == backendSetName &&
+					request.UpdateBackendSetDetails.Backends == nil
+			})).
+			Return(networkloadbalancer.UpdateBackendSetResponse{OpcWorkRequestId: &updateWorkRequestID}, nil)
+		ociClient.EXPECT().
+			CreateBackend(t.Context(), mock.MatchedBy(func(request networkloadbalancer.CreateBackendRequest) bool {
+				return lo.FromPtr(request.NetworkLoadBalancerId) == nlbID &&
+					lo.FromPtr(request.BackendSetName) == backendSetName &&
+					lo.FromPtr(request.Name) == fmt.Sprintf("%s:%d", ipAddress, port) &&
+					lo.FromPtr(request.IpAddress) == ipAddress &&
+					lo.FromPtr(request.Port) == port &&
+					lo.FromPtr(request.Weight) == 3
+			})).
+			Return(networkloadbalancer.CreateBackendResponse{OpcWorkRequestId: &createBackendWorkRequestID}, nil)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), updateWorkRequestID).Return(nil)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), createBackendWorkRequestID).Return(nil)
+
+		err := updateNetworkLoadBalancerBackendSet(
+			t.Context(),
+			ociClient,
+			workRequestsWatcher,
+			&networkloadbalancer.NetworkLoadBalancer{
+				Id:             &nlbID,
+				LifecycleState: networkloadbalancer.LifecycleStateActive,
+			},
+			backendSetName,
+			"update",
+			networkloadbalancer.UpdateBackendSetDetails{
+				Backends: []networkloadbalancer.BackendDetails{
+					{
+						IpAddress: &ipAddress,
+						Port:      &port,
+						Weight:    new(1),
+						IsDrain:   new(true),
+					},
+					{
+						IpAddress: &ipAddress,
+						Port:      &port,
+						Weight:    new(2),
+						IsDrain:   new(true),
+					},
+				},
+			},
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("syncs backend member create update and delete", func(t *testing.T) {
+		fake := faker.New()
+		nlbID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		createName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		updateName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		deleteName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		keepName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		createWorkRequestID := fake.UUID().V4()
+		updateWorkRequestID := fake.UUID().V4()
+		deleteWorkRequestID := fake.UUID().V4()
+		ociClient := NewMockociNetworkLoadBalancerClient(t)
+		workRequestsWatcher := NewMockworkRequestsWatcher(t)
+		ociClient.EXPECT().
+			CreateBackend(t.Context(), mock.MatchedBy(func(request networkloadbalancer.CreateBackendRequest) bool {
+				return lo.FromPtr(request.NetworkLoadBalancerId) == nlbID &&
+					lo.FromPtr(request.BackendSetName) == backendSetName &&
+					lo.FromPtr(request.Name) == createName &&
+					lo.FromPtr(request.Weight) == 2
+			})).
+			Return(networkloadbalancer.CreateBackendResponse{OpcWorkRequestId: &createWorkRequestID}, nil)
+		ociClient.EXPECT().
+			UpdateBackend(t.Context(), mock.MatchedBy(func(request networkloadbalancer.UpdateBackendRequest) bool {
+				return lo.FromPtr(request.NetworkLoadBalancerId) == nlbID &&
+					lo.FromPtr(request.BackendSetName) == backendSetName &&
+					lo.FromPtr(request.BackendName) == updateName &&
+					lo.FromPtr(request.Weight) == 3 &&
+					lo.FromPtr(request.IsDrain)
+			})).
+			Return(networkloadbalancer.UpdateBackendResponse{OpcWorkRequestId: &updateWorkRequestID}, nil)
+		ociClient.EXPECT().
+			DeleteBackend(t.Context(), mock.MatchedBy(func(request networkloadbalancer.DeleteBackendRequest) bool {
+				return lo.FromPtr(request.NetworkLoadBalancerId) == nlbID &&
+					lo.FromPtr(request.BackendSetName) == backendSetName &&
+					lo.FromPtr(request.BackendName) == deleteName
+			})).
+			Return(networkloadbalancer.DeleteBackendResponse{OpcWorkRequestId: &deleteWorkRequestID}, nil)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), createWorkRequestID).Return(nil)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), updateWorkRequestID).Return(nil)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), deleteWorkRequestID).Return(nil)
+
+		err := syncNetworkLoadBalancerBackends(
+			t.Context(),
+			ociClient,
+			workRequestsWatcher,
+			&networkloadbalancer.NetworkLoadBalancer{
+				Id: &nlbID,
+				BackendSets: map[string]networkloadbalancer.BackendSet{
+					backendSetName: {
+						Backends: []networkloadbalancer.Backend{
+							backendFromName(updateName, 1),
+							backendFromName(deleteName, 1),
+							backendFromName(keepName, 4),
+						},
+					},
+				},
+			},
+			backendSetName,
+			[]networkloadbalancer.BackendDetails{
+				backendDetailsFromName(createName, 2, false),
+				backendDetailsFromName(updateName, 3, true),
+				backendDetailsFromName(keepName, 4, false),
+			},
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("returns duplicate create backend errors", func(t *testing.T) {
+		fake := faker.New()
+		nlbID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		createName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		ociClient := NewMockociNetworkLoadBalancerClient(t)
+		workRequestsWatcher := NewMockworkRequestsWatcher(t)
+		duplicateErr := ociapi.NewRandomServiceError(
+			ociapi.RandomServiceErrorWithStatusCode(http.StatusConflict),
+			ociapi.RandomServiceErrorWithCode("NotAuthorizedOrResourceAlreadyExists"),
+			ociapi.RandomServiceErrorWithMessage("Duplicate backend IP/id + port combinations not allowed"),
+		)
+		ociClient.EXPECT().
+			CreateBackend(t.Context(), mock.Anything).
+			Return(networkloadbalancer.CreateBackendResponse{}, duplicateErr)
+
+		err := syncNetworkLoadBalancerBackends(
+			t.Context(),
+			ociClient,
+			workRequestsWatcher,
+			&networkloadbalancer.NetworkLoadBalancer{
+				Id: &nlbID,
+				BackendSets: map[string]networkloadbalancer.BackendSet{
+					backendSetName: {},
+				},
+			},
+			backendSetName,
+			[]networkloadbalancer.BackendDetails{backendDetailsFromName(createName, 1, false)},
+		)
+
+		require.ErrorIs(t, err, duplicateErr)
+	})
+
+	t.Run("treats missing delete backend as already reconciled", func(t *testing.T) {
+		fake := faker.New()
+		nlbID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		deleteName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		ociClient := NewMockociNetworkLoadBalancerClient(t)
+		workRequestsWatcher := NewMockworkRequestsWatcher(t)
+		ociClient.EXPECT().
+			DeleteBackend(t.Context(), mock.Anything).
+			Return(networkloadbalancer.DeleteBackendResponse{}, ociapi.NewRandomServiceError(
+				ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+			))
+
+		err := syncNetworkLoadBalancerBackends(
+			t.Context(),
+			ociClient,
+			workRequestsWatcher,
+			&networkloadbalancer.NetworkLoadBalancer{
+				Id: &nlbID,
+				BackendSets: map[string]networkloadbalancer.BackendSet{
+					backendSetName: {Backends: []networkloadbalancer.Backend{backendFromName(deleteName, 1)}},
+				},
+			},
+			backendSetName,
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("creates backend when update target disappears", func(t *testing.T) {
+		fake := faker.New()
+		nlbID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		backendName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		createWorkRequestID := fake.UUID().V4()
+		ociClient := NewMockociNetworkLoadBalancerClient(t)
+		workRequestsWatcher := NewMockworkRequestsWatcher(t)
+		ociClient.EXPECT().
+			UpdateBackend(t.Context(), mock.Anything).
+			Return(networkloadbalancer.UpdateBackendResponse{}, ociapi.NewRandomServiceError(
+				ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+			))
+		ociClient.EXPECT().
+			CreateBackend(t.Context(), mock.Anything).
+			Return(networkloadbalancer.CreateBackendResponse{OpcWorkRequestId: &createWorkRequestID}, nil)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), createWorkRequestID).Return(nil)
+
+		err := syncNetworkLoadBalancerBackends(
+			t.Context(),
+			ociClient,
+			workRequestsWatcher,
+			&networkloadbalancer.NetworkLoadBalancer{
+				Id: &nlbID,
+				BackendSets: map[string]networkloadbalancer.BackendSet{
+					backendSetName: {Backends: []networkloadbalancer.Backend{backendFromName(backendName, 1)}},
+				},
+			},
+			backendSetName,
+			[]networkloadbalancer.BackendDetails{backendDetailsFromName(backendName, 2, false)},
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("returns missing backend work request errors", func(t *testing.T) {
+		fake := faker.New()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		backendName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		assert.ErrorContains(t,
+			waitForNetworkLoadBalancerBackendOperation(t.Context(), nil, nil, "create", backendSetName, backendName),
+			"missing work request id",
+		)
+	})
+
+	t.Run("wraps backend member operation errors", func(t *testing.T) {
+		fake := faker.New()
+		nlbID := "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		backendName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		backend := backendDetailsFromName(backendName, 1, false)
+		createErr := errors.New("create failed")
+		updateErr := errors.New("update failed")
+		deleteErr := errors.New("delete failed")
+
+		createClient := NewMockociNetworkLoadBalancerClient(t)
+		createClient.EXPECT().CreateBackend(t.Context(), mock.Anything).
+			Return(networkloadbalancer.CreateBackendResponse{}, createErr)
+		require.ErrorIs(t,
+			createNetworkLoadBalancerBackend(t.Context(), createClient, nil, &nlbID, backendSetName, backend),
+			createErr,
+		)
+
+		updateClient := NewMockociNetworkLoadBalancerClient(t)
+		updateClient.EXPECT().UpdateBackend(t.Context(), mock.Anything).
+			Return(networkloadbalancer.UpdateBackendResponse{}, updateErr)
+		require.ErrorIs(t,
+			updateNetworkLoadBalancerBackend(
+				t.Context(),
+				updateClient,
+				nil,
+				&nlbID,
+				backendSetName,
+				backendName,
+				backend,
+			),
+			updateErr,
+		)
+
+		deleteClient := NewMockociNetworkLoadBalancerClient(t)
+		deleteClient.EXPECT().DeleteBackend(t.Context(), mock.Anything).
+			Return(networkloadbalancer.DeleteBackendResponse{}, deleteErr)
+		require.ErrorIs(t,
+			deleteNetworkLoadBalancerBackend(t.Context(), deleteClient, nil, &nlbID, backendSetName, backendName),
+			deleteErr,
+		)
+	})
+
+	t.Run("wraps backend work request wait errors", func(t *testing.T) {
+		fake := faker.New()
+		workRequestID := fake.UUID().V4()
+		backendSetName := "bs_" + fake.Lorem().Word()
+		backendName := fmt.Sprintf("%s:%d", fake.Internet().Ipv4(), fake.IntBetween(1024, 65535))
+		wantErr := errors.New("wait failed")
+		workRequestsWatcher := NewMockworkRequestsWatcher(t)
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(wantErr)
+
+		err := waitForNetworkLoadBalancerBackendOperation(
+			t.Context(),
+			workRequestsWatcher,
+			&workRequestID,
+			"create",
+			backendSetName,
+			backendName,
+		)
+
+		require.ErrorIs(t, err, wantErr)
+	})
+}
+
+func backendFromName(name string, weight int) networkloadbalancer.Backend {
+	ipAddress, port := splitNetworkLoadBalancerBackendName(name)
+	return networkloadbalancer.Backend{
+		Name:      new(name),
+		IpAddress: new(ipAddress),
+		Port:      new(port),
+		Weight:    new(weight),
+		IsDrain:   new(false),
+	}
+}
+
+func backendDetailsFromName(name string, weight int, drain bool) networkloadbalancer.BackendDetails {
+	ipAddress, port := splitNetworkLoadBalancerBackendName(name)
+	return networkloadbalancer.BackendDetails{
+		Name:      new(name),
+		IpAddress: new(ipAddress),
+		Port:      new(port),
+		Weight:    new(weight),
+		IsDrain:   new(drain),
+	}
+}
+
+func splitNetworkLoadBalancerBackendName(name string) (string, int) {
+	ipAddress, rawPort, _ := strings.Cut(name, ":")
+	port, _ := strconv.Atoi(rawPort)
+	return ipAddress, port
 }

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -125,6 +125,7 @@ type removeMissingListenersParams struct {
 	loadBalancerID       string
 	knownListeners       map[string]loadbalancer.Listener
 	knownRoutingPolicies map[string]loadbalancer.RoutingPolicy
+	cleanupListenerNames map[string]struct{}
 	gatewayListeners     []gatewayv1.Listener
 }
 
@@ -210,6 +211,7 @@ type ociLoadBalancerModelImpl struct {
 	workRequestsWatcher workRequestsWatcher
 	routingRulesMapper  ociLoadBalancerRoutingRulesMapper
 	routingPolicyLocks  routingPolicyLocks
+	certificateLocks    loadBalancerCertificateLocks
 }
 
 type ensureHTTP2ListenerProtocolParams struct {
@@ -405,7 +407,7 @@ func (m *ociLoadBalancerModelImpl) reconcileDefaultBackendSet(
 	ctx context.Context,
 	params reconcileDefaultBackendParams,
 ) (loadbalancer.BackendSet, error) {
-	defaultBackendSetName := params.gateway.Name + "-default"
+	defaultBackendSetName := gatewayDefaultBackendSetName(*params.gateway)
 	desiredPolicy := "ROUND_ROBIN"
 	desiredHealthChecker := loadBalancerBackendSetHealthChecker(defaultBackendSetPort)
 	if existingBackendSet, ok := params.knownBackendSets[defaultBackendSetName]; ok {
@@ -584,17 +586,36 @@ func (m *ociLoadBalancerModelImpl) reconcileListenerSecretCertificate(
 		return cert, nil
 	}
 
-	cert, err := m.createListenerCertificate(ctx, createListenerCertificateParams{
-		loadBalancerID: params.loadBalancerID,
-		listenerName:   params.listenerSpec.Name,
-		certName:       certName,
-		secret:         secret,
-		caPEM:          caPEM,
-	})
+	cert, err := m.certificateLocks.withLock(
+		loadBalancerCertificateLockKey(params.loadBalancerID, certName),
+		func(cachedCert *loadbalancer.Certificate) (loadbalancer.Certificate, error) {
+			if cachedCert != nil {
+				m.logCertificateAlreadyExists(ctx, params.loadBalancerID, params.listenerSpec.Name, certName, secret)
+				params.resultingCertificates[certName] = *cachedCert
+				return *cachedCert, nil
+			}
+			if cert, ok := params.resultingCertificates[certName]; ok {
+				m.logCertificateAlreadyExists(ctx, params.loadBalancerID, params.listenerSpec.Name, certName, secret)
+				return cert, nil
+			}
+
+			cert, createErr := m.createListenerCertificate(ctx, createListenerCertificateParams{
+				loadBalancerID: params.loadBalancerID,
+				listenerName:   params.listenerSpec.Name,
+				certName:       certName,
+				secret:         secret,
+				caPEM:          caPEM,
+			})
+			if createErr != nil {
+				return loadbalancer.Certificate{}, createErr
+			}
+			params.resultingCertificates[certName] = cert
+			return cert, nil
+		},
+	)
 	if err != nil {
 		return loadbalancer.Certificate{}, err
 	}
-	params.resultingCertificates[certName] = cert
 	return cert, nil
 }
 
@@ -786,7 +807,31 @@ func (m *ociLoadBalancerModelImpl) reconcileListenerRoutingPolicy(
 ) error {
 	listenerName := string(params.listenerSpec.Name)
 	routingPolicyName := listenerPolicyName(listenerName)
+	return m.routingPolicyLocks.withLock(
+		routingPolicyLockKey(params.loadBalancerID, routingPolicyName),
+		func() error {
+			return m.reconcileListenerRoutingPolicyLocked(ctx, params, routingPolicyName, listenerName)
+		},
+	)
+}
+
+func (m *ociLoadBalancerModelImpl) reconcileListenerRoutingPolicyLocked(
+	ctx context.Context,
+	params reconcileHTTPListenerParams,
+	routingPolicyName string,
+	listenerName string,
+) error {
 	policy, ok := params.knownRoutingPolicies[routingPolicyName]
+	if !ok || routingPolicyDefaultRuleDrifted(policy, params.defaultBackendSetName) {
+		refreshedPolicy, found, err := m.getListenerRoutingPolicy(ctx, params.loadBalancerID, routingPolicyName)
+		if err != nil {
+			return err
+		}
+		if found {
+			policy = refreshedPolicy
+			ok = true
+		}
+	}
 
 	if !ok {
 		return m.createListenerRoutingPolicy(ctx, params, routingPolicyName, listenerName)
@@ -802,6 +847,28 @@ func (m *ociLoadBalancerModelImpl) reconcileListenerRoutingPolicy(
 	)
 
 	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) getListenerRoutingPolicy(
+	ctx context.Context,
+	loadBalancerID string,
+	routingPolicyName string,
+) (loadbalancer.RoutingPolicy, bool, error) {
+	routingPolicyRes, err := m.ociClient.GetRoutingPolicy(ctx, loadbalancer.GetRoutingPolicyRequest{
+		LoadBalancerId:    &loadBalancerID,
+		RoutingPolicyName: &routingPolicyName,
+	})
+	if err != nil {
+		if routingPolicyNotFound(err) {
+			return loadbalancer.RoutingPolicy{}, false, nil
+		}
+		return loadbalancer.RoutingPolicy{}, false, fmt.Errorf(
+			"failed to get routing policy %s: %w",
+			routingPolicyName,
+			err,
+		)
+	}
+	return routingPolicyRes.RoutingPolicy, true, nil
 }
 
 func (m *ociLoadBalancerModelImpl) createListenerRoutingPolicy(
@@ -1440,20 +1507,22 @@ func (m *ociLoadBalancerModelImpl) removeOrphanedListenerRoutingPolicies(
 			attachedPolicyNames[*listener.RoutingPolicyName] = struct{}{}
 		}
 	}
+	cleanupPolicyNames := map[string]struct{}{}
+	for listenerName := range params.cleanupListenerNames {
+		cleanupPolicyNames[listenerPolicyName(listenerName)] = struct{}{}
+	}
 
 	var errs []error
 	for policyName := range params.knownRoutingPolicies {
-		if !isControllerManagedListenerPolicyName(policyName) {
-			continue
-		}
 		policy := params.knownRoutingPolicies[policyName]
-		if !isDefaultCatchAllOnlyRoutingPolicy(policy) {
-			continue
-		}
-		if _, desired := desiredPolicyNames[policyName]; desired {
-			continue
-		}
-		if _, attached := attachedPolicyNames[policyName]; attached {
+		if !shouldRemoveOrphanedListenerRoutingPolicy(
+			policyName,
+			policy,
+			desiredPolicyNames,
+			attachedPolicyNames,
+			cleanupPolicyNames,
+			params.cleanupListenerNames != nil,
+		) {
 			continue
 		}
 
@@ -1469,6 +1538,34 @@ func (m *ociLoadBalancerModelImpl) removeOrphanedListenerRoutingPolicies(
 	}
 
 	return errs
+}
+
+func shouldRemoveOrphanedListenerRoutingPolicy(
+	policyName string,
+	policy loadbalancer.RoutingPolicy,
+	desiredPolicyNames map[string]struct{},
+	attachedPolicyNames map[string]struct{},
+	cleanupPolicyNames map[string]struct{},
+	hasCleanupScope bool,
+) bool {
+	if !isControllerManagedListenerPolicyName(policyName) {
+		return false
+	}
+	if hasCleanupScope {
+		if _, shouldCleanup := cleanupPolicyNames[policyName]; !shouldCleanup {
+			return false
+		}
+	}
+	if !isDefaultCatchAllOnlyRoutingPolicy(policy) {
+		return false
+	}
+	if _, desired := desiredPolicyNames[policyName]; desired {
+		return false
+	}
+	if _, attached := attachedPolicyNames[policyName]; attached {
+		return false
+	}
+	return true
 }
 
 func isDefaultCatchAllOnlyRoutingPolicy(policy loadbalancer.RoutingPolicy) bool {
@@ -1493,6 +1590,11 @@ func (m *ociLoadBalancerModelImpl) removeMissingListeners(
 
 	var errs []error
 	for listenerName, listener := range params.knownListeners {
+		if params.cleanupListenerNames != nil {
+			if _, shouldCleanup := params.cleanupListenerNames[listenerName]; !shouldCleanup {
+				continue
+			}
+		}
 		if _, existsInGateway := gatewayListenerNames[listenerName]; !existsInGateway {
 			if err := m.deleteMissingListener(ctx, params.loadBalancerID, listener); err != nil {
 				m.logger.WarnContext(ctx, "Failed to delete listener, will try with others",
@@ -1608,6 +1710,62 @@ func (l *routingPolicyLocks) release(key string, lock *routingPolicyLock) {
 	}
 }
 
+type loadBalancerCertificateLocks struct {
+	mu    sync.Mutex
+	locks map[string]*loadBalancerCertificateLock
+}
+
+type loadBalancerCertificateLock struct {
+	mu          sync.Mutex
+	refs        int
+	certificate *loadbalancer.Certificate
+}
+
+func (l *loadBalancerCertificateLocks) withLock(
+	key string,
+	operation func(cachedCert *loadbalancer.Certificate) (loadbalancer.Certificate, error),
+) (loadbalancer.Certificate, error) {
+	lock := l.acquire(key)
+	lock.mu.Lock()
+	defer func() {
+		lock.mu.Unlock()
+		l.release(key, lock)
+	}()
+
+	cert, err := operation(lock.certificate)
+	if err != nil {
+		return loadbalancer.Certificate{}, err
+	}
+	lock.certificate = &cert
+	return cert, nil
+}
+
+func (l *loadBalancerCertificateLocks) acquire(key string) *loadBalancerCertificateLock {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.locks == nil {
+		l.locks = make(map[string]*loadBalancerCertificateLock)
+	}
+	lock := l.locks[key]
+	if lock == nil {
+		lock = &loadBalancerCertificateLock{}
+		l.locks[key] = lock
+	}
+	lock.refs++
+	return lock
+}
+
+func (l *loadBalancerCertificateLocks) release(key string, lock *loadBalancerCertificateLock) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	lock.refs--
+	if lock.refs == 0 && l.locks[key] == lock {
+		delete(l.locks, key)
+	}
+}
+
 func (m *ociLoadBalancerModelImpl) commitRoutingPolicy(
 	ctx context.Context,
 	params commitRoutingPolicyParams,
@@ -1631,6 +1789,9 @@ func (m *ociLoadBalancerModelImpl) commitRoutingPolicyLocked(
 		LoadBalancerId:    &params.loadBalancerID,
 	})
 	if err != nil {
+		if routingPolicyNotFound(err) {
+			return m.createMissingCommittedRoutingPolicy(ctx, params, policyName)
+		}
 		return fmt.Errorf("failed to get routing policy %s: %w", policyName, err)
 	}
 
@@ -1661,6 +1822,10 @@ func (m *ociLoadBalancerModelImpl) commitRoutingPolicyLocked(
 
 	mergedRules := lo.Values(currentRulesByName)
 	sortRoutingRules(mergedRules)
+
+	if len(mergedRules) == 0 {
+		return m.deleteMissingRoutingPolicy(ctx, params.loadBalancerID, &policyName)
+	}
 
 	if routingRulesEqual(policyResponse.RoutingPolicy.Rules, mergedRules) {
 		m.logger.DebugContext(ctx, "Routing policy already up to date, skipping update",
@@ -1707,8 +1872,58 @@ func (m *ociLoadBalancerModelImpl) commitRoutingPolicyLocked(
 	return nil
 }
 
+func (m *ociLoadBalancerModelImpl) createMissingCommittedRoutingPolicy(
+	ctx context.Context,
+	params commitRoutingPolicyParams,
+	policyName string,
+) error {
+	if len(params.policyRules) == 0 {
+		m.logger.InfoContext(ctx, "Routing policy already deleted, skipping commit",
+			slog.String("loadBalancerId", params.loadBalancerID),
+			slog.String("routingPolicyName", policyName),
+		)
+		return nil
+	}
+
+	rules := slices.Clone(params.policyRules)
+	sortRoutingRules(rules)
+
+	m.logger.InfoContext(ctx, "Creating missing routing policy during route commit",
+		slog.String("loadBalancerId", params.loadBalancerID),
+		slog.String("routingPolicyName", policyName),
+	)
+
+	createRes, err := m.ociClient.CreateRoutingPolicy(ctx, loadbalancer.CreateRoutingPolicyRequest{
+		LoadBalancerId: &params.loadBalancerID,
+		CreateRoutingPolicyDetails: loadbalancer.CreateRoutingPolicyDetails{
+			Name:                     &policyName,
+			ConditionLanguageVersion: loadbalancer.CreateRoutingPolicyDetailsConditionLanguageVersionV1,
+			Rules:                    rules,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create routing policy %s: %w", policyName, err)
+	}
+	if createRes.OpcWorkRequestId == nil {
+		return fmt.Errorf("failed to create routing policy %s: missing work request id", policyName)
+	}
+	if err = m.workRequestsWatcher.WaitFor(ctx, *createRes.OpcWorkRequestId); err != nil {
+		return fmt.Errorf("failed to wait for routing policy %s creation: %w", policyName, err)
+	}
+	return nil
+}
+
+func routingPolicyNotFound(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	return ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound
+}
+
 func routingPolicyLockKey(loadBalancerID, policyName string) string {
 	return loadBalancerID + "/" + policyName
+}
+
+func loadBalancerCertificateLockKey(loadBalancerID, certificateName string) string {
+	return loadBalancerID + "/" + certificateName
 }
 
 func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
@@ -1725,7 +1940,10 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 	)
 	previouslyProgrammedCertificates = append(
 		previouslyProgrammedCertificates,
-		knownFrontendMTLSCertificateNames(params.knownCertificates, params.desiredCertificates)...,
+		knownFrontendMTLSCertificateNames(
+			params.knownCertificates,
+			append(params.desiredCertificates, previouslyProgrammedCertificates...),
+		)...,
 	)
 
 	for _, certName := range normalizeProgrammedCertificateNames(previouslyProgrammedCertificates) {

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -1946,6 +1946,7 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 		)...,
 	)
 
+	var cleanupErrs []error
 	for _, certName := range normalizeProgrammedCertificateNames(previouslyProgrammedCertificates) {
 		if _, isDesired := desiredCertificates[certName]; isDesired {
 			continue
@@ -1971,6 +1972,7 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 				slog.String("certificateName", certName),
 				slog.String("loadBalancerId", params.loadBalancerID),
 			)
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("failed to delete certificate %s: %w", certName, err))
 			continue
 		}
 		if resp.OpcWorkRequestId == nil {
@@ -1978,6 +1980,10 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 				slog.String("certificateName", certName),
 				slog.String("loadBalancerId", params.loadBalancerID),
 			)
+			cleanupErrs = append(cleanupErrs, fmt.Errorf(
+				"failed to delete certificate %s: missing work request id",
+				certName,
+			))
 			continue
 		}
 
@@ -1987,6 +1993,11 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 				slog.String("loadBalancerId", params.loadBalancerID),
 				slog.String("certificateName", certName),
 			)
+			cleanupErrs = append(cleanupErrs, fmt.Errorf(
+				"failed to wait for certificate %s deletion: %w",
+				certName,
+				err,
+			))
 			continue
 		}
 
@@ -1998,6 +2009,9 @@ func (m *ociLoadBalancerModelImpl) removeUnusedCertificates(
 
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("failed to remove unused certificates: %w", err)
+	}
+	if len(cleanupErrs) > 0 {
+		return errors.Join(cleanupErrs...)
 	}
 
 	return nil

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -4839,7 +4839,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			ociLoadBalancerClient.AssertNotCalled(t, "DeleteCertificate")
 		})
 
-		t.Run("continues when certificate delete has no work request id", func(t *testing.T) {
+		t.Run("returns error when only certificate delete has no work request id", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
@@ -4870,10 +4870,37 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			err := model.removeUnusedCertificates(t.Context(), params)
 
-			require.NoError(t, err)
+			require.ErrorContains(t, err, "missing work request id")
 		})
 
-		t.Run("continues deletion even if one fails", func(t *testing.T) {
+		t.Run("returns error when certificate delete has no work request id", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			unusedCert := makeManagedCertificate("default", "unused", fake.UUID().V4())
+			params := removeUnusedCertificatesParams{
+				loadBalancerID: fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(unusedCert.CertificateName),
+				},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					lo.FromPtr(unusedCert.CertificateName): unusedCert,
+				},
+			}
+
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: unusedCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{}, nil).Once()
+
+			err := model.removeUnusedCertificates(t.Context(), params)
+
+			require.ErrorContains(t, err, "missing work request id")
+		})
+
+		t.Run("continues deletion even if one fails and returns error", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
@@ -4932,10 +4959,38 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
 
 			err := model.removeUnusedCertificates(t.Context(), params)
-			require.NoError(t, err)
+			require.ErrorIs(t, err, wantErr)
 		})
 
-		t.Run("handles wait failure", func(t *testing.T) {
+		t.Run("returns error when certificate delete fails", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			unusedCert := makeManagedCertificate("default", "unused", fake.UUID().V4())
+			params := removeUnusedCertificatesParams{
+				loadBalancerID: fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(unusedCert.CertificateName),
+				},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					lo.FromPtr(unusedCert.CertificateName): unusedCert,
+				},
+			}
+
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: unusedCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{}, wantErr).Once()
+
+			err := model.removeUnusedCertificates(t.Context(), params)
+
+			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("returns error when certificate delete wait fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
@@ -4978,7 +5033,40 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(wantErr).Once()
 
 			err := model.removeUnusedCertificates(t.Context(), params)
-			require.NoError(t, err)
+			require.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("returns error when only certificate delete wait fails", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			unusedCert := makeManagedCertificate("default", "unused", fake.UUID().V4())
+			params := removeUnusedCertificatesParams{
+				loadBalancerID: fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{
+					lo.FromPtr(unusedCert.CertificateName),
+				},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					lo.FromPtr(unusedCert.CertificateName): unusedCert,
+				},
+			}
+
+			workRequestID := fake.UUID().V4()
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: unusedCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{
+				OpcWorkRequestId: &workRequestID,
+			}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(wantErr).Once()
+
+			err := model.removeUnusedCertificates(t.Context(), params)
+
+			require.ErrorIs(t, err, wantErr)
 		})
 	})
 }

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 	"maps"
 	"math/rand/v2"
+	"net/http"
 	"slices"
 	"sort"
 	"strings"
@@ -849,6 +850,114 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			assert.Contains(t, gotResult.reconciledCertificates, certName)
 		})
 
+		t.Run("serializes concurrent missing certificate creation", func(t *testing.T) {
+			fakeData := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			secretName := gatewayv1.ObjectName("tls-secret-" + fakeData.Lorem().Word())
+			secretNamespace := gatewayv1.Namespace("tls-ns-" + fakeData.Lorem().Word())
+			listener := makeRandomListener(
+				randomListenerWithHTTPSParamsOpt(),
+				func(l *gatewayv1.Listener) {
+					l.TLS.CertificateRefs = []gatewayv1.SecretObjectReference{{
+						Name:      secretName,
+						Namespace: &secretNamespace,
+					}}
+				},
+			)
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(listener))
+			ref := listener.TLS.CertificateRefs[0]
+			secret := makeRandomSecret(randomSecretWithTLSDataOpt())
+			certName := ociCertificateNameFromSecret(secret)
+			loadBalancerID := fakeData.UUID().V4()
+			workRequestID := fakeData.UUID().V4()
+
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			setupClientGet(t, k8sClient, types.NamespacedName{
+				Namespace: string(lo.FromPtr(ref.Namespace)),
+				Name:      string(ref.Name),
+			}, secret).Twice()
+
+			createStarted := make(chan struct{})
+			releaseCreate := make(chan struct{})
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			ociLoadBalancerClient.EXPECT().CreateCertificate(t.Context(), loadbalancer.CreateCertificateRequest{
+				LoadBalancerId: &loadBalancerID,
+				CreateCertificateDetails: loadbalancer.CreateCertificateDetails{
+					CertificateName:   &certName,
+					PublicCertificate: new(string(secret.Data[corev1.TLSCertKey])),
+					PrivateKey:        new(string(secret.Data[corev1.TLSPrivateKeyKey])),
+				},
+			}).RunAndReturn(func(
+				context.Context,
+				loadbalancer.CreateCertificateRequest,
+			) (loadbalancer.CreateCertificateResponse, error) {
+				close(createStarted)
+				<-releaseCreate
+				return loadbalancer.CreateCertificateResponse{OpcWorkRequestId: &workRequestID}, nil
+			}).Once()
+
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			reconcile := func() error {
+				result, err := model.reconcileListenersCertificates(t.Context(), reconcileListenersCertificatesParams{
+					loadBalancerID:    loadBalancerID,
+					gateway:           gateway,
+					knownCertificates: map[string]loadbalancer.Certificate{},
+				})
+				if err != nil {
+					return err
+				}
+				gotCerts := result.certificatesByListener[string(listener.Name)]
+				if len(gotCerts) != 1 || lo.FromPtr(gotCerts[0].CertificateName) != certName {
+					return fmt.Errorf("unexpected listener certificates: %#v", gotCerts)
+				}
+				return nil
+			}
+
+			errs := make(chan error, 2)
+			go func() {
+				errs <- reconcile()
+			}()
+			select {
+			case <-createStarted:
+			case <-time.After(time.Second):
+				require.Fail(t, "timed out waiting for first certificate create")
+			}
+			go func() {
+				errs <- reconcile()
+			}()
+
+			lockKey := loadBalancerCertificateLockKey(loadBalancerID, certName)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				model.certificateLocks.mu.Lock()
+				defer model.certificateLocks.mu.Unlock()
+
+				lock := model.certificateLocks.locks[lockKey]
+				if assert.NotNil(collect, lock) {
+					assert.Equal(collect, 2, lock.refs)
+				}
+			}, time.Second, 10*time.Millisecond)
+
+			close(releaseCreate)
+
+			for range 2 {
+				select {
+				case err := <-errs:
+					require.NoError(t, err)
+				case <-time.After(time.Second):
+					require.Fail(t, "timed out waiting for certificate reconciliation")
+				}
+			}
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				model.certificateLocks.mu.Lock()
+				defer model.certificateLocks.mu.Unlock()
+				assert.Empty(collect, model.certificateLocks.locks)
+			}, time.Second, 10*time.Millisecond)
+		})
+
 		t.Run("fails when secret get fails", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := newOciLoadBalancerModel(deps)
@@ -1254,6 +1363,11 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
 			routingPolicyWorkRequestID := fake.UUID().V4()
 
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
 			ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(t.Context(), loadbalancer.CreateRoutingPolicyRequest{
 				LoadBalancerId: &params.loadBalancerID,
 				CreateRoutingPolicyDetails: loadbalancer.CreateRoutingPolicyDetails{
@@ -1339,6 +1453,11 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			routingPolicyName := listenerPolicyName(string(gwListener.Name))
 			routingPolicyWorkRequestID := fake.UUID().V4()
 
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
 			ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(t.Context(), loadbalancer.CreateRoutingPolicyRequest{
 				LoadBalancerId: &params.loadBalancerID,
 				CreateRoutingPolicyDetails: loadbalancer.CreateRoutingPolicyDetails{
@@ -1480,6 +1599,108 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
 		})
 
+		t.Run("uses routing policy created after load balancer snapshot", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
+			params := reconcileHTTPListenerParams{
+				loadBalancerID:        fake.UUID().V4(),
+				knownListeners:        map[string]loadbalancer.Listener{},
+				knownRoutingPolicies:  map[string]loadbalancer.RoutingPolicy{},
+				defaultBackendSetName: defaultBackendSetName,
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			listenerWorkRequestID := fake.UUID().V4()
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
+			}, nil)
+			ociLoadBalancerClient.EXPECT().CreateListener(t.Context(), loadbalancer.CreateListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				CreateListenerDetails: loadbalancer.CreateListenerDetails{
+					Name:                  new(string(gwListener.Name)),
+					Port:                  new(int(gwListener.Port)),
+					Protocol:              new("HTTP"),
+					DefaultBackendSetName: new(params.defaultBackendSetName),
+					RoutingPolicyName:     new(routingPolicyName),
+				},
+			}).Return(loadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: &listenerWorkRequestID,
+			}, nil)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), listenerWorkRequestID).Return(nil)
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.NoError(t, err)
+			ociLoadBalancerClient.AssertNotCalled(t, "CreateRoutingPolicy")
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
+		})
+
+		t.Run("uses refreshed routing policy when snapshot default rule is stale", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			gwListener := makeRandomListener(
+				randomListenerWithHTTPProtocolOpt(),
+			)
+
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			defaultBackendSetName := fake.UUID().V4()
+			params := reconcileHTTPListenerParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					fake.UUID().V4(): makeRandomOCIListener(),
+				},
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					routingPolicyName: makeMatchingRoutingPolicy(routingPolicyName, "wrong-"+fake.UUID().V4()),
+				},
+				defaultBackendSetName: defaultBackendSetName,
+				listenerSpec:          &gwListener,
+			}
+
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+			listenerWorkRequestID := fake.UUID().V4()
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: makeMatchingRoutingPolicy(routingPolicyName, defaultBackendSetName),
+			}, nil)
+			ociLoadBalancerClient.EXPECT().CreateListener(t.Context(), loadbalancer.CreateListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				CreateListenerDetails: loadbalancer.CreateListenerDetails{
+					Name:                  new(string(gwListener.Name)),
+					Port:                  new(int(gwListener.Port)),
+					Protocol:              new("HTTP"),
+					DefaultBackendSetName: new(params.defaultBackendSetName),
+					RoutingPolicyName:     new(routingPolicyName),
+				},
+			}).Return(loadbalancer.CreateListenerResponse{
+				OpcWorkRequestId: &listenerWorkRequestID,
+			}, nil)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), listenerWorkRequestID).Return(nil)
+
+			err := model.reconcileHTTPListener(t.Context(), params)
+
+			require.NoError(t, err)
+			ociLoadBalancerClient.AssertNotCalled(t, "CreateRoutingPolicy")
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
+		})
+
 		t.Run("does not create routing policy when frontend mTLS validation fails", func(t *testing.T) {
 			fakeData := faker.New()
 			deps := makeMockDeps(t)
@@ -1557,6 +1778,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
 			ociLoadBalancerClient.EXPECT().
 				CreateRoutingPolicy(t.Context(), mock.Anything).
 				Return(loadbalancer.CreateRoutingPolicyResponse{}, nil)
@@ -1605,6 +1832,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			policyWorkRequestID := fake.UUID().V4()
 			listenerWorkRequestID := fake.UUID().V4()
 
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: existingPolicy,
+			}, nil)
 			ociLoadBalancerClient.EXPECT().UpdateRoutingPolicy(
 				t.Context(),
 				mock.MatchedBy(func(req loadbalancer.UpdateRoutingPolicyRequest) bool {
@@ -1680,6 +1913,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			policyWorkRequestID := fake.UUID().V4()
 			listenerWorkRequestID := fake.UUID().V4()
 
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: existingPolicy,
+			}, nil)
 			ociLoadBalancerClient.EXPECT().UpdateRoutingPolicy(
 				t.Context(),
 				mock.MatchedBy(func(req loadbalancer.UpdateRoutingPolicyRequest) bool {
@@ -1740,6 +1979,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			}
 
 			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: existingPolicy,
+			}, nil)
 			ociLoadBalancerClient.EXPECT().
 				UpdateRoutingPolicy(t.Context(), mock.Anything).
 				Return(loadbalancer.UpdateRoutingPolicyResponse{}, nil)
@@ -1771,6 +2016,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
 			wantErr := errors.New(fake.Lorem().Sentence(10))
 
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
 			ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(t.Context(), mock.Anything).
 				Return(loadbalancer.CreateRoutingPolicyResponse{}, wantErr)
 
@@ -1802,6 +2053,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			routingPolicyWorkRequestID := fake.UUID().V4()
 			wantErr := errors.New(fake.Lorem().Sentence(10))
 
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
 			ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(t.Context(), mock.Anything).
 				Return(loadbalancer.CreateRoutingPolicyResponse{
 					OpcWorkRequestId: &routingPolicyWorkRequestID,
@@ -1838,6 +2095,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			routingPolicyWorkRequestID := fake.UUID().V4()
 
 			// Expect routing policy creation to succeed
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
 			ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(t.Context(), mock.Anything).
 				Return(loadbalancer.CreateRoutingPolicyResponse{
 					OpcWorkRequestId: &routingPolicyWorkRequestID,
@@ -1879,6 +2142,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			routingPolicyWorkRequestID := fake.UUID().V4()
 
 			// Expect routing policy creation to succeed
+			routingPolicyName := listenerPolicyName(string(gwListener.Name))
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &routingPolicyName,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
 			ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(t.Context(), mock.Anything).
 				Return(loadbalancer.CreateRoutingPolicyResponse{
 					OpcWorkRequestId: &routingPolicyWorkRequestID,
@@ -2397,6 +2666,71 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("preserves listeners that are outside cleanup scope", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			currentListener := makeRandomListener()
+			currentOCIListener := makeRandomOCIListener(func(l *loadbalancer.Listener) {
+				l.Name = new(string(currentListener.Name))
+			})
+			scopedStaleListener := makeRandomOCIListener()
+			otherGatewayListener := makeRandomOCIListener()
+
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					lo.FromPtr(currentOCIListener.Name):   currentOCIListener,
+					lo.FromPtr(scopedStaleListener.Name):  scopedStaleListener,
+					lo.FromPtr(otherGatewayListener.Name): otherGatewayListener,
+				},
+				cleanupListenerNames: map[string]struct{}{
+					lo.FromPtr(currentOCIListener.Name):  {},
+					lo.FromPtr(scopedStaleListener.Name): {},
+				},
+				gatewayListeners: []gatewayv1.Listener{
+					currentListener,
+				},
+			}
+
+			workRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteListener(t.Context(), loadbalancer.DeleteListenerRequest{
+				LoadBalancerId: &params.loadBalancerID,
+				ListenerName:   scopedStaleListener.Name,
+			}).Return(loadbalancer.DeleteListenerResponse{OpcWorkRequestId: &workRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			err := model.removeMissingListeners(t.Context(), params)
+
+			require.NoError(t, err)
+		})
+
+		t.Run("preserves all listeners when cleanup scope is empty", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+
+			currentOCIListener := makeRandomOCIListener()
+			otherGatewayListener := makeRandomOCIListener()
+
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownListeners: map[string]loadbalancer.Listener{
+					lo.FromPtr(currentOCIListener.Name):   currentOCIListener,
+					lo.FromPtr(otherGatewayListener.Name): otherGatewayListener,
+				},
+				cleanupListenerNames: map[string]struct{}{},
+				gatewayListeners:     nil,
+			}
+
+			err := model.removeMissingListeners(t.Context(), params)
+
+			require.NoError(t, err)
+		})
+
 		t.Run("removes stale ListenerSet derived listeners", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -2585,6 +2919,50 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			workRequestsWatcher.EXPECT().WaitFor(t.Context(), deleteRTMPSPolicyRequestID).Return(nil).Once()
 
 			err := model.removeMissingListeners(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("preserves orphaned routing policies outside cleanup scope", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			scopedListenerName := "scoped-" + fake.Lorem().Word()
+			otherGatewayListenerName := "other-" + fake.Lorem().Word()
+			scopedPolicyName := listenerPolicyName(scopedListenerName)
+			otherGatewayPolicyName := listenerPolicyName(otherGatewayListenerName)
+			defaultRule := loadbalancer.RoutingRule{
+				Name:      new(defaultCatchAllRuleName),
+				Condition: new("any(http.request.url.path sw '/')"),
+			}
+			params := removeMissingListenersParams{
+				loadBalancerID: fake.UUID().V4(),
+				knownRoutingPolicies: map[string]loadbalancer.RoutingPolicy{
+					scopedPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &scopedPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+					otherGatewayPolicyName: makeRandomOCIRoutingPolicy(func(p *loadbalancer.RoutingPolicy) {
+						p.Name = &otherGatewayPolicyName
+						p.Rules = []loadbalancer.RoutingRule{defaultRule}
+					}),
+				},
+				cleanupListenerNames: map[string]struct{}{
+					scopedListenerName: {},
+				},
+			}
+
+			deletePolicyRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteRoutingPolicy(t.Context(), loadbalancer.DeleteRoutingPolicyRequest{
+				LoadBalancerId:    &params.loadBalancerID,
+				RoutingPolicyName: &scopedPolicyName,
+			}).Return(loadbalancer.DeleteRoutingPolicyResponse{OpcWorkRequestId: &deletePolicyRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), deletePolicyRequestID).Return(nil).Once()
+
+			err := model.removeMissingListeners(t.Context(), params)
+
 			require.NoError(t, err)
 		})
 
@@ -3163,6 +3541,186 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 	})
 
 	t.Run("commitRoutingPolicy", func(t *testing.T) {
+		t.Run("creates missing routing policy with desired rules", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			loadBalancerID := fake.UUID().V4()
+			listenerName := fake.UUID().V4()
+			policyName := listenerPolicyName(listenerName)
+			workRequestID := fake.UUID().V4()
+			newRules := []loadbalancer.RoutingRule{
+				makeRandomOCIRoutingRule(),
+				makeRandomOCIRoutingRule(),
+			}
+			wantRules := slices.Clone(newRules)
+			sortRoutingRules(wantRules)
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				RoutingPolicyName: new(policyName),
+				LoadBalancerId:    &loadBalancerID,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
+			ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(
+				t.Context(),
+				mock.MatchedBy(func(req loadbalancer.CreateRoutingPolicyRequest) bool {
+					require.Equal(t, loadBalancerID, lo.FromPtr(req.LoadBalancerId))
+					require.Equal(t, policyName, lo.FromPtr(req.CreateRoutingPolicyDetails.Name))
+					require.Equal(
+						t,
+						loadbalancer.CreateRoutingPolicyDetailsConditionLanguageVersionV1,
+						req.CreateRoutingPolicyDetails.ConditionLanguageVersion,
+					)
+					require.Equal(t, wantRules, req.CreateRoutingPolicyDetails.Rules)
+					return true
+				}),
+			).Return(loadbalancer.CreateRoutingPolicyResponse{OpcWorkRequestId: &workRequestID}, nil)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil)
+
+			err := model.commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID: loadBalancerID,
+				listenerName:   listenerName,
+				policyRules:    newRules,
+			})
+
+			require.NoError(t, err)
+		})
+
+		t.Run("ignores missing routing policy with no desired rules", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			listenerName := fake.UUID().V4()
+			policyName := listenerPolicyName(listenerName)
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				RoutingPolicyName: new(policyName),
+				LoadBalancerId:    &loadBalancerID,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{},
+				ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
+
+			err := model.commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID: loadBalancerID,
+				listenerName:   listenerName,
+			})
+
+			require.NoError(t, err)
+			ociLoadBalancerClient.AssertNotCalled(t, "CreateRoutingPolicy")
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
+		})
+
+		t.Run("returns missing routing policy create errors", func(t *testing.T) {
+			fake := faker.New()
+			for name, tc := range map[string]struct {
+				setup func(
+					*testing.T,
+					*MockociLoadBalancerClient,
+					*MockworkRequestsWatcher,
+					string,
+					string,
+					error,
+				)
+				wantContains string
+			}{
+				"create fails": {
+					setup: func(
+						t *testing.T,
+						ociLoadBalancerClient *MockociLoadBalancerClient,
+						_ *MockworkRequestsWatcher,
+						loadBalancerID string,
+						policyName string,
+						wantErr error,
+					) {
+						ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(
+							t.Context(),
+							mock.MatchedBy(func(req loadbalancer.CreateRoutingPolicyRequest) bool {
+								return lo.FromPtr(req.LoadBalancerId) == loadBalancerID &&
+									lo.FromPtr(req.CreateRoutingPolicyDetails.Name) == policyName
+							}),
+						).Return(loadbalancer.CreateRoutingPolicyResponse{}, wantErr)
+					},
+					wantContains: "failed to create routing policy",
+				},
+				"create returns no work request": {
+					setup: func(
+						t *testing.T,
+						ociLoadBalancerClient *MockociLoadBalancerClient,
+						_ *MockworkRequestsWatcher,
+						loadBalancerID string,
+						policyName string,
+						_ error,
+					) {
+						ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(
+							t.Context(),
+							mock.MatchedBy(func(req loadbalancer.CreateRoutingPolicyRequest) bool {
+								return lo.FromPtr(req.LoadBalancerId) == loadBalancerID &&
+									lo.FromPtr(req.CreateRoutingPolicyDetails.Name) == policyName
+							}),
+						).Return(loadbalancer.CreateRoutingPolicyResponse{}, nil)
+					},
+					wantContains: "missing work request id",
+				},
+				"wait fails": {
+					setup: func(
+						t *testing.T,
+						ociLoadBalancerClient *MockociLoadBalancerClient,
+						workRequestsWatcher *MockworkRequestsWatcher,
+						loadBalancerID string,
+						policyName string,
+						wantErr error,
+					) {
+						workRequestID := fake.UUID().V4()
+						ociLoadBalancerClient.EXPECT().CreateRoutingPolicy(
+							t.Context(),
+							mock.MatchedBy(func(req loadbalancer.CreateRoutingPolicyRequest) bool {
+								return lo.FromPtr(req.LoadBalancerId) == loadBalancerID &&
+									lo.FromPtr(req.CreateRoutingPolicyDetails.Name) == policyName
+							}),
+						).Return(loadbalancer.CreateRoutingPolicyResponse{OpcWorkRequestId: &workRequestID}, nil)
+						workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(wantErr)
+					},
+					wantContains: "failed to wait for routing policy",
+				},
+			} {
+				t.Run(name, func(t *testing.T) {
+					deps := makeMockDeps(t)
+					model := newOciLoadBalancerModel(deps)
+					ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+					workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+					loadBalancerID := fake.UUID().V4()
+					listenerName := fake.UUID().V4()
+					policyName := listenerPolicyName(listenerName)
+					wantErr := errors.New(fake.Lorem().Sentence(10))
+
+					ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+						RoutingPolicyName: new(policyName),
+						LoadBalancerId:    &loadBalancerID,
+					}).Return(loadbalancer.GetRoutingPolicyResponse{},
+						ociapi.NewRandomServiceError(ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound)))
+					tc.setup(t, ociLoadBalancerClient, workRequestsWatcher, loadBalancerID, policyName, wantErr)
+
+					err := model.commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+						loadBalancerID: loadBalancerID,
+						listenerName:   listenerName,
+						policyRules:    []loadbalancer.RoutingRule{makeRandomOCIRoutingRule()},
+					})
+
+					require.Error(t, err)
+					require.ErrorContains(t, err, tc.wantContains)
+					if name != "create returns no work request" {
+						require.ErrorIs(t, err, wantErr)
+					}
+				})
+			}
+		})
+
 		t.Run("successfully merge and update routing policy", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)
@@ -3397,6 +3955,51 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 
 			err := model.commitRoutingPolicy(t.Context(), params)
 			require.NoError(t, err)
+		})
+
+		t.Run("deletes routing policy when removing previous rules leaves it empty", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			loadBalancerID := fake.UUID().V4()
+			listenerName := fake.UUID().V4()
+			policyName := listenerPolicyName(listenerName)
+			previousRule := loadbalancer.RoutingRule{
+				Name:      new("route-" + fake.Lorem().Word()),
+				Condition: new("any(http.request.url.path sw '/')"),
+			}
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				RoutingPolicyName: new(policyName),
+				LoadBalancerId:    &loadBalancerID,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: loadbalancer.RoutingPolicy{
+					Name:                     new(policyName),
+					Rules:                    []loadbalancer.RoutingRule{previousRule},
+					ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+				},
+			}, nil)
+
+			workRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteRoutingPolicy(t.Context(), loadbalancer.DeleteRoutingPolicyRequest{
+				LoadBalancerId:    &loadBalancerID,
+				RoutingPolicyName: &policyName,
+			}).Return(loadbalancer.DeleteRoutingPolicyResponse{
+				OpcWorkRequestId: &workRequestID,
+			}, nil)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil)
+
+			err := model.commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  loadBalancerID,
+				listenerName:    listenerName,
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{lo.FromPtr(previousRule.Name)},
+			})
+			require.NoError(t, err)
+			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
 		})
 
 		t.Run("orders grpc rules before http rules and default catch all", func(t *testing.T) {
@@ -4126,6 +4729,47 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				CertificateName: staleFrontendMTLSCert.CertificateName,
 			}).Return(loadbalancer.DeleteCertificateResponse{OpcWorkRequestId: &workRequestID}, nil).Once()
 			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+			err := model.removeUnusedCertificates(t.Context(), params)
+			require.NoError(t, err)
+		})
+
+		t.Run("removes frontend mTLS certificate aliases for previously programmed certificates", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			previousCert := makeManagedCertificate("default", "gateway-tls", fake.UUID().V4())
+			previousCertName := lo.FromPtr(previousCert.CertificateName)
+			frontendMTLSCert := makeRandomOCICertificate()
+			frontendMTLSCertName := previousCertName + "-fmtls-19443-" + fake.RandomStringWithLength(8)
+			frontendMTLSCert.CertificateName = &frontendMTLSCertName
+
+			params := removeUnusedCertificatesParams{
+				loadBalancerID:                   fake.UUID().V4(),
+				previouslyProgrammedCertificates: []string{previousCertName},
+				knownCertificates: map[string]loadbalancer.Certificate{
+					previousCertName:       previousCert,
+					frontendMTLSCertName:   frontendMTLSCert,
+					fake.UUID().V4() + "x": makeRandomOCICertificate(),
+				},
+			}
+
+			previousWorkRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: previousCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{OpcWorkRequestId: &previousWorkRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), previousWorkRequestID).Return(nil).Once()
+
+			frontendMTLSWorkRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().DeleteCertificate(t.Context(), loadbalancer.DeleteCertificateRequest{
+				LoadBalancerId:  &params.loadBalancerID,
+				CertificateName: frontendMTLSCert.CertificateName,
+			}).Return(loadbalancer.DeleteCertificateResponse{OpcWorkRequestId: &frontendMTLSWorkRequestID}, nil).Once()
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), frontendMTLSWorkRequestID).Return(nil).Once()
 
 			err := model.removeUnusedCertificates(t.Context(), params)
 			require.NoError(t, err)

--- a/internal/app/tcproute_model.go
+++ b/internal/app/tcproute_model.go
@@ -527,12 +527,17 @@ func mergeNetworkLoadBalancerBackend(
 	desired map[string]networkloadbalancer.BackendDetails,
 	backend networkloadbalancer.BackendDetails,
 ) {
-	key := fmt.Sprintf("%s:%d", lo.FromPtr(backend.IpAddress), lo.FromPtr(backend.Port))
+	key := networkLoadBalancerBackendKey(backend)
+	backend.Name = new(key)
 	if existing, found := desired[key]; found {
 		backend.Weight = new(lo.FromPtr(existing.Weight) + lo.FromPtr(backend.Weight))
 		backend.IsDrain = new(lo.FromPtr(existing.IsDrain) && lo.FromPtr(backend.IsDrain))
 	}
 	desired[key] = backend
+}
+
+func networkLoadBalancerBackendKey(backend networkloadbalancer.BackendDetails) string {
+	return fmt.Sprintf("%s:%d", lo.FromPtr(backend.IpAddress), lo.FromPtr(backend.Port))
 }
 
 func tcpBackendsEqual(current []networkloadbalancer.Backend, desired []networkloadbalancer.BackendDetails) bool {

--- a/internal/app/tcproute_model_test.go
+++ b/internal/app/tcproute_model_test.go
@@ -1811,6 +1811,58 @@ func TestTCPRouteModel(t *testing.T) {
 		require.ErrorAs(t, err, &busyErr)
 	})
 
+	t.Run("programRoute returns busy error when backend set is not created yet", func(t *testing.T) {
+		port := gatewayv1.PortNumber(1935)
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "rtmp"},
+			Spec: gatewayv1.TCPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{Name: "edge"}},
+				},
+				Rules: []gatewayv1.TCPRouteRule{{
+					BackendRefs: []gatewayv1.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "backend", Port: &port},
+					}},
+				}},
+			},
+		}
+		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: port}
+		objects := append(l4GatewayObjects(listener), &route)
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithRuntimeObjects(objects...).
+			Build()
+		model := newTCPRouteModel(tcpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  k8sClient,
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{},
+				},
+			},
+			OciNetworkLoadBalancerAPI: &stubNetworkLoadBalancerClient{
+				updateBackendSetErr: ociapi.NewRandomServiceError(
+					ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+					ociapi.RandomServiceErrorWithCode("NotAuthorizedOrNotFound"),
+					ociapi.RandomServiceErrorWithMessage("Unknown resource BackendSet bs_rtmp"),
+				),
+			},
+			WorkRequestsWatcher: &stubWorkRequestsWatcher{},
+		})
+
+		err := model.programRoute(t.Context(), resolvedTCPRouteDetails{
+			tcpRoute: route,
+			gatewayDetails: resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "edge"}},
+			},
+			matchedListener: listener,
+		})
+
+		var busyErr *networkLoadBalancerBusyError
+		require.ErrorAs(t, err, &busyErr)
+	})
+
 	t.Run("programRoute returns busy error when NLB is already updating", func(t *testing.T) {
 		port := gatewayv1.PortNumber(1935)
 		listener := gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: port}

--- a/internal/app/udproute_model_test.go
+++ b/internal/app/udproute_model_test.go
@@ -1509,6 +1509,64 @@ func TestUDPRouteModel(t *testing.T) {
 		require.ErrorAs(t, err, &busyErr)
 	})
 
+	t.Run("programRoute returns busy error when backend set is not created yet", func(t *testing.T) {
+		port := gatewayv1.PortNumber(5684)
+		route := gatewayv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "iot",
+				Name:      "coap",
+				Annotations: map[string]string{
+					NetworkLoadBalancerUDPRouteHealthCheckPortAnnotation: "5684",
+				},
+			},
+			Spec: gatewayv1.UDPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{Name: "edge"}},
+				},
+				Rules: []gatewayv1.UDPRouteRule{{
+					BackendRefs: []gatewayv1.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "backend", Port: &port},
+					}},
+				}},
+			},
+		}
+		listener := gatewayv1.Listener{Name: "coap", Protocol: gatewayv1.UDPProtocolType, Port: port}
+		objects := append(l4GatewayObjects(listener), &route)
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithRuntimeObjects(objects...).
+			Build()
+		model := newUDPRouteModel(udpRouteModelDeps{
+			RootLogger: diag.RootTestLogger(),
+			K8sClient:  k8sClient,
+			NetworkLoadBalancerModel: stubNetworkLoadBalancerGatewayModel{
+				networkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+					Id:          new("nlb-id"),
+					BackendSets: map[string]networkloadbalancer.BackendSet{},
+				},
+			},
+			OciNetworkLoadBalancerAPI: &stubNetworkLoadBalancerClient{
+				updateBackendSetErr: ociapi.NewRandomServiceError(
+					ociapi.RandomServiceErrorWithStatusCode(http.StatusNotFound),
+					ociapi.RandomServiceErrorWithCode("NotAuthorizedOrNotFound"),
+					ociapi.RandomServiceErrorWithMessage("Unknown resource BackendSet bs_coap"),
+				),
+			},
+			WorkRequestsWatcher: &stubWorkRequestsWatcher{},
+		})
+
+		err := model.programRoute(t.Context(), resolvedUDPRouteDetails{
+			udpRoute: route,
+			gatewayDetails: resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "edge"}},
+			},
+			matchedListener: listener,
+		})
+
+		var busyErr *networkLoadBalancerBusyError
+		require.ErrorAs(t, err, &busyErr)
+	})
+
 	t.Run("programRoute returns busy error when NLB is already updating", func(t *testing.T) {
 		port := gatewayv1.PortNumber(5684)
 		listener := gatewayv1.Listener{Name: "coap", Protocol: gatewayv1.UDPProtocolType, Port: port}

--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -627,13 +627,6 @@ func (m *WatchesModel) indexGatewayByCertificateSecrets(ctx context.Context, obj
 		return nil
 	}
 
-	if gateway.Annotations == nil || gateway.Annotations[ControllerClassName] != "true" {
-		logger.DebugContext(ctx, "Gateway is not accepted by this controller. Skipping indexing",
-			slog.String("gateway", client.ObjectKeyFromObject(gateway).String()),
-		)
-		return nil
-	}
-
 	uniqueSecretKeys := make(map[string]struct{})
 	for _, listener := range gateway.Spec.Listeners {
 		if (listener.Protocol != gatewayv1.HTTPSProtocolType && listener.Protocol != gatewayv1.TLSProtocolType) ||

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -1608,6 +1608,30 @@ func TestWatchesModel(t *testing.T) {
 			require.ElementsMatch(t, wantIndices, result)
 		})
 
+		t.Run("indexes Gateway before controller acceptance is recorded", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+
+			listener := makeRandomListener(randomListenerWithHTTPSParamsOpt())
+			gateway := newRandomGateway(randomGatewayWithListenersOpt(listener))
+			delete(gateway.Annotations, ControllerClassName)
+
+			wantIndices := lo.Map(
+				listener.TLS.CertificateRefs,
+				func(ref gatewayv1.SecretObjectReference, _ int) string {
+					ns := gateway.Namespace
+					if ref.Namespace != nil {
+						ns = string(*ref.Namespace)
+					}
+					return ns + "/" + string(ref.Name)
+				},
+			)
+
+			result := model.indexGatewayByCertificateSecrets(t.Context(), gateway)
+
+			require.ElementsMatch(t, wantIndices, result)
+		})
+
 		t.Run("ignores non-Gateway objects", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := NewWatchesModel(deps)
@@ -1631,14 +1655,6 @@ func TestWatchesModel(t *testing.T) {
 			gateway := newRandomGateway(withRelevantGatewayClass) // Only HTTP listeners by default
 			result := model.indexGatewayByCertificateSecrets(t.Context(), gateway)
 			require.Empty(t, result)
-		})
-
-		t.Run("ignores Gateways without correct controller class", func(t *testing.T) {
-			deps := makeMockDeps(t)
-			model := NewWatchesModel(deps)
-			gateway := newRandomGateway() // No controller class set
-			result := model.indexGatewayByCertificateSecrets(t.Context(), gateway)
-			require.Nil(t, result)
 		})
 	})
 

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -456,7 +456,10 @@ func gatewayControllerAnnotationChanged(updateEvent event.UpdateEvent) bool {
 
 func gatewayControllerWatchedAnnotations() []string {
 	return []string{
+		app.LoadBalancerGatewayIDAnnotation,
+		app.GatewayProgrammedCertificatesAnnotation,
 		app.LoadBalancerGatewayProgrammedListenersAnnotation,
+		app.NetworkLoadBalancerGatewayIDAnnotation,
 		app.NetworkLoadBalancerGatewayProgrammedListenersAnnotation,
 		app.NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation,
 	}

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -394,7 +394,7 @@ func setupGatewayController(
 		Named("gateway").
 		For(
 			&gatewayv1.Gateway{},
-			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
+			builder.WithPredicates(gatewayObjectPredicate()),
 		).
 		Watches(
 			&corev1.Secret{},
@@ -419,6 +419,40 @@ func setupGatewayController(
 	return controllerBuilder.Complete(wireupReconciler(deps.GatewayCtrl, middlewares...))
 }
 
+func gatewayObjectPredicate() predicate.Funcs {
+	generationChanged := predicate.GenerationChangedPredicate{}
+	labelChanged := predicate.LabelChangedPredicate{}
+	return predicate.Funcs{
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			return generationChanged.Update(updateEvent) ||
+				labelChanged.Update(updateEvent) ||
+				gatewayControllerAnnotationChanged(updateEvent)
+		},
+	}
+}
+
+func gatewayControllerAnnotationChanged(updateEvent event.UpdateEvent) bool {
+	if updateEvent.ObjectOld == nil || updateEvent.ObjectNew == nil {
+		return false
+	}
+	oldAnnotations := updateEvent.ObjectOld.GetAnnotations()
+	newAnnotations := updateEvent.ObjectNew.GetAnnotations()
+	for _, annotation := range gatewayControllerWatchedAnnotations() {
+		if oldAnnotations[annotation] != newAnnotations[annotation] {
+			return true
+		}
+	}
+	return false
+}
+
+func gatewayControllerWatchedAnnotations() []string {
+	return []string{
+		app.LoadBalancerGatewayProgrammedListenersAnnotation,
+		app.NetworkLoadBalancerGatewayProgrammedListenersAnnotation,
+		app.NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation,
+	}
+}
+
 func setupNetworkLoadBalancerGatewayController(
 	mgr manager.Manager,
 	deps StartManagerDeps,
@@ -430,7 +464,7 @@ func setupNetworkLoadBalancerGatewayController(
 		Named("networkloadbalancer-gateway").
 		For(
 			&gatewayv1.Gateway{},
-			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
+			builder.WithPredicates(gatewayObjectPredicate()),
 		).
 		Watches(
 			&configtypes.GatewayConfig{},

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -426,9 +426,18 @@ func gatewayObjectPredicate() predicate.Funcs {
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
 			return generationChanged.Update(updateEvent) ||
 				labelChanged.Update(updateEvent) ||
+				gatewayDeletionStarted(updateEvent) ||
 				gatewayControllerAnnotationChanged(updateEvent)
 		},
 	}
+}
+
+func gatewayDeletionStarted(updateEvent event.UpdateEvent) bool {
+	if updateEvent.ObjectOld == nil || updateEvent.ObjectNew == nil {
+		return false
+	}
+	return updateEvent.ObjectOld.GetDeletionTimestamp() == nil &&
+		updateEvent.ObjectNew.GetDeletionTimestamp() != nil
 }
 
 func gatewayControllerAnnotationChanged(updateEvent event.UpdateEvent) bool {

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -14,8 +14,80 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/gemyago/oke-gateway-api/internal/app"
 	"github.com/gemyago/oke-gateway-api/internal/diag"
 )
+
+func TestGatewayObjectPredicate(t *testing.T) {
+	fake := faker.New()
+
+	t.Run("accepts removal of controller listener ownership annotation", func(t *testing.T) {
+		oldGateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fake.UUID().V4(),
+				Name:       "gateway-" + fake.UUID().V4(),
+				Generation: 1,
+				Annotations: map[string]string{
+					app.LoadBalancerGatewayProgrammedListenersAnnotation: "https",
+				},
+			},
+		}
+		newGateway := oldGateway.DeepCopy()
+		delete(newGateway.Annotations, app.LoadBalancerGatewayProgrammedListenersAnnotation)
+
+		result := gatewayObjectPredicate().Update(event.UpdateEvent{
+			ObjectOld: oldGateway,
+			ObjectNew: newGateway,
+		})
+
+		assert.True(t, result)
+	})
+
+	t.Run("accepts changes to network load balancer ownership annotations", func(t *testing.T) {
+		oldGateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fake.UUID().V4(),
+				Name:       "gateway-" + fake.UUID().V4(),
+				Generation: 1,
+				Annotations: map[string]string{
+					app.NetworkLoadBalancerGatewayProgrammedListenersAnnotation:   "tcp",
+					app.NetworkLoadBalancerGatewayProgrammedBackendSetsAnnotation: "bs_tcp",
+				},
+			},
+		}
+		newGateway := oldGateway.DeepCopy()
+		newGateway.Annotations[app.NetworkLoadBalancerGatewayProgrammedListenersAnnotation] = "tcp,udp"
+
+		result := gatewayObjectPredicate().Update(event.UpdateEvent{
+			ObjectOld: oldGateway,
+			ObjectNew: newGateway,
+		})
+
+		assert.True(t, result)
+	})
+
+	t.Run("ignores unrelated annotation only updates", func(t *testing.T) {
+		oldGateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fake.UUID().V4(),
+				Name:       "gateway-" + fake.UUID().V4(),
+				Generation: 1,
+				Annotations: map[string]string{
+					"example.com/checksum": "before",
+				},
+			},
+		}
+		newGateway := oldGateway.DeepCopy()
+		newGateway.Annotations["example.com/checksum"] = "after"
+
+		result := gatewayObjectPredicate().Update(event.UpdateEvent{
+			ObjectOld: oldGateway,
+			ObjectNew: newGateway,
+		})
+
+		assert.False(t, result)
+	})
+}
 
 func TestL7RouteObjectPredicate(t *testing.T) {
 	t.Run("accepts annotation only updates", func(t *testing.T) {

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -66,6 +66,52 @@ func TestGatewayObjectPredicate(t *testing.T) {
 		assert.True(t, result)
 	})
 
+	t.Run("accepts removal of cleanup critical ALB annotations", func(t *testing.T) {
+		oldGateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fake.UUID().V4(),
+				Name:       "gateway-" + fake.UUID().V4(),
+				Generation: 1,
+				Annotations: map[string]string{
+					app.LoadBalancerGatewayIDAnnotation:         "ocid1.loadbalancer.oc1.." + fake.UUID().V4(),
+					app.GatewayProgrammedCertificatesAnnotation: "cert-" + fake.UUID().V4(),
+				},
+			},
+		}
+		newGateway := oldGateway.DeepCopy()
+		delete(newGateway.Annotations, app.LoadBalancerGatewayIDAnnotation)
+		delete(newGateway.Annotations, app.GatewayProgrammedCertificatesAnnotation)
+
+		result := gatewayObjectPredicate().Update(event.UpdateEvent{
+			ObjectOld: oldGateway,
+			ObjectNew: newGateway,
+		})
+
+		assert.True(t, result)
+	})
+
+	t.Run("accepts removal of cleanup critical NLB annotations", func(t *testing.T) {
+		oldGateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fake.UUID().V4(),
+				Name:       "gateway-" + fake.UUID().V4(),
+				Generation: 1,
+				Annotations: map[string]string{
+					app.NetworkLoadBalancerGatewayIDAnnotation: "ocid1.networkloadbalancer.oc1.." + fake.UUID().V4(),
+				},
+			},
+		}
+		newGateway := oldGateway.DeepCopy()
+		delete(newGateway.Annotations, app.NetworkLoadBalancerGatewayIDAnnotation)
+
+		result := gatewayObjectPredicate().Update(event.UpdateEvent{
+			ObjectOld: oldGateway,
+			ObjectNew: newGateway,
+		})
+
+		assert.True(t, result)
+	})
+
 	t.Run("accepts deletion timestamp changes", func(t *testing.T) {
 		oldGateway := &gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/k8s/start_manager_test.go
+++ b/internal/k8s/start_manager_test.go
@@ -66,6 +66,26 @@ func TestGatewayObjectPredicate(t *testing.T) {
 		assert.True(t, result)
 	})
 
+	t.Run("accepts deletion timestamp changes", func(t *testing.T) {
+		oldGateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "ns-" + fake.UUID().V4(),
+				Name:       "gateway-" + fake.UUID().V4(),
+				Generation: 1,
+			},
+		}
+		newGateway := oldGateway.DeepCopy()
+		now := metav1.Now()
+		newGateway.DeletionTimestamp = &now
+
+		result := gatewayObjectPredicate().Update(event.UpdateEvent{
+			ObjectOld: oldGateway,
+			ObjectNew: newGateway,
+		})
+
+		assert.True(t, result)
+	})
+
 	t.Run("ignores unrelated annotation only updates", func(t *testing.T) {
 		oldGateway := &gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

Closes #10 

Fixes Gateway-owned OCI resource cleanup when multiple Gateways share the same OCI Load Balancer.

Previously, ALB listener cleanup inferred ownership from the listener default backend set. If a listener from another Gateway drifted to use the current Gateway’s default backend set, the controller could incorrectly delete that other Gateway’s listener during reconciliation.

This change records ALB listener ownership explicitly on the Gateway and scopes listener/routing-policy cleanup to the listeners owned by that Gateway.

## Changes
- Track ALB programmed listeners with a Gateway annotation.
- Use explicit listener ownership for ALB cleanup instead of default backend set matching.
- Scope orphan routing policy cleanup to owned listeners.
- Reconcile Gateway updates when controller-owned ALB/NLB cleanup annotations change.
- Add regression tests for ALB ownership cleanup and Gateway annotation restore behavior.
