### PR TITLE
Set Gateway API resources pending during reconciliation

### DIFF
--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -41,6 +41,7 @@ const (
 	backendTLSPolicyTag                  = "oke-gateway-api-policy"
 	backendTLSManagedByValue             = "backend-tls-policy"
 	defaultBackendTLSVerifyDepth         = 3
+	backendTLSPolicyReasonPending        = gatewayv1.PolicyConditionReason("Pending")
 )
 
 var (
@@ -336,7 +337,21 @@ func (m *backendTLSPolicyModelImpl) resolveAcceptedPolicy(
 			policy.Name,
 		)
 	}
-	if err = m.ensurePolicyFinalizerAndCompartment(ctx, policy, compartmentID); err != nil {
+	if err = m.setPolicyPendingConditions(ctx, policy, params.gateway); err != nil {
+		return nil, err
+	}
+	policyToFinalize := policy
+	if err = m.k8sClient.Get(ctx, apitypes.NamespacedName{
+		Namespace: policy.Namespace,
+		Name:      policy.Name,
+	}, &policyToFinalize); err != nil {
+		return nil, fmt.Errorf("failed to get BackendTLSPolicy %s/%s after pending status update: %w",
+			policy.Namespace,
+			policy.Name,
+			err,
+		)
+	}
+	if err = m.ensurePolicyFinalizerAndCompartment(ctx, policyToFinalize, compartmentID); err != nil {
 		return nil, err
 	}
 
@@ -852,6 +867,32 @@ func (m *backendTLSPolicyModelImpl) setPolicyErrorConditions(
 			metav1.ConditionFalse,
 			reason,
 			message,
+		),
+	)
+}
+
+func (m *backendTLSPolicyModelImpl) setPolicyPendingConditions(
+	ctx context.Context,
+	policy gatewayv1.BackendTLSPolicy,
+	gateway gatewayv1.Gateway,
+) error {
+	return m.setPolicyConditions(
+		ctx,
+		policy,
+		gateway,
+		backendTLSPolicyCondition(
+			policy.Generation,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+			"BackendTLSPolicy is accepted.",
+		),
+		backendTLSPolicyCondition(
+			policy.Generation,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionUnknown,
+			backendTLSPolicyReasonPending,
+			"BackendTLSPolicy reconciliation is in progress.",
 		),
 	)
 }

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -34,6 +34,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/gemyago/oke-gateway-api/internal/diag"
+	"github.com/gemyago/oke-gateway-api/internal/services/k8sapi"
 	"github.com/gemyago/oke-gateway-api/internal/services/ociapi"
 	"github.com/gemyago/oke-gateway-api/internal/types"
 )
@@ -362,6 +363,7 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 			K8sClient: fake.NewClientBuilder().
 				WithScheme(newL4TestScheme(t)).
 				WithObjects(objects...).
+				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
 				Build(),
 			OciLoadBalancerClient:     lbClient,
 			OciCertificatesMgmtClient: certsClient,
@@ -436,6 +438,75 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		_, err := model.resolveForBackendRef(t.Context(), resolveParams)
 
 		require.ErrorIs(t, err, errBackendTLSPolicyNotFound)
+	})
+
+	t.Run("setPolicyPendingConditions marks policy accepted with pending refs", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "pending", serviceName, "tls", baseOptions, "ca")
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithObjects(&policy).
+			WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+			Build()
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		err := model.setPolicyPendingConditions(t.Context(), policy, gateway)
+
+		require.NoError(t, err)
+		var updated gatewayv1.BackendTLSPolicy
+		require.NoError(t, k8sClient.Get(t.Context(), apitypes.NamespacedName{
+			Namespace: namespace,
+			Name:      "pending",
+		}, &updated))
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.PolicyConditionAccepted,
+			metav1.ConditionTrue,
+			gatewayv1.PolicyReasonAccepted,
+		)
+		assertBackendTLSPolicyCondition(
+			t,
+			updated,
+			gatewayv1.BackendTLSPolicyConditionResolvedRefs,
+			metav1.ConditionUnknown,
+			backendTLSPolicyReasonPending,
+		)
+	})
+
+	t.Run("setPolicyPendingConditions returns status update errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "pending-error", serviceName, "tls", baseOptions, "ca")
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		k8sClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: namespace, Name: "pending-error"}, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				typedPolicy, ok := obj.(*gatewayv1.BackendTLSPolicy)
+				require.True(t, ok)
+				*typedPolicy = policy
+				return nil
+			}).
+			Once()
+		k8sClient.EXPECT().Status().Return(statusWriter)
+		wantErr := errors.New("status failed")
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.BackendTLSPolicy")).
+			Return(wantErr)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     NewMockociLoadBalancerClient(t),
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		err := model.setPolicyPendingConditions(t.Context(), policy, gateway)
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to update BackendTLSPolicy")
 	})
 
 	t.Run("selects oldest policy and marks lower precedence policy conflicted", func(t *testing.T) {
@@ -991,6 +1062,128 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		require.NotNil(t, sslConfig)
 		assert.Len(t, certsClient.updateCalls, 1)
 		assert.Equal(t, newPEM, lo.FromPtr(certsClient.updateCalls[0].UpdateCaBundleDetails.CaBundlePem))
+	})
+
+	t.Run("resolveAcceptedPolicy returns pending status update errors", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "pending-resolve-error", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: string(ref.Name)},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		k8sClient := NewMockk8sClient(t)
+		k8sClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: namespace, Name: string(ref.Name)}, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				typedCA, ok := obj.(*corev1.ConfigMap)
+				require.True(t, ok)
+				*typedCA = ca
+				return nil
+			})
+		k8sClient.EXPECT().
+			Get(
+				t.Context(),
+				apitypes.NamespacedName{Namespace: namespace, Name: "pending-resolve-error"},
+				mock.AnythingOfType("*v1.BackendTLSPolicy"),
+			).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				typedPolicy, ok := obj.(*gatewayv1.BackendTLSPolicy)
+				require.True(t, ok)
+				*typedPolicy = policy
+				return nil
+			}).
+			Once()
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		k8sClient.EXPECT().Status().Return(statusWriter)
+		wantErr := errors.New("pending status failed")
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.BackendTLSPolicy")).
+			Return(wantErr)
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		_, err := model.resolveAcceptedPolicy(t.Context(), backendTLSPolicyCandidate{
+			policy:    policy,
+			targetRef: targetRef,
+		}, resolveParams)
+
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("resolveAcceptedPolicy returns policy refresh errors after pending status", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "pending-refresh-error", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		ca := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: string(ref.Name)},
+			Data:       map[string]string{"ca.crt": testCAPEM(t)},
+		}
+		k8sClient := NewMockk8sClient(t)
+		k8sClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: namespace, Name: string(ref.Name)}, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				typedCA, ok := obj.(*corev1.ConfigMap)
+				require.True(t, ok)
+				*typedCA = ca
+				return nil
+			})
+		pendingGetCall := k8sClient.EXPECT().
+			Get(
+				t.Context(),
+				apitypes.NamespacedName{Namespace: namespace, Name: "pending-refresh-error"},
+				mock.AnythingOfType("*v1.BackendTLSPolicy"),
+			).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				typedPolicy, ok := obj.(*gatewayv1.BackendTLSPolicy)
+				require.True(t, ok)
+				*typedPolicy = policy
+				return nil
+			}).
+			Once()
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		k8sClient.EXPECT().Status().Return(statusWriter)
+		statusCall := statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.BackendTLSPolicy")).
+			Return(nil).
+			NotBefore(pendingGetCall)
+		wantErr := errors.New("refresh failed")
+		k8sClient.EXPECT().
+			Get(
+				t.Context(),
+				apitypes.NamespacedName{Namespace: namespace, Name: "pending-refresh-error"},
+				mock.Anything,
+			).
+			Return(wantErr).
+			NotBefore(statusCall)
+		lbClient := NewMockociLoadBalancerClient(t)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), mock.Anything).
+			Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadbalancer.LoadBalancer{CompartmentId: &compartmentID},
+			}, nil)
+		model := newBackendTLSPolicyModel(backendTLSPolicyModelDeps{
+			RootLogger:                diag.RootTestLogger(),
+			K8sClient:                 k8sClient,
+			OciLoadBalancerClient:     lbClient,
+			OciCertificatesMgmtClient: newStubCertificatesManagementClient(),
+		})
+
+		_, err := model.resolveAcceptedPolicy(t.Context(), backendTLSPolicyCandidate{
+			policy:    policy,
+			targetRef: targetRef,
+		}, resolveParams)
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "after pending status update")
 	})
 
 	t.Run("rejects unowned existing OCI CA bundle", func(t *testing.T) {

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -504,7 +504,6 @@ func TestGatewayController(t *testing.T) {
 					gateway: *gateway,
 				}).
 				Return(false).Once()
-
 			wantErr := errors.New(fake.Lorem().Sentence(10))
 
 			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
@@ -551,7 +550,6 @@ func TestGatewayController(t *testing.T) {
 					gateway: *gateway,
 				}).
 				Return(false).Once()
-
 			wantErr := &resourceStatusError{
 				conditionType: string(gatewayv1.GatewayConditionProgrammed),
 				reason:        fake.Lorem().Word(),
@@ -613,7 +611,6 @@ func TestGatewayController(t *testing.T) {
 					gateway: *gateway,
 				}).
 				Return(false).Once()
-
 			wantErr := &resourceStatusError{
 				conditionType: string(gatewayv1.GatewayConditionProgrammed),
 				reason:        fake.Lorem().Word(),
@@ -673,7 +670,6 @@ func TestGatewayController(t *testing.T) {
 					gateway: *gateway,
 				}).
 				Return(false).Once()
-
 			wantErr := errors.New(fake.Lorem().Sentence(10))
 
 			expectGatewayProgrammingProtection(mockResourcesModel, gateway, nil)
