### PR TITLE
Reconcile L7 routes when Gateway listeners change

### DIFF
--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -2785,9 +2785,11 @@ func TestGatewayModelImpl(t *testing.T) {
 			mockLBModel.EXPECT().
 				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
 					_, hasListenerSetListener := params.knownListeners[vanishedListenerSetListenerName]
-					_, cleansListenerSetListener := params.cleanupListenerNames[vanishedListenerSetListenerName]
 					return hasListenerSetListener &&
-						cleansListenerSetListener
+						assert.ObjectsAreEqual(
+							map[string]struct{}{vanishedListenerSetListenerName: {}},
+							params.cleanupListenerNames,
+						)
 				})).
 				Return(nil)
 			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -2785,11 +2785,9 @@ func TestGatewayModelImpl(t *testing.T) {
 			mockLBModel.EXPECT().
 				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
 					_, hasListenerSetListener := params.knownListeners[vanishedListenerSetListenerName]
+					_, cleansListenerSetListener := params.cleanupListenerNames[vanishedListenerSetListenerName]
 					return hasListenerSetListener &&
-						assert.ObjectsAreEqual(
-							map[string]struct{}{vanishedListenerSetListenerName: {}},
-							params.cleanupListenerNames,
-						)
+						cleansListenerSetListener
 				})).
 				Return(nil)
 			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -661,6 +661,12 @@ func (m *grpcRouteModelImpl) isProgrammingRequired(details resolvedGRPCRouteDeta
 	if !found {
 		return true
 	}
+	if l7ProgrammedListenersChanged(
+		details.grpcRoute.Annotations[GRPCRouteProgrammedPolicyRulesAnnotation],
+		details.matchedListeners,
+	) {
+		return true
+	}
 
 	return !m.resourcesModel.isConditionSet(isConditionSetParams{
 		resource:      &details.grpcRoute,

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1203,6 +1203,49 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 
 			assert.False(t, got)
 		})
+
+		t.Run("returns true when matched listener set changed", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			deps.ResourcesModel = newResourcesModel(resourcesModelDeps{
+				K8sClient:  deps.K8sClient,
+				RootLogger: diag.RootTestLogger(),
+			})
+			model := newGRPCRouteModel(deps)
+			oldListenerName := gatewayv1.SectionName("old-" + fake.Lorem().Word())
+			newListenerName := gatewayv1.SectionName("new-" + fake.Lorem().Word())
+			gatewayData := makeResolvedGateway(
+				gatewayv1.Listener{Name: oldListenerName, Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+				gatewayv1.Listener{Name: newListenerName, Port: 8443, Protocol: gatewayv1.HTTPSProtocolType},
+			)
+			parentRef := gatewayv1.ParentReference{Name: gatewayv1.ObjectName(gatewayData.gateway.Name)}
+			route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+				route.Generation = 1
+				route.Annotations = map[string]string{
+					GRPCRouteProgrammingRevisionAnnotation:    GRPCRouteProgrammingRevisionValue,
+					GRPCRouteProgrammedPolicyRulesAnnotation:  string(oldListenerName) + "/" + fake.UUID().V4(),
+					L7RouteProgrammedLoadBalancerIDAnnotation: gatewayData.config.Spec.LoadBalancerID,
+				}
+				route.Status.Parents = []gatewayv1.RouteParentStatus{{
+					ParentRef:      parentRef,
+					ControllerName: ControllerClassName,
+					Conditions: []metav1.Condition{{
+						Type:               string(gatewayv1.RouteConditionResolvedRefs),
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: route.Generation,
+					}},
+				}}
+			})
+
+			got := model.isProgrammingRequired(resolvedGRPCRouteDetails{
+				gatewayDetails:   gatewayData,
+				grpcRoute:        route,
+				matchedRef:       parentRef,
+				matchedListeners: gatewayData.gateway.Spec.Listeners,
+			})
+
+			assert.True(t, got)
+		})
 	})
 
 	t.Run("programRoute", func(t *testing.T) {

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -423,6 +423,38 @@ func mergeL7ProgrammedPolicyRules(
 	return merged
 }
 
+func l7ProgrammedListenersChanged(
+	programmedPolicyRulesAnnotation string,
+	matchedListeners []gatewayv1.Listener,
+) bool {
+	if len(matchedListeners) == 0 {
+		return false
+	}
+
+	programmedListenerNames := map[string]struct{}{}
+	for _, rule := range parseProgrammedHTTPRoutePolicyRules(programmedPolicyRulesAnnotation) {
+		if rule.listenerName == "" {
+			continue
+		}
+		programmedListenerNames[rule.listenerName] = struct{}{}
+	}
+
+	matchedListenerNames := map[string]struct{}{}
+	for _, listener := range matchedListeners {
+		matchedListenerNames[string(listener.Name)] = struct{}{}
+	}
+
+	if len(programmedListenerNames) != len(matchedListenerNames) {
+		return true
+	}
+	for listenerName := range matchedListenerNames {
+		if _, found := programmedListenerNames[listenerName]; !found {
+			return true
+		}
+	}
+	return false
+}
+
 func l7RoutesShareListenerHostname(
 	gateway gatewayv1.Gateway,
 	effectiveListeners []effectiveListener,
@@ -1540,6 +1572,12 @@ func (m *httpRouteModelImpl) isProgrammingRequired(
 	})
 
 	if !found {
+		return true, nil
+	}
+	if l7ProgrammedListenersChanged(
+		details.httpRoute.Annotations[HTTPRouteProgrammedPolicyRulesAnnotation],
+		details.matchedListeners,
+	) {
 		return true, nil
 	}
 

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -124,6 +124,62 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 		})
 	})
 