@@ -728,7 +724,7 @@ func TestGatewayController(t *testing.T) {
 			result, err := controller.Reconcile(t.Context(), req)
 
 			require.ErrorIs(t, err, wantErr)
-			require.ErrorContains(t, err, "failed to set pending programmed condition")
+			require.ErrorContains(t, err, "failed to persist programming protection")
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 

--- a/internal/app/gateway_controller_test.go
+++ b/internal/app/gateway_controller_test.go
@@ -695,6 +695,43 @@ func TestGatewayController(t *testing.T) {
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 
+		t.Run("handle pending programmed condition error", func(t *testing.T) {
+			fake := faker.New()
+			gateway := newRandomGateway()
+			markGatewayAccepted(gateway)
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: gateway.Namespace,
+					Name:      gateway.Name,
+				},
+			}
+
+			deps := newMockDeps(t)
+			controller := NewGatewayController(deps)
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			mockGatewayModel, _ := deps.GatewayModel.(*MockgatewayModel)
+
+			mockGatewayModel.EXPECT().
+				resolveReconcileRequest(t.Context(), req, mock.MatchedBy(func(receiver *resolvedGatewayDetails) bool {
+					receiver.gateway = *gateway
+					return true
+				})).
+				Return(true, nil).Once()
+			mockGatewayModel.EXPECT().
+				isProgrammed(t.Context(), &resolvedGatewayDetails{gateway: *gateway}).
+				Return(false).Once()
+
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			mockResourcesModel.EXPECT().setCondition(t.Context(), mock.Anything).Return(wantErr).Once()
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, "failed to set pending programmed condition")
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
 		t.Run("skip program when condition is already set", func(t *testing.T) {
 			gateway := newRandomGateway()
 			markGatewayAccepted(gateway)

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -2785,9 +2785,11 @@ func TestGatewayModelImpl(t *testing.T) {
 			mockLBModel.EXPECT().
 				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
 					_, hasListenerSetListener := params.knownListeners[vanishedListenerSetListenerName]
-					_, cleansListenerSetListener := params.cleanupListenerNames[vanishedListenerSetListenerName]
 					return hasListenerSetListener &&
-						cleansListenerSetListener
+						assert.ObjectsAreEqual(
+							map[string]struct{}{vanishedListenerSetListenerName: {}},
+							params.cleanupListenerNames,
+						)
 				})).
 				Return(nil)
 			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -2785,11 +2785,9 @@ func TestGatewayModelImpl(t *testing.T) {
 			mockLBModel.EXPECT().
 				removeMissingListeners(t.Context(), mock.MatchedBy(func(params removeMissingListenersParams) bool {
 					_, hasListenerSetListener := params.knownListeners[vanishedListenerSetListenerName]
+					_, cleansListenerSetListener := params.cleanupListenerNames[vanishedListenerSetListenerName]
 					return hasListenerSetListener &&
-						assert.ObjectsAreEqual(
-							map[string]struct{}{vanishedListenerSetListenerName: {}},
-							params.cleanupListenerNames,
-						)
+						cleansListenerSetListener
 				})).
 				Return(nil)
 			mockLBModel.EXPECT().removeUnusedCertificates(t.Context(), mock.Anything).Return(nil)

--- a/internal/app/grpcroute_controller.go
+++ b/internal/app/grpcroute_controller.go
@@ -83,6 +83,16 @@ func (r *GRPCRouteController) reconcileResolvedRoute(
 		return true, nil
 	}
 
+	if err = r.grpcRouteModel.setPending(ctx, setGRPCRouteProgrammedParams{
+		gatewayClass: resolvedData.gatewayDetails.gatewayClass,
+		gateway:      resolvedData.gatewayDetails.gateway,
+		config:       resolvedData.gatewayDetails.config,
+		grpcRoute:    *acceptedRoute,
+		matchedRef:   resolvedData.matchedRef,
+	}); err != nil {
+		return false, fmt.Errorf("failed to set pending status: %w", err)
+	}
+
 	knownBackends, err := r.grpcRouteModel.resolveBackendRefs(ctx, resolveGRPCBackendRefsParams{
 		grpcRoute: *acceptedRoute,
 	})

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -28,6 +28,7 @@ type fakeGRPCRouteModel struct {
 	programRouteFunc        func(context.Context, programGRPCRouteParams) (programGRPCRouteResult, error)
 	deprovisionRouteFunc    func(context.Context, deprovisionGRPCRouteParams) error
 	setRejectedFunc         func(context.Context, resolvedGRPCRouteDetails, grpcRouteStatusError) error
+	setPendingFunc          func(context.Context, setGRPCRouteProgrammedParams) error
 	setProgrammedFunc       func(context.Context, setGRPCRouteProgrammedParams) error
 }
 
@@ -89,6 +90,16 @@ func (m fakeGRPCRouteModel) setRejected(
 	statusErr grpcRouteStatusError,
 ) error {
 	return m.setRejectedFunc(ctx, details, statusErr)
+}
+
+func (m fakeGRPCRouteModel) setPending(
+	ctx context.Context,
+	params setGRPCRouteProgrammedParams,
+) error {
+	if m.setPendingFunc == nil {
+		return nil
+	}
+	return m.setPendingFunc(ctx, params)
 }
 
 func (m fakeGRPCRouteModel) setProgrammed(
@@ -171,6 +182,7 @@ func TestGRPCRouteController(t *testing.T) {
 		resolved := makeResolved(route)
 		service := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: "grpc-svc"}}
 		backendModel := NewMockhttpBackendModel(t)
+		pendingSet := false
 		routeModel := fakeGRPCRouteModel{
 			resolveRequestFunc: func(
 				_ context.Context,
@@ -187,9 +199,15 @@ func TestGRPCRouteController(t *testing.T) {
 				return map[string]corev1.Service{service.Namespace + "/" + service.Name: service}, nil
 			},
 			programRouteFunc: func(_ context.Context, params programGRPCRouteParams) (programGRPCRouteResult, error) {
+				assert.True(t, pendingSet)
 				assert.Equal(t, route.Name, params.grpcRoute.Name)
 				assert.Equal(t, service, params.knownBackends[service.Namespace+"/"+service.Name])
 				return programGRPCRouteResult{programmedPolicyRules: []string{"grpc/rule"}}, nil
+			},
+			setPendingFunc: func(_ context.Context, params setGRPCRouteProgrammedParams) error {
+				assert.Equal(t, route.Name, params.grpcRoute.Name)
+				pendingSet = true
+				return nil
 			},
 			setProgrammedFunc: func(_ context.Context, params setGRPCRouteProgrammedParams) error {
 				assert.Equal(t, []string{"grpc/rule"}, params.programmedPolicyRules)
@@ -208,6 +226,35 @@ func TestGRPCRouteController(t *testing.T) {
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, got.RequeueAfter, 2*time.Minute)
 		assert.LessOrEqual(t, got.RequeueAfter, 2*time.Minute+(2*time.Minute)/maxDriftRequeueJitterRatio)
+	})
+
+	t.Run("returns pending status update errors", func(t *testing.T) {
+		route := makeRoute()
+		resolved := makeResolved(route)
+		wantErr := errors.New("pending failed")
+		routeModel := fakeGRPCRouteModel{
+			resolveRequestFunc: func(
+				context.Context,
+				reconcile.Request,
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
+				return resolvedMap(route, resolved), nil
+			},
+			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
+			acceptRouteFunc: func(_ context.Context, details resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
+				return &details.grpcRoute, nil
+			},
+			setPendingFunc: func(context.Context, setGRPCRouteProgrammedParams) error {
+				return wantErr
+			},
+		}
+
+		_, err := newController(routeModel, NewMockhttpBackendModel(t)).
+			Reconcile(t.Context(), reconcile.Request{NamespacedName: apitypes.NamespacedName{
+				Namespace: route.Namespace,
+				Name:      route.Name,
+			}})
+
+		require.ErrorIs(t, err, wantErr)
 	})
 
 	t.Run("syncs endpoints when programming is not required", func(t *testing.T) {

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -108,6 +108,11 @@ type grpcRouteModel interface {
 		ctx context.Context,
 		params setGRPCRouteProgrammedParams,
 	) error
+
+	setPending(
+		ctx context.Context,
+		params setGRPCRouteProgrammedParams,
+	) error
 }
 
 type grpcRouteStatusError struct {
@@ -702,6 +707,25 @@ func (m *grpcRouteModelImpl) setProgrammed(
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update programmed status for GRPCRoute %s: %w", grpcRoute.Name, err)
+	}
+
+	return nil
+}
+
+func (m *grpcRouteModelImpl) setPending(
+	ctx context.Context,
+	params setGRPCRouteProgrammedParams,
+) error {
+	grpcRoute := params.grpcRoute.DeepCopy()
+	err := setL7RoutePending(ctx, m.resourcesModel, setL7RouteProgrammedParams{
+		resource:       grpcRoute,
+		parentStatuses: grpcRoute.Status.Parents,
+		gatewayClass:   params.gatewayClass,
+		gateway:        params.gateway,
+		matchedRef:     params.matchedRef,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update pending status for GRPCRoute %s: %w", grpcRoute.Name, err)
 	}
 
 	return nil

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1564,6 +1564,36 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 
 		require.ErrorIs(t, err, wantErr)
 	})
+
+	t.Run("setPending", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newGRPCRouteModel(deps)
+		resourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+		gateway := gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw-" + fake.Lorem().Word()}}
+		parentRef := gatewayv1.ParentReference{Name: gatewayv1.ObjectName(gateway.Name)}
+
+		resourcesModel.EXPECT().setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+			return params.conditionType == string(gatewayv1.RouteConditionResolvedRefs) &&
+				params.status == metav1.ConditionUnknown &&
+				params.reason == string(gatewayv1.RouteReasonPending) &&
+				params.message == fmt.Sprintf("Route programming by %s is in progress", gateway.Name)
+		})).Return(nil).Once()
+
+		err := model.setPending(t.Context(), setGRPCRouteProgrammedParams{
+			grpcRoute: makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+				route.Status.Parents = []gatewayv1.RouteParentStatus{{
+					ParentRef:      parentRef,
+					ControllerName: ControllerClassName,
+				}}
+			}),
+			gatewayClass: gatewayv1.GatewayClass{Spec: gatewayv1.GatewayClassSpec{ControllerName: ControllerClassName}},
+			gateway:      gateway,
+			matchedRef:   parentRef,
+		})
+
+		require.NoError(t, err)
+	})
 }
 
 func TestGRPCRouteStatusError(t *testing.T) {

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -77,7 +77,7 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 		return true, nil
 	}
 
-	r.logger.DebugContext(ctx, "Performing HTTProute programming",
+	r.logger.DebugContext(ctx, "Performing HTTPRoute programming",
 		slog.String("httpRoute", resolvedData.httpRoute.Name),
 		slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
 	)
@@ -125,7 +125,7 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 		return false, fmt.Errorf("failed to set programmed status: %w", err)
 	}
 
-	r.logger.InfoContext(ctx, "Successfully programmed HTTProute",
+	r.logger.InfoContext(ctx, "Successfully programmed HTTPRoute",
 		slog.String("httpRoute", resolvedData.httpRoute.Name),
 		slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
 	)
@@ -152,7 +152,7 @@ func (r *HTTPRouteController) deprovisionResolvedRoute(
 			resolvedData.gatewayDetails.gateway.Name, err)
 	}
 
-	r.logger.InfoContext(ctx, "Successfully deprovisioned HTTProute",
+	r.logger.InfoContext(ctx, "Successfully deprovisioned HTTPRoute",
 		slog.String("httpRoute", resolvedData.httpRoute.Name),
 		slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
 	)
@@ -175,7 +175,7 @@ func (r *HTTPRouteController) setPending(
 }
 
 func (r *HTTPRouteController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	r.logger.InfoContext(ctx, fmt.Sprintf("Processing reconciliation for HTTProute %s", req.NamespacedName))
+	r.logger.InfoContext(ctx, fmt.Sprintf("Processing reconciliation for HTTPRoute %s", req.NamespacedName))
 
 	resolvedRequests, err := r.httpRouteModel.resolveRequest(ctx, req)
 	if err != nil {
@@ -209,7 +209,7 @@ func (r *HTTPRouteController) Reconcile(ctx context.Context, req reconcile.Reque
 		}
 	}
 
-	r.logger.InfoContext(ctx, fmt.Sprintf("Reconciled HTTProute %s", req.NamespacedName))
+	r.logger.InfoContext(ctx, fmt.Sprintf("Reconciled HTTPRoute %s", req.NamespacedName))
 
 	return driftRequeue(r.driftInterval), nil
 }

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/dig"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // HTTPRouteController is a simple controller that watches HTTPRoute resources.
@@ -50,27 +51,7 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 	resolvedData resolvedRouteDetails,
 ) (bool, error) {
 	if resolvedData.httpRoute.DeletionTimestamp != nil {
-		r.logger.InfoContext(ctx, "HTTPRoute is marked for deletion, deprovisioning",
-			slog.String("httpRoute", resolvedData.httpRoute.Name),
-			slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
-		)
-		err := r.httpRouteModel.deprovisionRoute(ctx, deprovisionRouteParams{
-			gateway:          resolvedData.gatewayDetails.gateway,
-			config:           resolvedData.gatewayDetails.config,
-			httpRoute:        resolvedData.httpRoute,
-			matchedListeners: resolvedData.matchedListeners,
-		})
-		if err != nil {
-			return false, fmt.Errorf("failed to deprovision route for gateway %s: %w",
-				resolvedData.gatewayDetails.gateway.Name, err)
-		}
-
-		r.logger.InfoContext(ctx, "Successfully deprovisioned HTTProute",
-			slog.String("httpRoute", resolvedData.httpRoute.Name),
-			slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
-		)
-
-		return false, nil
+		return false, r.deprovisionResolvedRoute(ctx, resolvedData)
 	}
 
 	acceptedRoute, err := r.httpRouteModel.acceptRoute(ctx, resolvedData)
@@ -100,6 +81,10 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 		slog.String("httpRoute", resolvedData.httpRoute.Name),
 		slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
 	)
+
+	if err = r.setPending(ctx, resolvedData, *acceptedRoute); err != nil {
+		return false, fmt.Errorf("failed to set pending status: %w", err)
+	}
 
 	knownBackends, err := r.httpRouteModel.resolveBackendRefs(ctx, resolveBackendRefsParams{
 		httpRoute: *acceptedRoute,
@@ -146,6 +131,47 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 	)
 
 	return true, nil
+}
+
+func (r *HTTPRouteController) deprovisionResolvedRoute(
+	ctx context.Context,
+	resolvedData resolvedRouteDetails,
+) error {
+	r.logger.InfoContext(ctx, "HTTPRoute is marked for deletion, deprovisioning",
+		slog.String("httpRoute", resolvedData.httpRoute.Name),
+		slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
+	)
+	err := r.httpRouteModel.deprovisionRoute(ctx, deprovisionRouteParams{
+		gateway:          resolvedData.gatewayDetails.gateway,
+		config:           resolvedData.gatewayDetails.config,
+		httpRoute:        resolvedData.httpRoute,
+		matchedListeners: resolvedData.matchedListeners,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to deprovision route for gateway %s: %w",
+			resolvedData.gatewayDetails.gateway.Name, err)
+	}
+
+	r.logger.InfoContext(ctx, "Successfully deprovisioned HTTProute",
+		slog.String("httpRoute", resolvedData.httpRoute.Name),
+		slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
+	)
+
+	return nil
+}
+
+func (r *HTTPRouteController) setPending(
+	ctx context.Context,
+	resolvedData resolvedRouteDetails,
+	acceptedRoute gatewayv1.HTTPRoute,
+) error {
+	return r.httpRouteModel.setPending(ctx, setProgrammedParams{
+		gatewayClass: resolvedData.gatewayDetails.gatewayClass,
+		gateway:      resolvedData.gatewayDetails.gateway,
+		config:       resolvedData.gatewayDetails.config,
+		httpRoute:    acceptedRoute,
+		matchedRef:   resolvedData.matchedRef,
+	})
 }
 
 func (r *HTTPRouteController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -27,6 +27,22 @@ func TestHTTPRouteController(t *testing.T) {
 			RootLogger:       diag.RootTestLogger(),
 		}
 	}
+	expectPending := func(
+		mockModel *MockhttpRouteModel,
+		resolvedData resolvedRouteDetails,
+		acceptedRoute gatewayv1.HTTPRoute,
+	) {
+		mockModel.EXPECT().setPending(
+			t.Context(),
+			setProgrammedParams{
+				gatewayClass: resolvedData.gatewayDetails.gatewayClass,
+				gateway:      resolvedData.gatewayDetails.gateway,
+				config:       resolvedData.gatewayDetails.config,
+				httpRoute:    acceptedRoute,
+				matchedRef:   resolvedData.matchedRef,
+			},
+		).Return(nil).Once()
+	}
 
 	t.Run("sets BackendTLSPolicy availability on concrete model", func(t *testing.T) {
 		model := &httpRouteModelImpl{}
@@ -90,6 +106,8 @@ func TestHTTPRouteController(t *testing.T) {
 				t.Context(),
 				wantResolvedData,
 			).Return(&wantAcceptedRoute, nil)
+
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
 
 			mockModel.EXPECT().resolveBackendRefs(
 				t.Context(),
@@ -358,6 +376,8 @@ func TestHTTPRouteController(t *testing.T) {
 				wantResolvedData,
 			).Return(&wantAcceptedRoute, nil)
 
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
+
 			wantErr := fmt.Errorf("resolve backend refs error: %s", fake.Lorem().Sentence(10))
 			mockModel.EXPECT().resolveBackendRefs(
 				t.Context(),
@@ -365,6 +385,41 @@ func TestHTTPRouteController(t *testing.T) {
 					httpRoute: wantAcceptedRoute,
 				},
 			).Return(nil, wantErr)
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.ErrorIs(t, err, wantErr)
+			assert.Equal(t, reconcile.Result{}, result)
+		})
+
+		t.Run("SetPendingError", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			controller := NewHTTPRouteController(deps)
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: fake.Internet().Domain(),
+					Name:      fake.Lorem().Word(),
+				},
+			}
+			wantResolvedData := resolvedRouteDetails{
+				httpRoute: makeRandomHTTPRoute(),
+				gatewayDetails: resolvedGatewayDetails{
+					gateway: *newRandomGateway(),
+					config:  makeRandomGatewayConfig(),
+				},
+			}
+			wantAcceptedRoute := makeRandomHTTPRoute()
+			wantErr := fmt.Errorf("set pending error: %s", fake.Lorem().Sentence(10))
+
+			mockModel, _ := deps.HTTPRouteModel.(*MockhttpRouteModel)
+			mockModel.EXPECT().resolveRequest(t.Context(), req).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
+			}, (error)(nil))
+			mockModel.EXPECT().acceptRoute(t.Context(), wantResolvedData).Return(&wantAcceptedRoute, nil)
+			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
+			mockModel.EXPECT().setPending(t.Context(), mock.Anything).Return(wantErr)
 
 			result, err := controller.Reconcile(t.Context(), req)
 
@@ -417,6 +472,8 @@ func TestHTTPRouteController(t *testing.T) {
 				t.Context(),
 				wantResolvedData,
 			).Return(&wantAcceptedRoute, nil)
+
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
 
 			mockModel.EXPECT().resolveBackendRefs(
 				t.Context(),
@@ -486,6 +543,7 @@ func TestHTTPRouteController(t *testing.T) {
 				t.Context(),
 				wantResolvedData,
 			).Return(&wantAcceptedRoute, nil)
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
 			mockModel.EXPECT().resolveBackendRefs(
 				t.Context(),
 				resolveBackendRefsParams{httpRoute: wantAcceptedRoute},
@@ -603,6 +661,8 @@ func TestHTTPRouteController(t *testing.T) {
 
 			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(false, nil)
 
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
+
 			wantBackendRefs := make(map[string]v1.Service)
 			for range 3 {
 				svc := makeRandomService()
@@ -708,6 +768,8 @@ func TestHTTPRouteController(t *testing.T) {
 				t.Context(),
 				wantResolvedData,
 			).Return(&wantAcceptedRoute, nil)
+
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
 
 			mockModel.EXPECT().resolveBackendRefs(
 				t.Context(),

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -251,6 +251,12 @@ type httpRouteModel interface {
 		ctx context.Context,
 		params setProgrammedParams,
 	) error
+
+	// setPending marks the route as accepted with programming in progress.
+	setPending(
+		ctx context.Context,
+		params setProgrammedParams,
+	) error
 }
 
 // parentRefSameTarget checks if two parent references target the same resource.
@@ -1638,6 +1644,35 @@ func setL7RouteProgrammed(
 	})
 }
 
+func setL7RoutePending(
+	ctx context.Context,
+	resourcesModel resourcesModel,
+	params setL7RouteProgrammedParams,
+) error {
+	_, statusIndex, found := lo.FindIndexOf(
+		params.parentStatuses,
+		func(status gatewayv1.RouteParentStatus) bool {
+			return status.ControllerName == params.gatewayClass.Spec.ControllerName &&
+				parentRefSameTarget(status.ParentRef, params.matchedRef)
+		},
+	)
+	if !found {
+		return fmt.Errorf("parent status not found for controller %s and parentRef %s",
+			params.gatewayClass.Spec.ControllerName,
+			params.matchedRef.Name,
+		)
+	}
+
+	return resourcesModel.setCondition(ctx, setConditionParams{
+		resource:      params.resource,
+		conditions:    &params.parentStatuses[statusIndex].Conditions,
+		conditionType: string(gatewayv1.RouteConditionResolvedRefs),
+		status:        metav1.ConditionUnknown,
+		reason:        string(gatewayv1.RouteReasonPending),
+		message:       fmt.Sprintf("Route programming by %s is in progress", params.gateway.Name),
+	})
+}
+
 func (m *httpRouteModelImpl) setProgrammed(
 	ctx context.Context,
 	params setProgrammedParams,
@@ -1661,6 +1696,25 @@ func (m *httpRouteModelImpl) setProgrammed(
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update programmed status for HTTProute %s: %w", httpRoute.Name, err)
+	}
+
+	return nil
+}
+
+func (m *httpRouteModelImpl) setPending(
+	ctx context.Context,
+	params setProgrammedParams,
+) error {
+	httpRoute := params.httpRoute.DeepCopy()
+	err := setL7RoutePending(ctx, m.resourcesModel, setL7RouteProgrammedParams{
+		resource:       httpRoute,
+		parentStatuses: httpRoute.Status.Parents,
+		gatewayClass:   params.gatewayClass,
+		gateway:        params.gateway,
+		matchedRef:     params.matchedRef,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update pending status for HTTPRoute %s: %w", httpRoute.Name, err)
 	}
 
 	return nil

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -2963,6 +2964,60 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("programs route after pending status update", func(t *testing.T) {
+			fakeData := faker.New()
+			route := makeRandomHTTPRoute()
+			route.Generation = rand.Int64N(1000) + 1
+			gatewayData := makeRandomAcceptedGatewayDetails()
+			matchedRef := makeRandomParentRef()
+			route.Status.Parents = []gatewayv1.RouteParentStatus{{
+				ParentRef:      matchedRef,
+				ControllerName: gatewayData.gatewayClass.Spec.ControllerName,
+			}}
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newL4TestScheme(t)).
+				WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+				WithObjects(&route).
+				Build()
+			model := newHTTPRouteModel(httpRouteModelDeps{
+				K8sClient:  k8sClient,
+				RootLogger: diag.RootTestLogger(),
+				ResourcesModel: newResourcesModel(resourcesModelDeps{
+					K8sClient:  k8sClient,
+					RootLogger: diag.RootTestLogger(),
+				}),
+			})
+
+			params := setProgrammedParams{
+				httpRoute:    route,
+				gatewayClass: gatewayData.gatewayClass,
+				gateway:      gatewayData.gateway,
+				config:       gatewayData.config,
+				matchedRef:   matchedRef,
+				programmedPolicyRules: []string{
+					"rule-" + fakeData.Lorem().Word(),
+				},
+				programmedBackendSets: []string{
+					"backend-set-" + fakeData.Lorem().Word(),
+				},
+			}
+
+			require.NoError(t, model.setPending(t.Context(), params))
+			require.NoError(t, model.setProgrammed(t.Context(), params))
+
+			var updated gatewayv1.HTTPRoute
+			require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(&route), &updated))
+			assert.Contains(t, updated.Finalizers, HTTPRouteProgrammedFinalizer)
+			assert.Equal(t,
+				string(gatewayv1.RouteReasonResolvedRefs),
+				meta.FindStatusCondition(
+					updated.Status.Parents[0].Conditions,
+					string(gatewayv1.RouteConditionResolvedRefs),
+				).Reason,
+			)
+		})
+
 		t.Run("parent status not found (wrong controller)", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)
@@ -3051,6 +3106,62 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			err := model.setProgrammed(t.Context(), details)
 			require.ErrorIs(t, err, updateErr)
+		})
+	})
+
+	t.Run("setPending", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			route := makeRandomHTTPRoute()
+			gatewayData := makeRandomAcceptedGatewayDetails()
+			matchedRef := makeRandomParentRef()
+			route.Status.Parents = []gatewayv1.RouteParentStatus{{
+				ParentRef:      matchedRef,
+				ControllerName: gatewayData.gatewayClass.Spec.ControllerName,
+			}}
+
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			mockResourcesModel.EXPECT().setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+				return params.conditionType == string(gatewayv1.RouteConditionResolvedRefs) &&
+					params.status == metav1.ConditionUnknown &&
+					params.reason == string(gatewayv1.RouteReasonPending) &&
+					params.message == fmt.Sprintf("Route programming by %s is in progress", gatewayData.gateway.Name)
+			})).Return(nil).Once()
+
+			err := model.setPending(t.Context(), setProgrammedParams{
+				httpRoute:    route,
+				gatewayClass: gatewayData.gatewayClass,
+				gateway:      gatewayData.gateway,
+				matchedRef:   matchedRef,
+			})
+
+			require.NoError(t, err)
+		})
+
+		t.Run("returns status update errors", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			route := makeRandomHTTPRoute()
+			gatewayData := makeRandomAcceptedGatewayDetails()
+			matchedRef := makeRandomParentRef()
+			route.Status.Parents = []gatewayv1.RouteParentStatus{{
+				ParentRef:      matchedRef,
+				ControllerName: gatewayData.gatewayClass.Spec.ControllerName,
+			}}
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			mockResourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			mockResourcesModel.EXPECT().setCondition(t.Context(), mock.Anything).Return(wantErr).Once()
+
+			err := model.setPending(t.Context(), setProgrammedParams{
+				httpRoute:    route,
+				gatewayClass: gatewayData.gatewayClass,
+				gateway:      gatewayData.gateway,
+				matchedRef:   matchedRef,
+			})
+
+			require.ErrorIs(t, err, wantErr)
 		})
 	})
 

--- a/internal/app/l4_controller_test.go
+++ b/internal/app/l4_controller_test.go
@@ -21,9 +21,11 @@ type stubTCPRouteModel struct {
 	resolveErr       error
 	programErr       error
 	deprovisionErr   error
+	setPendingErr    error
 	setProgrammedErr error
 	setRejectedErr   error
 	deprovisioned    bool
+	pending          bool
 	programmed       bool
 	rejected         bool
 }
@@ -41,6 +43,11 @@ func (s *stubTCPRouteModel) deprovisionRoute(context.Context, resolvedTCPRouteDe
 	return s.deprovisionErr
 }
 