+	t.Run("l7ProgrammedListenersChanged", func(t *testing.T) {
+		fake := faker.New()
+		listenerA := gatewayv1.SectionName("listener-a-" + fake.Lorem().Word())
+		listenerB := gatewayv1.SectionName("listener-b-" + fake.Lorem().Word())
+		ruleA := fake.UUID().V4()
+		ruleB := fake.UUID().V4()
+
+		t.Run("returns false when no listeners are matched", func(t *testing.T) {
+			assert.False(t, l7ProgrammedListenersChanged(
+				string(listenerA)+"/"+ruleA,
+				nil,
+			))
+		})
+
+		t.Run("returns false when programmed listeners match", func(t *testing.T) {
+			assert.False(t, l7ProgrammedListenersChanged(
+				strings.Join([]string{
+					string(listenerA) + "/" + ruleA,
+					string(listenerB) + "/" + ruleB,
+				}, ","),
+				[]gatewayv1.Listener{{Name: listenerB}, {Name: listenerA}},
+			))
+		})
+
+		t.Run("returns true when a matched listener was not programmed", func(t *testing.T) {
+			assert.True(t, l7ProgrammedListenersChanged(
+				string(listenerA)+"/"+ruleA,
+				[]gatewayv1.Listener{{Name: listenerA}, {Name: listenerB}},
+			))
+		})
+
+		t.Run("returns true when a programmed listener no longer matches", func(t *testing.T) {
+			assert.True(t, l7ProgrammedListenersChanged(
+				strings.Join([]string{
+					string(listenerA) + "/" + ruleA,
+					string(listenerB) + "/" + ruleB,
+				}, ","),
+				[]gatewayv1.Listener{{Name: listenerA}},
+			))
+		})
+
+		t.Run("returns true when programmed listener names differ", func(t *testing.T) {
+			assert.True(t, l7ProgrammedListenersChanged(
+				string(listenerA)+"/"+ruleA,
+				[]gatewayv1.Listener{{Name: listenerB}},
+			))
+		})
+
+		t.Run("returns true when previous policy rules are legacy unscoped entries", func(t *testing.T) {
+			assert.True(t, l7ProgrammedListenersChanged(
+				"legacy-rule-"+fake.Lorem().Word(),
+				[]gatewayv1.Listener{{Name: listenerA}},
+			))
+		})
+	})
+
 	t.Run("removeL7RoutePolicyRules", func(t *testing.T) {
 		t.Run("removes previous policy rules per listener", func(t *testing.T) {
 			fake := faker.New()
@@ -2701,6 +2757,47 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				details.httpRoute.Annotations = map[string]string{}
 			}
 			details.httpRoute.Annotations[HTTPRouteProgrammingRevisionAnnotation] = "2"
+			details.httpRoute.Status.Parents = []gatewayv1.RouteParentStatus{
+				{
+					ControllerName: controllerName,
+					ParentRef:      details.matchedRef,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.RouteConditionResolvedRefs),
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: details.httpRoute.Generation,
+						},
+					},
+				},
+			}
+
+			required, err := model.isProgrammingRequired(details)
+
+			require.NoError(t, err)
+			assert.True(t, required)
+		})
+
+		t.Run("ProgrammingRequired/MatchedListenerSetChanged", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			deps.ResourcesModel = newResourcesModel(resourcesModelDeps{
+				K8sClient:  deps.K8sClient,
+				RootLogger: diag.RootTestLogger(),
+			})
+			model := newHTTPRouteModel(deps)
+			controllerName, details := newIsProgrammingRequiredDetails()
+			oldListenerName := gatewayv1.SectionName("old-" + fake.Lorem().Word())
+			newListenerName := gatewayv1.SectionName("new-" + fake.Lorem().Word())
+
+			details.matchedListeners = []gatewayv1.Listener{
+				{Name: oldListenerName, Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+				{Name: newListenerName, Protocol: gatewayv1.HTTPProtocolType, Port: 8080},
+			}
+			details.httpRoute.Annotations = map[string]string{
+				HTTPRouteProgrammingRevisionAnnotation:    HTTPRouteProgrammingRevisionValue,
+				HTTPRouteProgrammedPolicyRulesAnnotation:  string(oldListenerName) + "/" + fake.UUID().V4(),
+				L7RouteProgrammedLoadBalancerIDAnnotation: details.gatewayDetails.config.Spec.LoadBalancerID,
+			}
 			details.httpRoute.Status.Parents = []gatewayv1.RouteParentStatus{
 				{
 					ControllerName: controllerName,

--- a/internal/app/watches_model.go
+++ b/internal/app/watches_model.go
@@ -824,6 +824,60 @@ func (m *WatchesModel) MapHTTPRouteToGRPCRoute(ctx context.Context, obj client.O
 	)
 }
 
+func (m *WatchesModel) MapGatewayToHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapGatewayToL7RouteRequests(
+		ctx, obj, httpRouteParentGatewayIndexKey, "HTTPRoutes",
+		func() client.ObjectList { return &gatewayv1.HTTPRouteList{} },
+	)
+}
+
+func (m *WatchesModel) MapGatewayToGRPCRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	return m.mapGatewayToL7RouteRequests(
+		ctx, obj, grpcRouteParentGatewayIndexKey, "GRPCRoutes",
+		func() client.ObjectList { return &gatewayv1.GRPCRouteList{} },
+	)
+}
+
+func (m *WatchesModel) mapGatewayToL7RouteRequests(
+	ctx context.Context,
+	obj client.Object,
+	indexKey string,
+	routeKind string,
+	newRouteList func() client.ObjectList,
+) []reconcile.Request {
+	gateway, ok := obj.(*gatewayv1.Gateway)
+	if !ok {
+		m.logger.WarnContext(ctx, "Received non-Gateway object", slog.Any("object", obj))
+		return nil
+	}
+
+	return mapParentGatewaysToL7RouteRequests(
+		ctx,
+		m.logger,
+		m.k8sClient,
+		[]string{path.Join(gateway.Namespace, gateway.Name)},
+		indexKey,
+		routeKind,
+		newRouteList,
+		appendL7RouteRequests,
+	)
+}
+
+func appendL7RouteRequests(routeList client.ObjectList, requestsByKey map[client.ObjectKey]reconcile.Request) {
+	items, err := meta.ExtractList(routeList)
+	if err != nil {
+		return
+	}
+	for _, item := range items {
+		route, ok := item.(client.Object)
+		if !ok || route.GetDeletionTimestamp() != nil {
+			continue
+		}
+		key := client.ObjectKeyFromObject(route)
+		requestsByKey[key] = reconcile.Request{NamespacedName: key}
+	}
+}
+
 func mapParentGatewaysToL7RouteRequests[T client.ObjectList](
 	ctx context.Context,
 	logger *slog.Logger,

--- a/internal/app/watches_model_test.go
+++ b/internal/app/watches_model_test.go
@@ -3165,6 +3165,99 @@ func TestWatchesModel(t *testing.T) {
 			require.Nil(t, model.MapGatewayToTLSRoute(t.Context(), &corev1.Service{}))
 		})
 
+		t.Run("maps Gateway changes to referencing HTTPRoutes", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mapper, ok := any(model).(interface {
+				MapGatewayToHTTPRoute(context.Context, client.Object) []reconcile.Request
+			})
+			require.True(t, ok, "WatchesModel must map Gateway changes to referencing HTTPRoutes")
+			gateway := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "web", Name: "edge"}}
+			httpRoutes := []gatewayv1.HTTPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "web", Name: "matched"},
+					Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{{Name: "edge"}},
+					}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "web", Name: "other"},
+					Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{{Name: "other"}},
+					}},
+				},
+			}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.HTTPRouteList{},
+					client.MatchingFields{httpRouteParentGatewayIndexKey: "web/edge"}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf(httpRoutes[:1]))
+					return nil
+				})
+
+			require.Equal(t,
+				[]reconcile.Request{{NamespacedName: apitypes.NamespacedName{Namespace: "web", Name: "matched"}}},
+				mapper.MapGatewayToHTTPRoute(t.Context(), gateway),
+			)
+			require.Nil(t, mapper.MapGatewayToHTTPRoute(t.Context(), &corev1.Service{}))
+		})
+
+		t.Run("maps Gateway changes to referencing GRPCRoutes", func(t *testing.T) {
+			deps := makeMockDeps(t)
+			model := NewWatchesModel(deps)
+			mapper, ok := any(model).(interface {
+				MapGatewayToGRPCRoute(context.Context, client.Object) []reconcile.Request
+			})
+			require.True(t, ok, "WatchesModel must map Gateway changes to referencing GRPCRoutes")
+			gateway := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "grpc", Name: "edge"}}
+			grpcRoutes := []gatewayv1.GRPCRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "grpc", Name: "matched"},
+					Spec: gatewayv1.GRPCRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{{Name: "edge"}},
+					}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "grpc", Name: "other"},
+					Spec: gatewayv1.GRPCRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{{Name: "other"}},
+					}},
+				},
+			}
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			mockK8sClient.EXPECT().
+				List(t.Context(), &gatewayv1.GRPCRouteList{},
+					client.MatchingFields{grpcRouteParentGatewayIndexKey: "grpc/edge"}).
+				RunAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					reflect.ValueOf(list).Elem().FieldByName("Items").Set(reflect.ValueOf(grpcRoutes[:1]))
+					return nil
+				})
+
+			require.Equal(t,
+				[]reconcile.Request{{NamespacedName: apitypes.NamespacedName{Namespace: "grpc", Name: "matched"}}},
+				mapper.MapGatewayToGRPCRoute(t.Context(), gateway),
+			)
+			require.Nil(t, mapper.MapGatewayToGRPCRoute(t.Context(), &corev1.Service{}))
+		})
+
+		t.Run("appends only active L7 route requests", func(t *testing.T) {
+			now := metav1.Now()
+			routes := &gatewayv1.HTTPRouteList{Items: []gatewayv1.HTTPRoute{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "web", Name: "active"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "web", Name: "deleting", DeletionTimestamp: &now}},
+			}}
+			requestsByKey := map[client.ObjectKey]reconcile.Request{}
+
+			appendL7RouteRequests(routes, requestsByKey)
+
+			require.Equal(t, map[client.ObjectKey]reconcile.Request{
+				{Namespace: "web", Name: "active"}: {
+					NamespacedName: apitypes.NamespacedName{Namespace: "web", Name: "active"},
+				},
+			}, requestsByKey)
+		})
+
 		t.Run("returns nil when indexed TLSRoute list fails for Gateway changes", func(t *testing.T) {
 			deps := makeMockDeps(t)
 			model := NewWatchesModel(deps)

--- a/internal/k8s/start_manager.go
+++ b/internal/k8s/start_manager.go
@@ -93,6 +93,7 @@ type setupL7RouteControllerParams struct {
 	name                       string
 	route                      client.Object
 	mapEndpoint                handler.MapFunc
+	mapGateway                 handler.MapFunc
 	pairedRoute                client.Object
 	mapPairedRoute             handler.MapFunc
 	mapListenerSetToRoute      handler.MapFunc
@@ -599,6 +600,7 @@ func setupHTTPRouteController(
 		name:                       "httproute",
 		route:                      &gatewayv1.HTTPRoute{},
 		mapEndpoint:                deps.WatchesModel.MapEndpointSliceToHTTPRoute,
+		mapGateway:                 deps.WatchesModel.MapGatewayToHTTPRoute,
 		pairedRoute:                &gatewayv1.GRPCRoute{},
 		mapPairedRoute:             deps.WatchesModel.MapGRPCRouteToHTTPRoute,
 		mapListenerSetToRoute:      listenerSetMapper(enableListenerSet, deps.WatchesModel.MapListenerSetToHTTPRoute),
@@ -620,6 +622,7 @@ func setupGRPCRouteController(
 		name:                       "grpcroute",
 		route:                      &gatewayv1.GRPCRoute{},
 		mapEndpoint:                deps.WatchesModel.MapEndpointSliceToGRPCRoute,
+		mapGateway:                 deps.WatchesModel.MapGatewayToGRPCRoute,
 		pairedRoute:                &gatewayv1.HTTPRoute{},
 		mapPairedRoute:             deps.WatchesModel.MapHTTPRouteToGRPCRoute,
 		mapListenerSetToRoute:      listenerSetMapper(enableListenerSet, deps.WatchesModel.MapListenerSetToGRPCRoute),
@@ -642,6 +645,11 @@ func setupL7RouteController(
 		Watches(
 			&discoveryv1.EndpointSlice{},
 			handler.EnqueueRequestsFromMapFunc(params.mapEndpoint),
+		).
+		Watches(
+			&gatewayv1.Gateway{},
+			handler.EnqueueRequestsFromMapFunc(params.mapGateway),
+			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
 		).
 		Watches(
 			params.pairedRoute,


### PR DESCRIPTION
## Summary

Closes #24.

Fixes L7 route reconciliation when a Gateway listener changes after a route has already been created.

Previously, an HTTPRoute or GRPCRoute that referenced a Gateway listener could remain unprogrammed if the listener was added later, because the route itself did not change. This adds Gateway watch wiring so affected L7 routes are reconciled when Gateway listeners change.

This also fixes a cleanup edge case found during live testing: when route cleanup removes the last rule from an OCI routing policy, the controller now deletes the routing policy instead of calling UpdateRoutingPolicy with an empty rules list, which OCI rejects.