+func (s *stubTCPRouteModel) setPending(context.Context, resolvedTCPRouteDetails) error {
+	s.pending = true
+	return s.setPendingErr
+}
+
 func (s *stubTCPRouteModel) setProgrammed(context.Context, resolvedTCPRouteDetails) error {
 	s.programmed = true
 	return s.setProgrammedErr
@@ -56,9 +63,11 @@ type stubUDPRouteModel struct {
 	resolveErr       error
 	programErr       error
 	deprovisionErr   error
+	setPendingErr    error
 	setProgrammedErr error
 	setRejectedErr   error
 	deprovisioned    bool
+	pending          bool
 	programmed       bool
 	rejected         bool
 }
@@ -76,6 +85,11 @@ func (s *stubUDPRouteModel) deprovisionRoute(context.Context, resolvedUDPRouteDe
 	return s.deprovisionErr
 }
 
+func (s *stubUDPRouteModel) setPending(context.Context, resolvedUDPRouteDetails) error {
+	s.pending = true
+	return s.setPendingErr
+}
+
 func (s *stubUDPRouteModel) setProgrammed(context.Context, resolvedUDPRouteDetails) error {
 	s.programmed = true
 	return s.setProgrammedErr
@@ -91,9 +105,11 @@ type stubTLSRouteModel struct {
 	resolveErr       error
 	programErr       error
 	deprovisionErr   error
+	setPendingErr    error
 	setProgrammedErr error
 	setRejectedErr   error
 	deprovisioned    bool
+	pending          bool
 	programmed       bool
 	rejected         bool
 }
@@ -109,6 +125,11 @@ func (s *stubTLSRouteModel) programRoute(context.Context, resolvedTLSRouteDetail
 func (s *stubTLSRouteModel) deprovisionRoute(context.Context, resolvedTLSRouteDetails) error {
 	s.deprovisioned = true
 	return s.deprovisionErr
+}
+
+func (s *stubTLSRouteModel) setPending(context.Context, resolvedTLSRouteDetails) error {
+	s.pending = true
+	return s.setPendingErr
 }
 
 func (s *stubTLSRouteModel) setProgrammed(context.Context, resolvedTLSRouteDetails) error {
@@ -135,6 +156,7 @@ func TestTCPRouteController(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Empty(t, result)
+		assert.True(t, model.pending)
 		assert.True(t, model.programmed)
 	})
 
@@ -278,6 +300,10 @@ func TestTCPRouteController(t *testing.T) {
 				resolved:         []resolvedTCPRouteDetails{{tcpRoute: gatewayv1.TCPRoute{}}},
 				setProgrammedErr: errors.New("boom"),
 			},
+			"set pending": {
+				resolved:      []resolvedTCPRouteDetails{{tcpRoute: gatewayv1.TCPRoute{}}},
+				setPendingErr: errors.New("boom"),
+			},
 			"set rejected": {
 				resolved: []resolvedTCPRouteDetails{{tcpRoute: gatewayv1.TCPRoute{}}},
 				programErr: newTCPRouteAcceptedStatusError(
@@ -336,6 +362,7 @@ func TestTLSRouteController(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Empty(t, result)
+		assert.True(t, model.pending)
 		assert.True(t, model.programmed)
 	})
 
@@ -491,6 +518,10 @@ func TestTLSRouteController(t *testing.T) {
 				resolved:   []resolvedTLSRouteDetails{{tlsRoute: gatewayv1.TLSRoute{}}},
 				programErr: errors.New("boom"),
 			},
+			"set pending": {
+				resolved:      []resolvedTLSRouteDetails{{tlsRoute: gatewayv1.TLSRoute{}}},
+				setPendingErr: errors.New("boom"),
+			},
 			"set programmed": {
 				resolved:         []resolvedTLSRouteDetails{{tlsRoute: gatewayv1.TLSRoute{}}},
 				setProgrammedErr: errors.New("boom"),
@@ -546,6 +577,7 @@ func TestUDPRouteController(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Empty(t, result)
+		assert.True(t, model.pending)
 		assert.True(t, model.programmed)
 	})
 

--- a/internal/app/mock_http_route_model.go
+++ b/internal/app/mock_http_route_model.go
@@ -424,6 +424,53 @@ func (_c *MockhttpRouteModel_setProgrammed_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
+// setPending provides a mock function with given fields: ctx, params
+func (_m *MockhttpRouteModel) setPending(ctx context.Context, params setProgrammedParams) error {
+	ret := _m.Called(ctx, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for setPending")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, setProgrammedParams) error); ok {
+		r0 = rf(ctx, params)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockhttpRouteModel_setPending_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'setPending'
+type MockhttpRouteModel_setPending_Call struct {
+	*mock.Call
+}
+
+// setPending is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params setProgrammedParams
+func (_e *MockhttpRouteModel_Expecter) setPending(ctx interface{}, params interface{}) *MockhttpRouteModel_setPending_Call {
+	return &MockhttpRouteModel_setPending_Call{Call: _e.mock.On("setPending", ctx, params)}
+}
+
+func (_c *MockhttpRouteModel_setPending_Call) Run(run func(ctx context.Context, params setProgrammedParams)) *MockhttpRouteModel_setPending_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(setProgrammedParams))
+	})
+	return _c
+}
+
+func (_c *MockhttpRouteModel_setPending_Call) Return(_a0 error) *MockhttpRouteModel_setPending_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockhttpRouteModel_setPending_Call) RunAndReturn(run func(context.Context, setProgrammedParams) error) *MockhttpRouteModel_setPending_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockhttpRouteModel creates a new instance of MockhttpRouteModel. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockhttpRouteModel(t interface {

--- a/internal/app/network_load_balancer_gateway_controller_test.go
+++ b/internal/app/network_load_balancer_gateway_controller_test.go
@@ -305,7 +305,7 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 		_, err := controller.Reconcile(t.Context(), req)
 
 		require.ErrorIs(t, err, wantErr)
-		require.ErrorContains(t, err, "failed to set pending programmed condition")
+		require.ErrorContains(t, err, "failed to persist programming protection")
 	})
 
 	t.Run("returns busy requeue for network load balancer busy errors", func(t *testing.T) {

--- a/internal/app/network_load_balancer_gateway_controller_test.go
+++ b/internal/app/network_load_balancer_gateway_controller_test.go
@@ -291,6 +291,23 @@ func TestNetworkLoadBalancerGatewayController(t *testing.T) {
 		assert.True(t, resourcesModel.setCalled)
 	})
 
+	t.Run("wraps pending programmed condition errors", func(t *testing.T) {
+		wantErr := errors.New("pending failed")
+		controller := NewNetworkLoadBalancerGatewayController(NetworkLoadBalancerGatewayControllerDeps{
+			RootLogger:     diag.RootTestLogger(),
+			ResourcesModel: &stubResourcesModel{conditionSet: true, setErr: wantErr},
+			GatewayModel: &stubNLBGatewayModel{
+				relevant: true,
+				data:     baseData,
+			},
+		})
+
+		_, err := controller.Reconcile(t.Context(), req)
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to set pending programmed condition")
+	})
+
 	t.Run("returns busy requeue for network load balancer busy errors", func(t *testing.T) {
 		resourcesModel := &stubResourcesModel{conditionSet: true}
 		gatewayModel := &stubNLBGatewayModel{

--- a/internal/app/resources_model.go
+++ b/internal/app/resources_model.go
@@ -2,15 +2,19 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
+	"reflect"
 
 	"go.uber.org/dig"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type setConditionParams struct {
@@ -71,7 +75,12 @@ func (m *resourcesModelImpl) setCondition(ctx context.Context, params setConditi
 	meta.SetStatusCondition(params.conditions, acceptedCondition)
 
 	if err := m.client.Status().Update(ctx, params.resource); err != nil {
-		return fmt.Errorf("failed to update status for %s: %w", params.resource.GetName(), err)
+		if !apierrors.IsConflict(err) {
+			return fmt.Errorf("failed to update status for %s: %w", params.resource.GetName(), err)
+		}
+		if retryErr := m.updateResourceStatusAfterConflict(ctx, params, acceptedCondition); retryErr != nil {
+			return retryErr
+		}
 	}
 
 	needsResourceUpdate := false
@@ -94,6 +103,9 @@ func (m *resourcesModelImpl) setCondition(ctx context.Context, params setConditi
 
 	if needsResourceUpdate {
 		if err := m.client.Update(ctx, params.resource); err != nil {
+			if apierrors.IsConflict(err) {
+				return m.updateResourceMetadataAfterConflict(ctx, params)
+			}
 			return fmt.Errorf(
 				"failed to update resource %s with finalizer/annotations: %w",
 				params.resource.GetName(),
@@ -102,6 +114,128 @@ func (m *resourcesModelImpl) setCondition(ctx context.Context, params setConditi
 		}
 	}
 
+	return nil
+}
+
+func (m *resourcesModelImpl) updateResourceStatusAfterConflict(
+	ctx context.Context,
+	params setConditionParams,
+	condition metav1.Condition,
+) error {
+	latest, ok := params.resource.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("failed to copy resource %s for status update", params.resource.GetName())
+	}
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(params.resource), latest); err != nil {
+		return fmt.Errorf(
+			"failed to refresh resource %s after status conflict: %w",
+			params.resource.GetName(),
+			err,
+		)
+	}
+	conditions, err := statusConditionsForRetry(latest, params.resource, *params.conditions)
+	if err != nil {
+		return err
+	}
+	meta.SetStatusCondition(conditions, condition)
+	if updateErr := m.client.Status().Update(ctx, latest); updateErr != nil {
+		return fmt.Errorf("failed to update status for %s after conflict: %w", params.resource.GetName(), updateErr)
+	}
+	return nil
+}
+
+func statusConditionsForRetry(
+	latest client.Object,
+	original client.Object,
+	targetConditions []metav1.Condition,
+) (*[]metav1.Condition, error) {
+	switch latestResource := latest.(type) {
+	case *gatewayv1.GatewayClass:
+		return &latestResource.Status.Conditions, nil
+	case *gatewayv1.Gateway:
+		return &latestResource.Status.Conditions, nil
+	case *gatewayv1.ListenerSet:
+		return &latestResource.Status.Conditions, nil
+	case *gatewayv1.HTTPRoute:
+		originalRoute, ok := original.(*gatewayv1.HTTPRoute)
+		if !ok {
+			break
+		}
+		return routeParentConditionsForRetry(
+			latestResource.Status.Parents,
+			originalRoute.Status.Parents,
+			targetConditions,
+		)
+	case *gatewayv1.GRPCRoute:
+		originalRoute, ok := original.(*gatewayv1.GRPCRoute)
+		if !ok {
+			break
+		}
+		return routeParentConditionsForRetry(
+			latestResource.Status.Parents,
+			originalRoute.Status.Parents,
+			targetConditions,
+		)
+	}
+	return nil, fmt.Errorf("failed to resolve status conditions for %s after conflict", original.GetName())
+}
+
+func routeParentConditionsForRetry(
+	latestParents []gatewayv1.RouteParentStatus,
+	originalParents []gatewayv1.RouteParentStatus,
+	targetConditions []metav1.Condition,
+) (*[]metav1.Condition, error) {
+	if len(originalParents) == 1 && len(latestParents) == 1 {
+		return &latestParents[0].Conditions, nil
+	}
+	for _, originalParent := range originalParents {
+		if !reflect.DeepEqual(originalParent.Conditions, targetConditions) {
+			continue
+		}
+		for i := range latestParents {
+			latestParent := &latestParents[i]
+			if latestParent.ControllerName == originalParent.ControllerName &&
+				parentRefSameTarget(latestParent.ParentRef, originalParent.ParentRef) {
+				return &latestParent.Conditions, nil
+			}
+		}
+	}
+	return nil, errors.New("failed to resolve route parent status after conflict")
+}
+
+func (m *resourcesModelImpl) updateResourceMetadataAfterConflict(
+	ctx context.Context,
+	params setConditionParams,
+) error {
+	latest, ok := params.resource.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("failed to copy resource %s for metadata update", params.resource.GetName())
+	}
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(params.resource), latest); err != nil {
+		return fmt.Errorf(
+			"failed to refresh resource %s after finalizer/annotations conflict: %w",
+			params.resource.GetName(),
+			err,
+		)
+	}
+	if params.finalizer != "" {
+		controllerutil.AddFinalizer(latest, params.finalizer)
+	}
+	if len(params.annotations) > 0 {
+		currentAnnotations := latest.GetAnnotations()
+		if currentAnnotations == nil {
+			currentAnnotations = make(map[string]string)
+		}
+		maps.Copy(currentAnnotations, params.annotations)
+		latest.SetAnnotations(currentAnnotations)
+	}
+	if err := m.client.Update(ctx, latest); err != nil {
+		return fmt.Errorf(
+			"failed to update resource %s with finalizer/annotations after conflict: %w",
+			params.resource.GetName(),
+			err,
+		)
+	}
 	return nil
 }
 
@@ -121,6 +255,7 @@ func (m *resourcesModelImpl) isConditionSet(params isConditionSetParams) bool {
 
 	existingCondition := meta.FindStatusCondition(params.conditions, params.conditionType)
 	if existingCondition != nil &&
+		existingCondition.Status == metav1.ConditionTrue &&
 		existingCondition.ObservedGeneration == params.resource.GetGeneration() {
 		return true
 	}

--- a/internal/app/resources_model_test.go
+++ b/internal/app/resources_model_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"math/rand/v2"
 	"testing"
@@ -9,8 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -392,6 +396,215 @@ func TestResourcesModelImpl_setCondition(t *testing.T) {
 		require.ErrorIs(t, err, expectedError, "Returned error should wrap the original Update error")
 	})
 
+	t.Run("StatusUpdateConflict_RefreshesAndUpdatesStatus", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "gateway-class-" + fake.Lorem().Word(),
+				Generation:      rand.Int64N(1000) + 1,
+				ResourceVersion: "old",
+			},
+			Status: gatewayv1.GatewayClassStatus{Conditions: []metav1.Condition{}},
+		}
+		latestGatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            gatewayClass.Name,
+				Generation:      gatewayClass.Generation,
+				ResourceVersion: "latest",
+			},
+			Status: gatewayv1.GatewayClassStatus{Conditions: []metav1.Condition{{
+				Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+				Status:             metav1.ConditionUnknown,
+				Reason:             string(gatewayv1.GatewayClassReasonPending),
+				ObservedGeneration: gatewayClass.Generation,
+			}}},
+		}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "gatewayclasses"},
+			gatewayClass.Name,
+			errors.New("modified"),
+		)
+
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Twice()
+		mockStatusWriter.EXPECT().
+			Update(t.Context(), gatewayClass, mock.Anything).
+			Return(conflictErr).
+			Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Name: gatewayClass.Name}, mock.AnythingOfType("*v1.GatewayClass")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.GatewayClass) = *latestGatewayClass
+				return nil
+			}).
+			Once()
+		mockStatusWriter.EXPECT().
+			Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updated := obj.(*gatewayv1.GatewayClass)
+				condition := meta.FindStatusCondition(
+					updated.Status.Conditions,
+					string(gatewayv1.GatewayClassConditionStatusAccepted),
+				)
+				return updated.ResourceVersion == "latest" &&
+					condition != nil &&
+					condition.Status == metav1.ConditionTrue &&
+					condition.Reason == string(gatewayv1.GatewayClassReasonAccepted)
+			}), mock.Anything).
+			Return(nil).
+			Once().
+			NotBefore(getCall)
+
+		err := model.setCondition(t.Context(), setConditionParams{
+			resource:      gatewayClass,
+			conditions:    &gatewayClass.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayClassConditionStatusAccepted),
+			status:        metav1.ConditionTrue,
+			reason:        string(gatewayv1.GatewayClassReasonAccepted),
+			message:       "accepted",
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("StatusUpdateConflict_ReturnsRetryUpdateError", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "gateway-class-" + fake.Lorem().Word()},
+		}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "gatewayclasses"},
+			gatewayClass.Name,
+			errors.New("modified"),
+		)
+		updateErr := errors.New("retry update failed")
+
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Twice()
+		mockStatusWriter.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(conflictErr).Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Name: gatewayClass.Name}, mock.AnythingOfType("*v1.GatewayClass")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.GatewayClass) = gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{Name: gatewayClass.Name},
+				}
+				return nil
+			}).
+			Once()
+		mockStatusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.GatewayClass"), mock.Anything).
+			Return(updateErr).
+			Once().
+			NotBefore(getCall)
+
+		err := model.setCondition(t.Context(), setConditionParams{
+			resource:      gatewayClass,
+			conditions:    &gatewayClass.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayClassConditionStatusAccepted),
+			status:        metav1.ConditionTrue,
+			reason:        string(gatewayv1.GatewayClassReasonAccepted),
+			message:       "accepted",
+		})
+
+		require.ErrorIs(t, err, updateErr)
+		require.ErrorContains(t, err, "failed to update status")
+	})
+
+	t.Run("StatusUpdateConflict_ReturnsRefreshError", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "gateway-class-" + fake.Lorem().Word()},
+		}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "gatewayclasses"},
+			gatewayClass.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("refresh failed")
+
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+		mockStatusWriter.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(conflictErr).Once()
+		mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Name: gatewayClass.Name}, mock.AnythingOfType("*v1.GatewayClass")).
+			Return(wantErr).
+			Once()
+
+		err := model.setCondition(t.Context(), setConditionParams{
+			resource:      gatewayClass,
+			conditions:    &gatewayClass.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayClassConditionStatusAccepted),
+			status:        metav1.ConditionTrue,
+			reason:        string(gatewayv1.GatewayClassReasonAccepted),
+			message:       "accepted",
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to refresh resource")
+	})
+
+	t.Run("StatusUpdateConflict_ReturnsParentResolutionError", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+
+		targetConditions := []metav1.Condition{{Type: string(gatewayv1.RouteConditionResolvedRefs)}}
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "routes-" + fake.Lorem().Word(),
+				Name:      "route-" + fake.Lorem().Word(),
+			},
+			Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{{
+					ParentRef:      gatewayv1.ParentReference{Name: "edge"},
+					ControllerName: gatewayv1.GatewayController(ControllerClassName),
+					Conditions:     targetConditions,
+				}},
+			}},
+		}
+		latestRoute := route.DeepCopy()
+		latestRoute.Status.Parents = []gatewayv1.RouteParentStatus{
+			{
+				ParentRef:      gatewayv1.ParentReference{Name: "other"},
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			},
+			{
+				ParentRef:      gatewayv1.ParentReference{Name: "another"},
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+			},
+		}
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(route), mock.AnythingOfType("*v1.HTTPRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.HTTPRoute) = *latestRoute
+				return nil
+			}).
+			Once()
+
+		err := model.updateResourceStatusAfterConflict(t.Context(), setConditionParams{
+			resource:   route,
+			conditions: &route.Status.Parents[0].Conditions,
+		}, metav1.Condition{
+			Type:   string(gatewayv1.RouteConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonResolvedRefs),
+		})
+
+		require.ErrorContains(t, err, "failed to resolve route parent status")
+	})
+
 	t.Run("HappyPath_AddsFinalizer_NoAnnotations", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
@@ -496,6 +709,158 @@ func TestResourcesModelImpl_setCondition(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("ResourceUpdateConflict_RefreshesAndUpdatesMetadata", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+
+		finalizerName := "test-finalizer/" + fake.Lorem().Word()
+		annotationKey := "annotation-" + fake.Lorem().Word()
+		annotationValue := "value-" + fake.Lorem().Word()
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "gateway-class-" + fake.Lorem().Word(),
+				Generation: rand.Int64N(1000) + 1,
+			},
+			Status: gatewayv1.GatewayClassStatus{Conditions: []metav1.Condition{}},
+		}
+		latestGatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            gatewayClass.Name,
+				Generation:      gatewayClass.Generation,
+				ResourceVersion: "latest",
+			},
+		}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "gatewayclasses"},
+			gatewayClass.Name,
+			errors.New("modified"),
+		)
+
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+		mockStatusWriter.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(nil).Once()
+		conflictCall := mockClient.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(conflictErr).Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Name: gatewayClass.Name}, mock.AnythingOfType("*v1.GatewayClass")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.GatewayClass) = *latestGatewayClass
+				return nil
+			}).
+			Once().
+			NotBefore(conflictCall)
+		mockClient.EXPECT().Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+			updated := obj.(*gatewayv1.GatewayClass)
+			if updated.ResourceVersion != "latest" {
+				return false
+			}
+			assert.Contains(t, updated.Finalizers, finalizerName)
+			assert.Equal(t, annotationValue, updated.Annotations[annotationKey])
+			return true
+		}), mock.Anything).Return(nil).Once().NotBefore(getCall)
+
+		err := model.setCondition(t.Context(), setConditionParams{
+			resource:      gatewayClass,
+			conditions:    &gatewayClass.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayClassConditionStatusAccepted),
+			status:        metav1.ConditionTrue,
+			reason:        string(gatewayv1.GatewayClassReasonAccepted),
+			message:       "accepted",
+			finalizer:     finalizerName,
+			annotations:   map[string]string{annotationKey: annotationValue},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ResourceUpdateConflict_ReturnsRefreshErrors", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "gateway-class-" + fake.Lorem().Word()},
+		}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "gatewayclasses"},
+			gatewayClass.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("refresh failed")
+
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+		mockStatusWriter.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(nil).Once()
+		mockClient.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(conflictErr).Once()
+		mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Name: gatewayClass.Name}, mock.AnythingOfType("*v1.GatewayClass")).
+			Return(wantErr).
+			Once()
+
+		err := model.setCondition(t.Context(), setConditionParams{
+			resource:      gatewayClass,
+			conditions:    &gatewayClass.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayClassConditionStatusAccepted),
+			status:        metav1.ConditionTrue,
+			reason:        string(gatewayv1.GatewayClassReasonAccepted),
+			message:       "accepted",
+			finalizer:     "test-finalizer/" + fake.Lorem().Word(),
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to refresh resource")
+	})
+
+	t.Run("ResourceUpdateConflict_ReturnsRetryUpdateErrors", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newResourcesModel(deps)
+		mockClient, _ := deps.K8sClient.(*Mockk8sClient)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+
+		gatewayClass := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "gateway-class-" + fake.Lorem().Word()},
+		}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "gatewayclasses"},
+			gatewayClass.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("retry update failed")
+
+		mockClient.EXPECT().Status().Return(mockStatusWriter).Once()
+		mockStatusWriter.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(nil).Once()
+		mockClient.EXPECT().Update(t.Context(), gatewayClass, mock.Anything).Return(conflictErr).Once()
+		mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Name: gatewayClass.Name}, mock.AnythingOfType("*v1.GatewayClass")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.GatewayClass) = gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{Name: gatewayClass.Name},
+				}
+				return nil
+			}).
+			Once()
+		mockClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.GatewayClass"), mock.Anything).
+			Return(wantErr).
+			Once()
+
+		err := model.setCondition(t.Context(), setConditionParams{
+			resource:      gatewayClass,
+			conditions:    &gatewayClass.Status.Conditions,
+			conditionType: string(gatewayv1.GatewayClassConditionStatusAccepted),
+			status:        metav1.ConditionTrue,
+			reason:        string(gatewayv1.GatewayClassReasonAccepted),
+			message:       "accepted",
+			finalizer:     "test-finalizer/" + fake.Lorem().Word(),
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to update resource")
+	})
+
 	t.Run("ErrorPath_FinalizerUpdateFails", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
@@ -590,6 +955,128 @@ func TestResourcesModelImpl_setCondition(t *testing.T) {
 	})
 }
 
+func TestResourcesModelImpl_statusConditionsForRetry(t *testing.T) {
+	fake := faker.New()
+
+	t.Run("returns top level Gateway conditions", func(t *testing.T) {
+		gateway := &gatewayv1.Gateway{Status: gatewayv1.GatewayStatus{Conditions: []metav1.Condition{{
+			Type:   "Programmed",
+			Status: metav1.ConditionUnknown,
+			Reason: "Pending-" + fake.Lorem().Word(),
+		}}}}
+
+		conditions, err := statusConditionsForRetry(gateway, gateway, nil)
+
+		require.NoError(t, err)
+		require.Same(t, &gateway.Status.Conditions[0], &(*conditions)[0])
+	})
+
+	t.Run("returns top level ListenerSet conditions", func(t *testing.T) {
+		listenerSet := &gatewayv1.ListenerSet{Status: gatewayv1.ListenerSetStatus{Conditions: []metav1.Condition{{
+			Type:   "Accepted",
+			Status: metav1.ConditionUnknown,
+			Reason: "Pending-" + fake.Lorem().Word(),
+		}}}}
+
+		conditions, err := statusConditionsForRetry(listenerSet, listenerSet, nil)
+
+		require.NoError(t, err)
+		require.Same(t, &listenerSet.Status.Conditions[0], &(*conditions)[0])
+	})
+
+	t.Run("returns matching HTTPRoute parent conditions", func(t *testing.T) {
+		targetConditions := []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonResolvedRefs),
+		}}
+		otherParentName := gatewayv1.ObjectName("other-" + fake.Lorem().Word())
+		edgeParentName := gatewayv1.ObjectName("edge-" + fake.Lorem().Word())
+		original := &gatewayv1.HTTPRoute{Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{
+			Parents: []gatewayv1.RouteParentStatus{
+				{
+					ParentRef:      gatewayv1.ParentReference{Name: otherParentName},
+					ControllerName: gatewayv1.GatewayController(ControllerClassName),
+					Conditions:     []metav1.Condition{{Type: "Accepted", Status: metav1.ConditionTrue}},
+				},
+				{
+					ParentRef:      gatewayv1.ParentReference{Name: edgeParentName},
+					ControllerName: gatewayv1.GatewayController(ControllerClassName),
+					Conditions:     targetConditions,
+				},
+			},
+		}}}
+		latest := original.DeepCopy()
+		latest.Status.Parents[1].Conditions = []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionResolvedRefs),
+			Status: metav1.ConditionUnknown,
+			Reason: string(gatewayv1.RouteReasonPending),
+		}}
+
+		conditions, err := statusConditionsForRetry(latest, original, targetConditions)
+
+		require.NoError(t, err)
+		require.Same(t, &latest.Status.Parents[1].Conditions[0], &(*conditions)[0])
+	})
+
+	t.Run("returns matching GRPCRoute parent conditions", func(t *testing.T) {
+		targetConditions := []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionFalse,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}}
+		parentName := gatewayv1.ObjectName("grpc-" + fake.Lorem().Word())
+		original := &gatewayv1.GRPCRoute{Status: gatewayv1.GRPCRouteStatus{RouteStatus: gatewayv1.RouteStatus{
+			Parents: []gatewayv1.RouteParentStatus{{
+				ParentRef:      gatewayv1.ParentReference{Name: parentName},
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+				Conditions:     targetConditions,
+			}},
+		}}}
+		latest := original.DeepCopy()
+
+		conditions, err := statusConditionsForRetry(latest, original, targetConditions)
+
+		require.NoError(t, err)
+		require.Same(t, &latest.Status.Parents[0].Conditions[0], &(*conditions)[0])
+	})
+
+	t.Run("returns error for mismatched route original type", func(t *testing.T) {
+		latest := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "route-" + fake.Lorem().Word()}}
+		original := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gateway-" + fake.Lorem().Word()}}
+
+		conditions, err := statusConditionsForRetry(latest, original, nil)
+
+		require.Nil(t, conditions)
+		require.ErrorContains(t, err, "failed to resolve status conditions")
+	})
+
+	t.Run("returns error when route parent is not found", func(t *testing.T) {
+		targetConditions := []metav1.Condition{{Type: string(gatewayv1.RouteConditionAccepted)}}
+		edgeParentName := gatewayv1.ObjectName("edge-" + fake.Lorem().Word())
+		otherParentName := gatewayv1.ObjectName("other-" + fake.Lorem().Word())
+		anotherParentName := gatewayv1.ObjectName("another-" + fake.Lorem().Word())
+		original := &gatewayv1.HTTPRoute{Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{
+			Parents: []gatewayv1.RouteParentStatus{{
+				ParentRef:      gatewayv1.ParentReference{Name: edgeParentName},
+				ControllerName: gatewayv1.GatewayController(ControllerClassName),
+				Conditions:     targetConditions,
+			}},
+		}}}
+		latest := original.DeepCopy()
+		latest.Status.Parents[0].ParentRef.Name = otherParentName
+		latest.Status.Parents = append(latest.Status.Parents, gatewayv1.RouteParentStatus{
+			ParentRef:      gatewayv1.ParentReference{Name: anotherParentName},
+			ControllerName: gatewayv1.GatewayController(ControllerClassName),
+		})
+
+		conditions, err := statusConditionsForRetry(latest, original, targetConditions)
+
+		require.Nil(t, conditions)
+		require.ErrorContains(t, err, "failed to resolve route parent status")
+	})
+}
+
 func TestResourcesModelImpl_isConditionSet(t *testing.T) {
 	newMockDeps := func(t *testing.T) resourcesModelDeps {
 		return resourcesModelDeps{
@@ -656,6 +1143,11 @@ func TestResourcesModelImpl_isConditionSet(t *testing.T) {
 	randomConditionWithObservedGeneration := func(observedGeneration int64) randomConditionsOpt {
 		return func(condition *metav1.Condition) {
 			condition.ObservedGeneration = observedGeneration
+		}
+	}
+	randomConditionWithStatus := func(status metav1.ConditionStatus) randomConditionsOpt {
+		return func(condition *metav1.Condition) {
+			condition.Status = status
 		}
 	}
 
@@ -736,6 +1228,39 @@ func TestResourcesModelImpl_isConditionSet(t *testing.T) {
 		}
 		result := model.isConditionSet(params)
 		assert.False(t, result, "Expected false for wrong observed generation")
+	})
+
+	t.Run("ConditionSet_CurrentGenerationButNotTrue", func(t *testing.T) {
+		fake := faker.New()
+		model := newResourcesModel(newMockDeps(t))
+		conditionType := fake.Internet().Domain()
+		generation := rand.Int64()
+
+		for _, status := range []metav1.ConditionStatus{
+			metav1.ConditionFalse,
+			metav1.ConditionUnknown,
+		} {
+			t.Run(string(status), func(t *testing.T) {
+				gatewayClass := newRandomResource(
+					randomResourceWithGeneration(generation),
+					randomResourceWithConditions(
+						newRandomConditions(
+							randomConditionWithType(conditionType),
+							randomConditionWithObservedGeneration(generation),
+							randomConditionWithStatus(status),
+						),
+					),
+				)
+
+				result := model.isConditionSet(isConditionSetParams{
+					resource:      gatewayClass,
+					conditions:    gatewayClass.Status.Conditions,
+					conditionType: conditionType,
+				})
+
+				assert.False(t, result, "Expected false for current generation condition that is not True")
+			})
+		}
 	})
 
 	t.Run("ConditionSetAndMatches_WithMatchingAnnotations", func(t *testing.T) {

--- a/internal/app/tcproute_controller.go
+++ b/internal/app/tcproute_controller.go
@@ -47,16 +47,23 @@ func (r *TCPRouteController) Reconcile(ctx context.Context, req reconcile.Reques
 		route:         func(details resolvedTCPRouteDetails) client.Object { return &details.tcpRoute },
 		deprovision:   r.tcpRouteModel.deprovisionRoute,
 		program:       r.tcpRouteModel.programRoute,
+		setPending:    r.tcpRouteModel.setPending,
 		setProgrammed: r.tcpRouteModel.setProgrammed,
 		driftInterval: r.driftInterval,
-		setRejected: func(details resolvedTCPRouteDetails, err error) (bool, error) {
-			var statusErr tcpRouteStatusError
-			if errors.As(err, &statusErr) {
-				return true, r.tcpRouteModel.setRejected(ctx, details, statusErr)
-			}
-			return false, nil
-		},
+		setRejected:   r.setRejected(ctx),
 	})
+}
+
+func (r *TCPRouteController) setRejected(
+	ctx context.Context,
+) func(resolvedTCPRouteDetails, error) (bool, error) {
+	return func(details resolvedTCPRouteDetails, err error) (bool, error) {
+		var statusErr tcpRouteStatusError
+		if errors.As(err, &statusErr) {
+			return true, r.tcpRouteModel.setRejected(ctx, details, statusErr)
+		}
+		return false, nil
+	}
 }
 
 type reconcileL4RouteParams[D any] struct {
@@ -69,6 +76,7 @@ type reconcileL4RouteParams[D any] struct {
 	route         func(D) client.Object
 	deprovision   func(context.Context, D) error
 	program       func(context.Context, D) error
+	setPending    func(context.Context, D) error
 	setProgrammed func(context.Context, D) error
 	driftInterval time.Duration
 	setRejected   func(D, error) (bool, error)
@@ -122,6 +130,10 @@ func reconcileResolvedL4Route[D any](
 			return fmt.Errorf("failed to deprovision %s %s: %w", params.routeKind, params.req.NamespacedName, err)
 		}
 		return nil
+	}
+
+	if err := params.setPending(ctx, resolvedRoute); err != nil {
+		return fmt.Errorf("failed to set %s %s pending status: %w", params.routeKind, params.req.NamespacedName, err)
 	}
 
 	if err := params.program(ctx, resolvedRoute); err != nil {

--- a/internal/app/tcproute_model.go
+++ b/internal/app/tcproute_model.go
@@ -35,6 +35,7 @@ type tcpRouteModel interface {
 	resolveRequest(ctx context.Context, req reconcile.Request) ([]resolvedTCPRouteDetails, error)
 	programRoute(ctx context.Context, details resolvedTCPRouteDetails) error
 	deprovisionRoute(ctx context.Context, details resolvedTCPRouteDetails) error
+	setPending(ctx context.Context, details resolvedTCPRouteDetails) error
 	setProgrammed(ctx context.Context, details resolvedTCPRouteDetails) error
 	setRejected(ctx context.Context, details resolvedTCPRouteDetails, statusErr tcpRouteStatusError) error
 }
@@ -1359,7 +1360,33 @@ func (m *tcpRouteModelImpl) updateParentStatus(
 	)
 
 	if err := m.client.Status().Update(ctx, &details.tcpRoute); err != nil {
+		if apierrors.IsConflict(err) {
+			if retryErr := m.updateParentStatusAfterConflict(ctx, details, conditions); retryErr != nil {
+				return retryErr
+			}
+			return nil
+		}
 		return fmt.Errorf("failed to update TCPRoute %s status: %w", details.tcpRoute.Name, err)
+	}
+	return nil
+}
+
+func (m *tcpRouteModelImpl) updateParentStatusAfterConflict(
+	ctx context.Context,
+	details resolvedTCPRouteDetails,
+	conditions []metav1.Condition,
+) error {
+	latest := details.tcpRoute.DeepCopy()
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(&details.tcpRoute), latest); err != nil {
+		return fmt.Errorf("failed to refresh TCPRoute %s status after conflict: %w", details.tcpRoute.Name, err)
+	}
+	latest.Status.Parents = mergeL4RouteParentStatus(
+		latest.Status.Parents,
+		details.matchedRef,
+		conditions,
+	)
+	if err := m.client.Status().Update(ctx, latest); err != nil {
+		return fmt.Errorf("failed to update TCPRoute %s status after conflict: %w", details.tcpRoute.Name, err)
 	}
 	return nil
 }
@@ -1412,6 +1439,23 @@ func (m *tcpRouteModelImpl) setProgrammed(ctx context.Context, details resolvedT
 	})
 }
 
+func (m *tcpRouteModelImpl) setPending(ctx context.Context, details resolvedTCPRouteDetails) error {
+	routeToUpdate := details.tcpRoute.DeepCopy()
+	return setL4RoutePending(setL4RoutePendingParams{
+		routeKind:      "TCPRoute",
+		controllerName: NetworkLoadBalancerControllerClassName,
+		routeToUpdate:  routeToUpdate,
+		updateParentStatus: func(conditions []metav1.Condition) error {
+			return m.updateParentStatus(ctx, resolvedTCPRouteDetails{
+				gatewayDetails:  details.gatewayDetails,
+				tcpRoute:        *routeToUpdate,
+				matchedRef:      details.matchedRef,
+				matchedListener: details.matchedListener,
+			}, conditions)
+		},
+	})
+}
+
 type setL4RouteProgrammedParams struct {
 	k8sClient          k8sClient
 	routeKind          string
@@ -1425,29 +1469,10 @@ type setL4RouteProgrammedParams struct {
 }
 
 func setL4RouteProgrammed(ctx context.Context, params setL4RouteProgrammedParams) error {
-	needsUpdate := controllerutil.AddFinalizer(params.routeToUpdate, params.finalizer)
-	if len(params.desiredBackendSets) > 0 {
-		setAnnotatedBackendSetNames(params.routeToUpdate, params.backendSetAnnotKey, params.desiredBackendSets)
-		needsUpdate = true
-	}
-	if params.loadBalancerID != "" &&
-		params.routeToUpdate.GetAnnotations()[L4RouteProgrammedNetworkLoadBalancerIDAnnotation] != params.loadBalancerID {
-		annotations := params.routeToUpdate.GetAnnotations()
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-		annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation] = params.loadBalancerID
-		params.routeToUpdate.SetAnnotations(annotations)
-		needsUpdate = true
-	}
+	needsUpdate := applyL4RouteProgrammedMetadata(params, params.routeToUpdate)
 	if needsUpdate {
-		if err := params.k8sClient.Update(ctx, params.routeToUpdate); err != nil {
-			return fmt.Errorf("failed to update %s %s/%s finalizer and annotations: %w",
-				params.routeKind,
-				params.routeToUpdate.GetNamespace(),
-				params.routeToUpdate.GetName(),
-				err,
-			)
+		if err := updateL4RouteProgrammedMetadata(ctx, params); err != nil {
+			return err
 		}
 	}
 
@@ -1470,6 +1495,110 @@ func setL4RouteProgrammed(ctx context.Context, params setL4RouteProgrammedParams
 			Status:             metav1.ConditionTrue,
 			Reason:             string(gatewayv1.RouteReasonResolvedRefs),
 			Message:            "Backend references resolved",
+			ObservedGeneration: params.routeToUpdate.GetGeneration(),
+			LastTransitionTime: metav1.Now(),
+		},
+	})
+}
+
+func applyL4RouteProgrammedMetadata(params setL4RouteProgrammedParams, route client.Object) bool {
+	needsUpdate := controllerutil.AddFinalizer(route, params.finalizer)
+	if len(params.desiredBackendSets) > 0 {
+		setAnnotatedBackendSetNames(route, params.backendSetAnnotKey, params.desiredBackendSets)
+		needsUpdate = true
+	}
+	if params.loadBalancerID != "" &&
+		route.GetAnnotations()[L4RouteProgrammedNetworkLoadBalancerIDAnnotation] != params.loadBalancerID {
+		annotations := route.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation] = params.loadBalancerID
+		route.SetAnnotations(annotations)
+		needsUpdate = true
+	}
+	return needsUpdate
+}
+
+func updateL4RouteProgrammedMetadata(ctx context.Context, params setL4RouteProgrammedParams) error {
+	if err := params.k8sClient.Update(ctx, params.routeToUpdate); err != nil {
+		if apierrors.IsConflict(err) {
+			if retryErr := updateL4RouteProgrammedMetadataAfterConflict(ctx, params); retryErr != nil {
+				return retryErr
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to update %s %s/%s finalizer and annotations: %w",
+			params.routeKind,
+			params.routeToUpdate.GetNamespace(),
+			params.routeToUpdate.GetName(),
+			err,
+		)
+	}
+	return nil
+}
+
+func updateL4RouteProgrammedMetadataAfterConflict(
+	ctx context.Context,
+	params setL4RouteProgrammedParams,
+) error {
+	latest, ok := params.routeToUpdate.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf(
+			"failed to copy %s %s/%s for finalizer and annotations update",
+			params.routeKind,
+			params.routeToUpdate.GetNamespace(),
+			params.routeToUpdate.GetName(),
+		)
+	}
+	if err := params.k8sClient.Get(ctx, client.ObjectKeyFromObject(params.routeToUpdate), latest); err != nil {
+		return fmt.Errorf(
+			"failed to refresh %s %s/%s after finalizer and annotations conflict: %w",
+			params.routeKind,
+			params.routeToUpdate.GetNamespace(),
+			params.routeToUpdate.GetName(),
+			err,
+		)
+	}
+	applyL4RouteProgrammedMetadata(params, latest)
+	if err := params.k8sClient.Update(ctx, latest); err != nil {
+		return fmt.Errorf("failed to update %s %s/%s finalizer and annotations: %w",
+			params.routeKind,
+			params.routeToUpdate.GetNamespace(),
+			params.routeToUpdate.GetName(),
+			err,
+		)
+	}
+	return nil
+}
+
+type setL4RoutePendingParams struct {
+	routeKind          string
+	controllerName     gatewayv1.GatewayController
+	routeToUpdate      client.Object
+	updateParentStatus func([]metav1.Condition) error
+}
+
+func setL4RoutePending(params setL4RoutePendingParams) error {
+	return params.updateParentStatus([]metav1.Condition{
+		{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+			Message: fmt.Sprintf(
+				"%s %s accepted by %s",
+				params.routeKind,
+				params.routeToUpdate.GetName(),
+				params.controllerName,
+			),
+			ObservedGeneration: params.routeToUpdate.GetGeneration(),
+			LastTransitionTime: metav1.Now(),
+		},
+		{
+			Type:               string(gatewayv1.RouteConditionResolvedRefs),
+			Status:             metav1.ConditionUnknown,
+			Reason:             string(gatewayv1.RouteReasonPending),
+			Message:            "Route programming is in progress",
 			ObservedGeneration: params.routeToUpdate.GetGeneration(),
 			LastTransitionTime: metav1.Now(),
 		},

--- a/internal/app/tcproute_model_test.go
+++ b/internal/app/tcproute_model_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jaswdr/faker/v2"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -1003,6 +1005,260 @@ func TestTCPRouteModel(t *testing.T) {
 		require.ErrorContains(t, err, "failed to update TCPRoute rtmp status")
 	})
 
+	t.Run("updateParentStatus preserves non matching parent status", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "rtmp",
+				Generation: 2,
+			},
+			Status: gatewayv1.TCPRouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
+					Parents: []gatewayv1.RouteParentStatus{{
+						ParentRef:      gatewayv1.ParentReference{Name: "other"},
+						ControllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+					}},
+				},
+			},
+		}
+		mockClient := NewMockk8sClient(t)
+		mockStatusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(mockStatusWriter)
+		mockStatusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+				updated := mustTCPRoute(t, obj)
+				require.Len(t, updated.Status.Parents, 2)
+				assert.Equal(t, gatewayv1.ObjectName("other"), updated.Status.Parents[0].ParentRef.Name)
+				assert.Equal(t, gatewayv1.ObjectName("edge"), updated.Status.Parents[1].ParentRef.Name)
+				assert.Len(t, updated.Status.Parents[1].Conditions, 1)
+				return nil
+			}).
+			Once()
+
+		model := newTCPRouteModel(tcpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		err := model.updateParentStatus(t.Context(), resolvedTCPRouteDetails{
+			tcpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("setProgrammed succeeds after pending status update", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "rtmp",
+				Generation: 2,
+			},
+			Status: gatewayv1.TCPRouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
+					Parents: []gatewayv1.RouteParentStatus{{
+						ParentRef:      gatewayv1.ParentReference{Name: "edge"},
+						ControllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+					}},
+				},
+			},
+		}
+		details := resolvedTCPRouteDetails{
+			tcpRoute: route,
+			gatewayDetails: resolvedGatewayDetails{
+				gateway: gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "edge"},
+					Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{
+						{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+					}},
+				},
+				config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: "nlb-id"}},
+			},
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(newL4TestScheme(t)).
+			WithStatusSubresource(&gatewayv1.TCPRoute{}).
+			WithObjects(&route).
+			Build()
+		model := newTCPRouteModel(tcpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+
+		require.NoError(t, model.setPending(t.Context(), details))
+		require.NoError(t, model.setProgrammed(t.Context(), details))
+
+		var updated gatewayv1.TCPRoute
+		require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(&route), &updated))
+		assert.Contains(t, updated.Finalizers, NetworkLoadBalancerTCPRouteProgrammedFinalizer)
+		assert.Equal(t, "nlb-id", updated.Annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation])
+		assert.Equal(t,
+			string(gatewayv1.RouteReasonResolvedRefs),
+			meta.FindStatusCondition(
+				updated.Status.Parents[0].Conditions,
+				string(gatewayv1.RouteConditionResolvedRefs),
+			).Reason,
+		)
+	})
+
+	t.Run("setProgrammed refreshes and updates status after conflict", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "rtmp",
+				Generation: 2,
+				Finalizers: []string{NetworkLoadBalancerTCPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation: "bs_rtmp",
+				},
+			},
+		}
+		latestRoute := route.DeepCopy()
+		latestRoute.ResourceVersion = "latest"
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tcproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		mockClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(statusWriter).Twice()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			Return(conflictErr).
+			Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.TCPRoute) = *latestRoute
+				return nil
+			}).
+			Once()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updated := obj.(*gatewayv1.TCPRoute)
+				condition := meta.FindStatusCondition(
+					updated.Status.Parents[0].Conditions,
+					string(gatewayv1.RouteConditionAccepted),
+				)
+				return updated.ResourceVersion == "latest" &&
+					condition != nil &&
+					condition.Status == metav1.ConditionTrue
+			}), mock.Anything).
+			Return(nil).
+			Once().
+			NotBefore(getCall)
+
+		model := newTCPRouteModel(tcpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		err := model.updateParentStatus(t.Context(), resolvedTCPRouteDetails{
+			tcpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("setProgrammed returns status retry errors after conflict", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "rtmp",
+				Generation: 2,
+				Finalizers: []string{NetworkLoadBalancerTCPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerTCPRouteProgrammedBackendSetsAnnotation: "bs_rtmp",
+				},
+			},
+		}
+		latestRoute := route.DeepCopy()
+		latestRoute.ResourceVersion = "latest"
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tcproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("retry update failed")
+		mockClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(statusWriter).Twice()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			Return(conflictErr).
+			Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.TCPRoute) = *latestRoute
+				return nil
+			}).
+			Once()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute"), mock.Anything).
+			Return(wantErr).
+			Once().
+			NotBefore(getCall)
+
+		model := newTCPRouteModel(tcpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		err := model.updateParentStatus(t.Context(), resolvedTCPRouteDetails{
+			tcpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to update TCPRoute")
+	})
+
+	t.Run("setProgrammed returns status refresh errors after conflict", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "iot",
+			Name:       "rtmp",
+			Generation: 2,
+		}}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tcproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("refresh failed")
+		mockClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(statusWriter).Once()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			Return(conflictErr).
+			Once()
+		mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.TCPRoute")).
+			Return(wantErr).
+			Once()
+
+		model := newTCPRouteModel(tcpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		err := model.updateParentStatus(t.Context(), resolvedTCPRouteDetails{
+			tcpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to refresh TCPRoute")
+	})
+
 	t.Run("setL4RouteProgrammed records load balancer id when annotations are nil", func(t *testing.T) {
 		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
 			Namespace:  "iot",
@@ -1028,6 +1284,229 @@ func TestTCPRouteModel(t *testing.T) {
 				require.Len(t, conditions, 2)
 				return nil
 			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("setL4RouteProgrammed retries metadata update after conflict", func(t *testing.T) {
+		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "iot",
+			Name:       "rtmp",
+			Generation: 1,
+		}}
+		latestRoute := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:       route.Namespace,
+			Name:            route.Name,
+			ResourceVersion: "latest",
+		}}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tcproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		mockClient := NewMockk8sClient(t)
+		conflictCall := mockClient.EXPECT().
+			Update(t.Context(), route, mock.Anything).
+			Return(conflictErr).
+			Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(route), mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.TCPRoute) = *latestRoute
+				return nil
+			}).
+			Once().
+			NotBefore(conflictCall)
+		mockClient.EXPECT().
+			Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updated := obj.(*gatewayv1.TCPRoute)
+				return updated.ResourceVersion == "latest" &&
+					assert.Contains(t, updated.Finalizers, NetworkLoadBalancerTCPRouteProgrammedFinalizer) &&
+					assert.Equal(t, "nlb-id", updated.Annotations[L4RouteProgrammedNetworkLoadBalancerIDAnnotation])
+			}), mock.Anything).
+			Return(nil).
+			Once().
+			NotBefore(getCall)
+
+		err := setL4RouteProgrammed(t.Context(), setL4RouteProgrammedParams{
+			k8sClient:      mockClient,
+			routeKind:      "TCPRoute",
+			controllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+			routeToUpdate:  route,
+			finalizer:      NetworkLoadBalancerTCPRouteProgrammedFinalizer,
+			loadBalancerID: "nlb-id",
+			updateParentStatus: func(conditions []metav1.Condition) error {
+				require.Len(t, conditions, 2)
+				return nil
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("updateL4RouteProgrammedMetadata returns conflict retry errors", func(t *testing.T) {
+		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "rtmp"}}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tcproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("refresh failed")
+		mockClient := NewMockk8sClient(t)
+		conflictCall := mockClient.EXPECT().
+			Update(t.Context(), route, mock.Anything).
+			Return(conflictErr).
+			Once()
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(route), mock.AnythingOfType("*v1.TCPRoute")).
+			Return(wantErr).
+			Once().
+			NotBefore(conflictCall)
+
+		err := updateL4RouteProgrammedMetadata(t.Context(), setL4RouteProgrammedParams{
+			k8sClient:     mockClient,
+			routeKind:     "TCPRoute",
+			routeToUpdate: route,
+			finalizer:     NetworkLoadBalancerTCPRouteProgrammedFinalizer,
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to refresh TCPRoute iot/rtmp")
+	})
+
+	t.Run("updateL4RouteProgrammedMetadata wraps update errors", func(t *testing.T) {
+		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "rtmp"}}
+		wantErr := errors.New("update failed")
+		mockClient := NewMockk8sClient(t)
+		mockClient.EXPECT().
+			Update(t.Context(), route, mock.Anything).
+			Return(wantErr).
+			Once()
+
+		err := updateL4RouteProgrammedMetadata(t.Context(), setL4RouteProgrammedParams{
+			k8sClient:     mockClient,
+			routeKind:     "TCPRoute",
+			routeToUpdate: route,
+			finalizer:     NetworkLoadBalancerTCPRouteProgrammedFinalizer,
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to update TCPRoute iot/rtmp")
+	})
+
+	t.Run("updateL4RouteProgrammedMetadataAfterConflict wraps refresh errors", func(t *testing.T) {
+		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "rtmp"}}
+		mockClient := NewMockk8sClient(t)
+		wantErr := errors.New("refresh failed")
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(route), mock.AnythingOfType("*v1.TCPRoute")).
+			Return(wantErr).
+			Once()
+
+		err := updateL4RouteProgrammedMetadataAfterConflict(t.Context(), setL4RouteProgrammedParams{
+			k8sClient:     mockClient,
+			routeKind:     "TCPRoute",
+			routeToUpdate: route,
+			finalizer:     NetworkLoadBalancerTCPRouteProgrammedFinalizer,
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to refresh TCPRoute iot/rtmp")
+	})
+
+	t.Run("updateL4RouteProgrammedMetadataAfterConflict wraps retry update errors", func(t *testing.T) {
+		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "rtmp"}}
+		mockClient := NewMockk8sClient(t)
+		wantErr := errors.New("retry update failed")
+		mockClient.EXPECT().
+			Get(t.Context(), client.ObjectKeyFromObject(route), mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.TCPRoute) = gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
+					Namespace: route.Namespace,
+					Name:      route.Name,
+				}}
+				return nil
+			}).
+			Once()
+		mockClient.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute"), mock.Anything).
+			Return(wantErr).
+			Once()
+
+		err := updateL4RouteProgrammedMetadataAfterConflict(t.Context(), setL4RouteProgrammedParams{
+			k8sClient:     mockClient,
+			routeKind:     "TCPRoute",
+			routeToUpdate: route,
+			finalizer:     NetworkLoadBalancerTCPRouteProgrammedFinalizer,
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to update TCPRoute iot/rtmp")
+	})
+
+	t.Run("setL4RoutePending sets accepted and pending resolved refs conditions", func(t *testing.T) {
+		fake := faker.New()
+		route := &gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "iot-" + fake.Lorem().Word(),
+			Name:       "rtmp-" + fake.Lorem().Word(),
+			Generation: 1,
+		}}
+
+		err := setL4RoutePending(setL4RoutePendingParams{
+			routeKind:      "TCPRoute",
+			controllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+			routeToUpdate:  route,
+			updateParentStatus: func(conditions []metav1.Condition) error {
+				require.Len(t, conditions, 2)
+
+				accepted := meta.FindStatusCondition(conditions, string(gatewayv1.RouteConditionAccepted))
+				require.NotNil(t, accepted)
+				assert.Equal(t, metav1.ConditionTrue, accepted.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonAccepted), accepted.Reason)
+
+				resolvedRefs := meta.FindStatusCondition(conditions, string(gatewayv1.RouteConditionResolvedRefs))
+				require.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionUnknown, resolvedRefs.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonPending), resolvedRefs.Reason)
+				assert.Equal(t, "Route programming is in progress", resolvedRefs.Message)
+				assert.Equal(t, route.Generation, resolvedRefs.ObservedGeneration)
+				return nil
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("setPending updates TCPRoute parent status", func(t *testing.T) {
+		route := gatewayv1.TCPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "iot",
+			Name:       "rtmp",
+			Generation: 2,
+		}}
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		k8sClient.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TCPRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+				updated := mustTCPRoute(t, obj)
+				require.Len(t, updated.Status.Parents, 1)
+				resolvedRefs := meta.FindStatusCondition(
+					updated.Status.Parents[0].Conditions,
+					string(gatewayv1.RouteConditionResolvedRefs),
+				)
+				require.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionUnknown, resolvedRefs.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonPending), resolvedRefs.Reason)
+				return nil
+			})
+		model := newTCPRouteModel(tcpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+
+		err := model.setPending(t.Context(), resolvedTCPRouteDetails{
+			tcpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "rtmp", Protocol: gatewayv1.TCPProtocolType, Port: 1935},
 		})
 
 		require.NoError(t, err)

--- a/internal/app/tlsroute_controller.go
+++ b/internal/app/tlsroute_controller.go
@@ -89,6 +89,10 @@ func (r *TLSRouteController) reconcileResolvedRoute(
 		return nil
 	}
 
+	if err := r.tlsRouteModel.setPending(ctx, resolvedRoute); err != nil {
+		return fmt.Errorf("failed to set TLSRoute %s pending status: %w", req.NamespacedName, err)
+	}
+
 	if err := r.tlsRouteModel.programRoute(ctx, resolvedRoute); err != nil {
 		var statusErr tlsRouteStatusError
 		if errors.As(err, &statusErr) {

--- a/internal/app/tlsroute_model.go
+++ b/internal/app/tlsroute_model.go
@@ -43,6 +43,7 @@ type tlsRouteModel interface {
 	resolveRequest(ctx context.Context, req reconcile.Request) ([]resolvedTLSRouteDetails, error)
 	programRoute(ctx context.Context, details resolvedTLSRouteDetails) error
 	deprovisionRoute(ctx context.Context, details resolvedTLSRouteDetails) error
+	setPending(ctx context.Context, details resolvedTLSRouteDetails) error
 	setProgrammed(ctx context.Context, details resolvedTLSRouteDetails) error
 	setRejected(ctx context.Context, details resolvedTLSRouteDetails, statusErr tlsRouteStatusError) error
 }
@@ -1585,7 +1586,34 @@ func (m *tlsRouteModelImpl) updateParentStatus(
 		conditions,
 	)
 	if err := m.client.Status().Update(ctx, &details.tlsRoute); err != nil {
+		if apierrors.IsConflict(err) {
+			if retryErr := m.updateParentStatusAfterConflict(ctx, details, conditions); retryErr != nil {
+				return retryErr
+			}
+			return nil
+		}
 		return fmt.Errorf("failed to update TLSRoute %s status: %w", details.tlsRoute.Name, err)
+	}
+	return nil
+}
+
+func (m *tlsRouteModelImpl) updateParentStatusAfterConflict(
+	ctx context.Context,
+	details resolvedTLSRouteDetails,
+	conditions []metav1.Condition,
+) error {
+	latest := details.tlsRoute.DeepCopy()
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(&details.tlsRoute), latest); err != nil {
+		return fmt.Errorf("failed to refresh TLSRoute %s status after conflict: %w", details.tlsRoute.Name, err)
+	}
+	latest.Status.Parents = mergeTLSRouteParentStatus(
+		latest.Status.Parents,
+		details.matchedRef,
+		details.gatewayDetails.gatewayClass.Spec.ControllerName,
+		conditions,
+	)
+	if err := m.client.Status().Update(ctx, latest); err != nil {
+		return fmt.Errorf("failed to update TLSRoute %s status after conflict: %w", details.tlsRoute.Name, err)
 	}
 	return nil
 }
@@ -1673,6 +1701,23 @@ func (m *tlsRouteModelImpl) setProgrammed(ctx context.Context, details resolvedT
 		return err
 	}
 	return nil
+}
+
+func (m *tlsRouteModelImpl) setPending(ctx context.Context, details resolvedTLSRouteDetails) error {
+	routeToUpdate := details.tlsRoute.DeepCopy()
+	return setL4RoutePending(setL4RoutePendingParams{
+		routeKind:      "TLSRoute",
+		controllerName: details.gatewayDetails.gatewayClass.Spec.ControllerName,
+		routeToUpdate:  routeToUpdate,
+		updateParentStatus: func(conditions []metav1.Condition) error {
+			return m.updateParentStatus(ctx, resolvedTLSRouteDetails{
+				gatewayDetails:  details.gatewayDetails,
+				tlsRoute:        *routeToUpdate,
+				matchedRef:      details.matchedRef,
+				matchedListener: details.matchedListener,
+			}, conditions)
+		},
+	})
 }
 
 func (m *tlsRouteModelImpl) setRejected(

--- a/internal/app/tlsroute_model_test.go
+++ b/internal/app/tlsroute_model_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1375,6 +1377,168 @@ func TestTLSRouteModelCertificateAndStatus(t *testing.T) {
 		require.ErrorContains(t, err, "failed to update TLSRoute")
 	})
 
+	t.Run("refreshes and updates parent status after conflict", func(t *testing.T) {
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		statusModel := newTLSRouteModel(tlsRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+		route := gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "media",
+				Name:       "rtmps",
+				Generation: 2,
+			},
+		}
+		latestRoute := route.DeepCopy()
+		latestRoute.ResourceVersion = "latest"
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tlsroutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		k8sClient.EXPECT().Status().Return(statusWriter).Twice()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TLSRoute")).
+			Return(conflictErr).
+			Once()
+		getCall := k8sClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.TLSRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.TLSRoute) = *latestRoute
+				return nil
+			}).
+			Once()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updated := obj.(*gatewayv1.TLSRoute)
+				condition := meta.FindStatusCondition(
+					updated.Status.Parents[0].Conditions,
+					string(gatewayv1.RouteConditionAccepted),
+				)
+				return updated.ResourceVersion == "latest" &&
+					condition != nil &&
+					condition.Status == metav1.ConditionTrue
+			}), mock.Anything).
+			Return(nil).
+			Once().
+			NotBefore(getCall)
+
+		err := statusModel.updateParentStatus(t.Context(), resolvedTLSRouteDetails{
+			tlsRoute: route,
+			matchedRef: gatewayv1.ParentReference{
+				Name: "edge",
+			},
+			gatewayDetails: resolvedGatewayDetails{
+				gatewayClass: gatewayv1.GatewayClass{Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerClassName,
+				}},
+			},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("returns parent status retry errors after conflict", func(t *testing.T) {
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		statusModel := newTLSRouteModel(tlsRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+		route := gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "media",
+				Name:       "rtmps",
+				Generation: 2,
+			},
+		}
+		latestRoute := route.DeepCopy()
+		latestRoute.ResourceVersion = "latest"
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tlsroutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("retry update failed")
+		k8sClient.EXPECT().Status().Return(statusWriter).Twice()
+		statusWriter.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.TLSRoute")).Return(conflictErr).Once()
+		getCall := k8sClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.TLSRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.TLSRoute) = *latestRoute
+				return nil
+			}).
+			Once()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TLSRoute"), mock.Anything).
+			Return(wantErr).
+			Once().
+			NotBefore(getCall)
+
+		err := statusModel.updateParentStatus(t.Context(), resolvedTLSRouteDetails{
+			tlsRoute: route,
+			matchedRef: gatewayv1.ParentReference{
+				Name: "edge",
+			},
+			gatewayDetails: resolvedGatewayDetails{
+				gatewayClass: gatewayv1.GatewayClass{Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerClassName,
+				}},
+			},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to update TLSRoute")
+	})
+
+	t.Run("returns parent status refresh errors after conflict", func(t *testing.T) {
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		statusModel := newTLSRouteModel(tlsRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+		route := gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "media",
+				Name:       "rtmps",
+				Generation: 2,
+			},
+		}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "tlsroutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("refresh failed")
+		k8sClient.EXPECT().Status().Return(statusWriter).Once()
+		statusWriter.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.TLSRoute")).Return(conflictErr).Once()
+		k8sClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.TLSRoute")).
+			Return(wantErr).
+			Once()
+
+		err := statusModel.updateParentStatus(t.Context(), resolvedTLSRouteDetails{
+			tlsRoute: route,
+			matchedRef: gatewayv1.ParentReference{
+				Name: "edge",
+			},
+			gatewayDetails: resolvedGatewayDetails{
+				gatewayClass: gatewayv1.GatewayClass{Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerClassName,
+				}},
+			},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to refresh TLSRoute")
+	})
+
 	t.Run("returns programmed finalizer update errors", func(t *testing.T) {
 		k8sClient := NewMockk8sClient(t)
 		statusModel := newTLSRouteModel(tlsRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
@@ -1450,6 +1614,48 @@ func TestTLSRouteModelCertificateAndStatus(t *testing.T) {
 				}},
 				config: types.GatewayConfig{Spec: types.GatewayConfigSpec{LoadBalancerID: "nlb-id"}},
 			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("setPending updates TLSRoute parent status", func(t *testing.T) {
+		sectionName := gatewayv1.SectionName("rtmps")
+		route := gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "media", Name: "rtmps", Generation: 2},
+		}
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		k8sClient.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.TLSRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+				updated, ok := obj.(*gatewayv1.TLSRoute)
+				require.True(t, ok)
+				require.Len(t, updated.Status.Parents, 1)
+				resolvedRefs := meta.FindStatusCondition(
+					updated.Status.Parents[0].Conditions,
+					string(gatewayv1.RouteConditionResolvedRefs),
+				)
+				require.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionUnknown, resolvedRefs.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonPending), resolvedRefs.Reason)
+				return nil
+			})
+		statusModel := newTLSRouteModel(tlsRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+
+		err := statusModel.setPending(t.Context(), resolvedTLSRouteDetails{
+			tlsRoute: route,
+			gatewayDetails: resolvedGatewayDetails{
+				gatewayClass: gatewayv1.GatewayClass{Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerClassName,
+				}},
+			},
+			matchedRef: gatewayv1.ParentReference{
+				Name:        "edge",
+				SectionName: &sectionName,
+			},
+			matchedListener: gatewayv1.Listener{Name: "rtmps", Protocol: gatewayv1.TLSProtocolType, Port: 443},
 		})
 
 		require.NoError(t, err)

--- a/internal/app/udproute_controller.go
+++ b/internal/app/udproute_controller.go
@@ -45,14 +45,21 @@ func (r *UDPRouteController) Reconcile(ctx context.Context, req reconcile.Reques
 		route:         func(details resolvedUDPRouteDetails) client.Object { return &details.udpRoute },
 		deprovision:   r.udpRouteModel.deprovisionRoute,
 		program:       r.udpRouteModel.programRoute,
+		setPending:    r.udpRouteModel.setPending,
 		setProgrammed: r.udpRouteModel.setProgrammed,
 		driftInterval: r.driftInterval,
-		setRejected: func(details resolvedUDPRouteDetails, err error) (bool, error) {
-			var statusErr udpRouteStatusError
-			if errors.As(err, &statusErr) {
-				return true, r.udpRouteModel.setRejected(ctx, details, statusErr)
-			}
-			return false, nil
-		},
+		setRejected:   r.setRejected(ctx),
 	})
+}
+
+func (r *UDPRouteController) setRejected(
+	ctx context.Context,
+) func(resolvedUDPRouteDetails, error) (bool, error) {
+	return func(details resolvedUDPRouteDetails, err error) (bool, error) {
+		var statusErr udpRouteStatusError
+		if errors.As(err, &statusErr) {
+			return true, r.udpRouteModel.setRejected(ctx, details, statusErr)
+		}
+		return false, nil
+	}
 }

--- a/internal/app/udproute_model.go
+++ b/internal/app/udproute_model.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/dig"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +34,7 @@ type udpRouteModel interface {
 	resolveRequest(ctx context.Context, req reconcile.Request) ([]resolvedUDPRouteDetails, error)
 	programRoute(ctx context.Context, details resolvedUDPRouteDetails) error
 	deprovisionRoute(ctx context.Context, details resolvedUDPRouteDetails) error
+	setPending(ctx context.Context, details resolvedUDPRouteDetails) error
 	setProgrammed(ctx context.Context, details resolvedUDPRouteDetails) error
 	setRejected(ctx context.Context, details resolvedUDPRouteDetails, statusErr udpRouteStatusError) error
 }
@@ -819,7 +821,33 @@ func (m *udpRouteModelImpl) updateParentStatus(
 	)
 
 	if err := m.client.Status().Update(ctx, &details.udpRoute); err != nil {
+		if apierrors.IsConflict(err) {
+			if retryErr := m.updateParentStatusAfterConflict(ctx, details, conditions); retryErr != nil {
+				return retryErr
+			}
+			return nil
+		}
 		return fmt.Errorf("failed to update UDPRoute %s status: %w", details.udpRoute.Name, err)
+	}
+	return nil
+}
+
+func (m *udpRouteModelImpl) updateParentStatusAfterConflict(
+	ctx context.Context,
+	details resolvedUDPRouteDetails,
+	conditions []metav1.Condition,
+) error {
+	latest := details.udpRoute.DeepCopy()
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(&details.udpRoute), latest); err != nil {
+		return fmt.Errorf("failed to refresh UDPRoute %s status after conflict: %w", details.udpRoute.Name, err)
+	}
+	latest.Status.Parents = mergeL4RouteParentStatus(
+		latest.Status.Parents,
+		details.matchedRef,
+		conditions,
+	)
+	if err := m.client.Status().Update(ctx, latest); err != nil {
+		return fmt.Errorf("failed to update UDPRoute %s status after conflict: %w", details.udpRoute.Name, err)
 	}
 	return nil
 }
@@ -835,6 +863,23 @@ func (m *udpRouteModelImpl) setProgrammed(ctx context.Context, details resolvedU
 		backendSetAnnotKey: NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation,
 		loadBalancerID:     details.gatewayDetails.config.Spec.LoadBalancerID,
 		desiredBackendSets: desiredUDPRouteBackendSetNames(details),
+		updateParentStatus: func(conditions []metav1.Condition) error {
+			return m.updateParentStatus(ctx, resolvedUDPRouteDetails{
+				gatewayDetails:  details.gatewayDetails,
+				udpRoute:        *routeToUpdate,
+				matchedRef:      details.matchedRef,
+				matchedListener: details.matchedListener,
+			}, conditions)
+		},
+	})
+}
+
+func (m *udpRouteModelImpl) setPending(ctx context.Context, details resolvedUDPRouteDetails) error {
+	routeToUpdate := details.udpRoute.DeepCopy()
+	return setL4RoutePending(setL4RoutePendingParams{
+		routeKind:      "UDPRoute",
+		controllerName: NetworkLoadBalancerControllerClassName,
+		routeToUpdate:  routeToUpdate,
 		updateParentStatus: func(conditions []metav1.Condition) error {
 			return m.updateParentStatus(ctx, resolvedUDPRouteDetails{
 				gatewayDetails:  details.gatewayDetails,

--- a/internal/app/udproute_model_test.go
+++ b/internal/app/udproute_model_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -712,6 +713,193 @@ func TestUDPRouteModel(t *testing.T) {
 		details.udpRoute = route
 		err = model.setProgrammed(t.Context(), details)
 		require.ErrorContains(t, err, "failed to update UDPRoute coap status")
+	})
+
+	t.Run("setProgrammed refreshes and updates status after conflict", func(t *testing.T) {
+		route := gatewayv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "coap",
+				Generation: 2,
+				Finalizers: []string{NetworkLoadBalancerUDPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation: "bs_coap",
+				},
+			},
+			Status: gatewayv1.UDPRouteStatus{RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{{
+				ParentRef:      gatewayv1.ParentReference{Name: "edge"},
+				ControllerName: gatewayv1.GatewayController(NetworkLoadBalancerControllerClassName),
+			}}}},
+		}
+		latestRoute := route.DeepCopy()
+		latestRoute.ResourceVersion = "latest"
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "udproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		mockClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(statusWriter).Twice()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.UDPRoute")).
+			Return(conflictErr).
+			Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.UDPRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.UDPRoute) = *latestRoute
+				return nil
+			}).
+			Once()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updated := obj.(*gatewayv1.UDPRoute)
+				condition := meta.FindStatusCondition(
+					updated.Status.Parents[0].Conditions,
+					string(gatewayv1.RouteConditionResolvedRefs),
+				)
+				return updated.ResourceVersion == "latest" &&
+					condition != nil &&
+					condition.Status == metav1.ConditionTrue
+			}), mock.Anything).
+			Return(nil).
+			Once().
+			NotBefore(getCall)
+
+		model := newUDPRouteModel(udpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		err := model.setProgrammed(t.Context(), resolvedUDPRouteDetails{
+			udpRoute: route,
+			gatewayDetails: resolvedGatewayDetails{gateway: gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "iot", Name: "edge"},
+			}},
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "coap", Protocol: gatewayv1.UDPProtocolType, Port: 5684},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("setProgrammed returns status retry errors after conflict", func(t *testing.T) {
+		route := gatewayv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "iot",
+				Name:       "coap",
+				Generation: 2,
+				Finalizers: []string{NetworkLoadBalancerUDPRouteProgrammedFinalizer},
+				Annotations: map[string]string{
+					NetworkLoadBalancerUDPRouteProgrammedBackendSetsAnnotation: "bs_coap",
+				},
+			},
+		}
+		latestRoute := route.DeepCopy()
+		latestRoute.ResourceVersion = "latest"
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "udproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("retry update failed")
+		mockClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(statusWriter).Twice()
+		statusWriter.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.UDPRoute")).Return(conflictErr).Once()
+		getCall := mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.UDPRoute")).
+			RunAndReturn(func(_ context.Context, _ apitypes.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				*obj.(*gatewayv1.UDPRoute) = *latestRoute
+				return nil
+			}).
+			Once()
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.UDPRoute"), mock.Anything).
+			Return(wantErr).
+			Once().
+			NotBefore(getCall)
+
+		model := newUDPRouteModel(udpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		err := model.updateParentStatus(t.Context(), resolvedUDPRouteDetails{
+			udpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "coap", Protocol: gatewayv1.UDPProtocolType, Port: 5684},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to update UDPRoute")
+	})
+
+	t.Run("setProgrammed returns status refresh errors after conflict", func(t *testing.T) {
+		route := gatewayv1.UDPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "iot",
+			Name:       "coap",
+			Generation: 2,
+		}}
+		conflictErr := apierrors.NewConflict(
+			schema.GroupResource{Resource: "udproutes"},
+			route.Name,
+			errors.New("modified"),
+		)
+		wantErr := errors.New("refresh failed")
+		mockClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		mockClient.EXPECT().Status().Return(statusWriter).Once()
+		statusWriter.EXPECT().Update(t.Context(), mock.AnythingOfType("*v1.UDPRoute")).Return(conflictErr).Once()
+		mockClient.EXPECT().
+			Get(t.Context(), apitypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, mock.AnythingOfType("*v1.UDPRoute")).
+			Return(wantErr).
+			Once()
+
+		model := newUDPRouteModel(udpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: mockClient})
+		err := model.updateParentStatus(t.Context(), resolvedUDPRouteDetails{
+			udpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "coap", Protocol: gatewayv1.UDPProtocolType, Port: 5684},
+		}, []metav1.Condition{{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}})
+
+		require.ErrorIs(t, err, wantErr)
+		require.ErrorContains(t, err, "failed to refresh UDPRoute")
+	})
+
+	t.Run("setPending updates UDPRoute parent status", func(t *testing.T) {
+		route := gatewayv1.UDPRoute{ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "iot",
+			Name:       "coap",
+			Generation: 2,
+		}}
+		k8sClient := NewMockk8sClient(t)
+		statusWriter := k8sapi.NewMockSubResourceWriter(t)
+		k8sClient.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().
+			Update(t.Context(), mock.AnythingOfType("*v1.UDPRoute")).
+			RunAndReturn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+				updated := mustUDPRoute(t, obj)
+				require.Len(t, updated.Status.Parents, 1)
+				require.Len(t, updated.Status.Parents[0].Conditions, 2)
+				for _, condition := range updated.Status.Parents[0].Conditions {
+					if condition.Type == string(gatewayv1.RouteConditionResolvedRefs) {
+						assert.Equal(t, metav1.ConditionUnknown, condition.Status)
+						assert.Equal(t, string(gatewayv1.RouteReasonPending), condition.Reason)
+					}
+				}
+				return nil
+			})
+		model := newUDPRouteModel(udpRouteModelDeps{RootLogger: diag.RootTestLogger(), K8sClient: k8sClient})
+
+		err := model.setPending(t.Context(), resolvedUDPRouteDetails{
+			udpRoute:        route,
+			matchedRef:      gatewayv1.ParentReference{Name: "edge"},
+			matchedListener: gatewayv1.Listener{Name: "coap", Protocol: gatewayv1.UDPProtocolType, Port: 5684},
+		})
+
+		require.NoError(t, err)
 	})
 
 	t.Run("deprovisionDetachedRoute clears annotated backend set and removes finalizer", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #29.

Updates reconciliation status handling so Gateway API resources show an in-progress state while the controller is actively programming OCI resources.

Before this change, resources could remain in their previous successful status during a new reconciliation, which made it hard to tell when the controller was actively applying changes. This now sets pending status at the start of programming, then restores the final successful status after programming completes.

This also handles the resource-version conflict introduced by writing pending status first. If the final status update sees a stale resource version, the controller refetches the latest object and retries the status update so resources do not remain stuck in pending.