### PR TITLE
Support GRPCRoute and HTTPRoute on shared HTTPS listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ Gateway frontend mutual TLS is supported on OCI Load Balancer HTTPS and terminat
 
 `GRPCRoute` uses the standard Gateway API CRDs and is reconciled on OCI Load Balancer with the other layer 7 routes. It is not implemented on OCI Network Load Balancer. Use `TCPRoute` if you only need gRPC passthrough to pods.
 
-The controller supports gRPC host, service, method, and exact header matching. `HTTPRoute` and `GRPCRoute` can share the same HTTPS listener and hostname; `GRPCRoute` rules require a native gRPC `content-type` and are ordered before broad `HTTPRoute` matches.
+The controller supports gRPC host, service, method, and exact header matching. `HTTPRoute` and `GRPCRoute` can share the same HTTPS listener and hostname; `GRPCRoute` rules require a native gRPC `content-type` and are ordered before broad `HTTPRoute` matches. Hostname conditions match both the bare host and the same host with the listener port, which covers HTTP/2 clients that send `:authority` as `api.example.com:443`.
 
-See [deploy/manifests/examples/grpcroute.yaml](./deploy/manifests/examples/grpcroute.yaml) for a minimal route example.
+Backend TLS is not required just because a `GRPCRoute` is present. Add a `BackendTLSPolicy` only when OCI Load Balancer should use TLS or mTLS to the backend Service port. See [deploy/manifests/examples/grpcroute.yaml](./deploy/manifests/examples/grpcroute.yaml) for a minimal route example and [deploy/manifests/examples/grpcroute-shared-listener.yaml](./deploy/manifests/examples/grpcroute-shared-listener.yaml) for HTTPRoute and GRPCRoute sharing one HTTPS listener.
 
 ## ListenerSet
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -64,12 +64,21 @@ kubectl apply -n oke-gw -f manifests/examples/serverroutes.yaml
 ## GRPCRoute example
 
 `GRPCRoute` uses the standard Gateway API CRDs and OCI Load Balancer. It is for gRPC-aware layer 7 routing; use `TCPRoute` on NLB only for gRPC passthrough.
+`HTTPRoute` and `GRPCRoute` can share one HTTPS listener and hostname. Native gRPC traffic is selected by `content-type: application/grpc*`; grpc-web or regular HTTP traffic can continue to use `HTTPRoute`. Backend TLS is optional and should be configured with `BackendTLSPolicy` only when OCI must use TLS to the backend Service port.
 
 ```sh
 kubectl apply -n oke-gw -f manifests/examples/gatewayconfig.yaml
 kubectl apply -n oke-gw -f manifests/examples/gatewayclass.yaml
 kubectl apply -n oke-gw -f manifests/examples/gateway-https-oci-certificate.yaml
 kubectl apply -n oke-gw -f manifests/examples/grpcroute.yaml
+```
+
+Apply the shared HTTPRoute and GRPCRoute listener example:
+
+```sh
+kubectl apply -n oke-gw -f manifests/examples/gatewayconfig.yaml
+kubectl apply -n oke-gw -f manifests/examples/gatewayclass.yaml
+kubectl apply -n oke-gw -f manifests/examples/grpcroute-shared-listener.yaml
 ```
 
 ## Layer 4 Network Load Balancer examples

--- a/deploy/manifests/examples/grpcroute-shared-listener.yaml
+++ b/deploy/manifests/examples/grpcroute-shared-listener.yaml
@@ -1,0 +1,67 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: grpc-shared-listener
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: api.example.com
+      tls:
+        mode: Terminate
+        options:
+          oci.oraclecloud.com/certificate-ocid: ocid1.certificate.oc1..exampleuniqueID
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grpc-web-api
+spec:
+  parentRefs:
+    - name: grpc-shared-listener
+      sectionName: https
+  hostnames:
+    - api.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: grpc-web-proxy
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: native-grpc-api
+spec:
+  parentRefs:
+    - name: grpc-shared-listener
+      sectionName: https
+  hostnames:
+    - api.example.com
+  rules:
+    - backendRefs:
+        - name: grpc-web-proxy
+          port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-web-proxy
+spec:
+  selector:
+    app: grpc-web-proxy
+  ports:
+    - name: grpc-web
+      port: 8080
+      targetPort: grpc-web
+      protocol: TCP

--- a/e2e/http_grpc_same_listener_test.go
+++ b/e2e/http_grpc_same_listener_test.go
@@ -2,9 +2,12 @@ package e2e
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +19,7 @@ import (
 
 	"github.com/gemyago/oke-gateway-api/e2e/internal/diag"
 	"github.com/gemyago/oke-gateway-api/e2e/internal/e2ek8s"
+	"github.com/gemyago/oke-gateway-api/e2e/internal/probe"
 )
 
 func testHTTPGRPCSameListenerProtocol(t *testing.T, live *liveFixture) {
@@ -32,6 +36,7 @@ func testHTTPGRPCSameListenerProtocol(t *testing.T, live *liveFixture) {
 	grpcRouteName := "grpc-" + suffix
 	backendName := "backend-" + suffix
 	secretName := "tls-" + suffix
+	responseText := "grpc same listener " + suffix
 
 	logTestProgress(
 		ctx,
@@ -68,7 +73,7 @@ func testHTTPGRPCSameListenerProtocol(t *testing.T, live *liveFixture) {
 		e2ek8s.StaticHTTPDeploymentOptions{
 			Namespace:    gatewayNamespace.namespaceName,
 			Name:         backendName,
-			ResponseText: "grpc same listener " + suffix,
+			ResponseText: responseText,
 		},
 	)))
 	_, err = e2ek8s.WaitForDeploymentReady(ctx, live.kubeClient.Client, gatewayNamespace.namespaceName, backendName, nil)
@@ -159,6 +164,46 @@ func testHTTPGRPCSameListenerProtocol(t *testing.T, live *liveFixture) {
 		string(listenerName),
 		"GRPC",
 	))
+
+	rootCAs := x509.NewCertPool()
+	require.True(t, rootCAs.AppendCertsFromPEM(caBundle.certPEM))
+	probeClient, err := probe.NewClient(live.publicIP, int(listenerPort), &probe.ClientOptions{
+		Scheme: "https",
+		HTTPClient: &http.Client{
+			Timeout: 15 * time.Second,
+			Transport: &http.Transport{
+				DisableKeepAlives: true,
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+					RootCAs:    rootCAs,
+					ServerName: string(host),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = probe.WaitForResponse(
+		ctx,
+		probeClient,
+		"/",
+		&probe.RequestOptions{Host: string(host)},
+		nil,
+		"wait for HTTPRoute response on shared GRPC listener",
+		func(response *probe.Response) (bool, string) {
+			switch {
+			case response == nil:
+				return false, "no response received"
+			case response.StatusCode != http.StatusOK:
+				return false, fmt.Sprintf("received status %d", response.StatusCode)
+			case response.BodyString() != responseText:
+				return false, fmt.Sprintf("received body %q", response.BodyString())
+			default:
+				return true, ""
+			}
+		},
+	)
+	require.NoError(t, err)
 }
 
 func waitForOCIListenerProtocol(

--- a/e2e/http_grpc_same_listener_test.go
+++ b/e2e/http_grpc_same_listener_test.go
@@ -1,0 +1,205 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaswdr/faker/v2"
+	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/stretchr/testify/require"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gemyago/oke-gateway-api/e2e/internal/diag"
+	"github.com/gemyago/oke-gateway-api/e2e/internal/e2ek8s"
+)
+
+func testHTTPGRPCSameListenerProtocol(t *testing.T, live *liveFixture) {
+	logger := startTestLogger(t)
+	ctx, cfg := newLiveHTTPContext(t)
+
+	fake := faker.New()
+	suffix := randomDNSLabel(fake)
+	gatewayName := "gateway-grpc-" + suffix
+	listenerName := gatewayv1.SectionName("grpc-" + suffix)
+	listenerPort := gatewayv1.PortNumber(20000 + rand.IntN(10000))
+	host := gatewayv1.Hostname("grpc-" + suffix + ".example.test")
+	httpRouteName := "http-" + suffix
+	grpcRouteName := "grpc-" + suffix
+	backendName := "backend-" + suffix
+	secretName := "tls-" + suffix
+
+	logTestProgress(
+		ctx,
+		t,
+		logger,
+		"Creating isolated Gateway for mixed HTTPRoute and GRPCRoute listener protocol test",
+		slog.String("listener", string(listenerName)),
+		slog.Int("port", int(listenerPort)),
+	)
+
+	gatewayNamespace, err := createIsolatedGatewayNamespace(ctx, t, live, cfg, suffix)
+	require.NoError(t, err)
+
+	caBundle, err := newCertificateAuthority("oke gateway api grpc e2e root " + suffix)
+	require.NoError(t, err)
+	leaf, err := caBundle.newLeaf(certificateSpec{
+		commonName: "oke gateway api grpc e2e leaf " + suffix,
+		dnsNames:   []string{string(host)},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, live.kubeClient.Create(ctx, e2ek8s.NewTLSSecret(e2ek8s.TLSSecretOptions{
+		Namespace:   gatewayNamespace.namespaceName,
+		Name:        secretName,
+		Certificate: leaf.certPEM,
+		PrivateKey:  leaf.keyPEM,
+	})))
+
+	require.NoError(t, live.kubeClient.Create(ctx, e2ek8s.NewEchoService(e2ek8s.EchoServiceOptions{
+		Namespace: gatewayNamespace.namespaceName,
+		Name:      backendName,
+	})))
+	require.NoError(t, live.kubeClient.Create(ctx, e2ek8s.NewStaticHTTPDeployment(
+		e2ek8s.StaticHTTPDeploymentOptions{
+			Namespace:    gatewayNamespace.namespaceName,
+			Name:         backendName,
+			ResponseText: "grpc same listener " + suffix,
+		},
+	)))
+	_, err = e2ek8s.WaitForDeploymentReady(ctx, live.kubeClient.Client, gatewayNamespace.namespaceName, backendName, nil)
+	require.NoError(t, err)
+	_, err = e2ek8s.WaitForServiceEndpointsReady(ctx, live.kubeClient.Client, gatewayNamespace.namespaceName, backendName, nil)
+	require.NoError(t, err)
+
+	gateway := e2ek8s.NewGateway(e2ek8s.GatewayOptions{
+		Namespace:         gatewayNamespace.namespaceName,
+		Name:              gatewayName,
+		GatewayClassName:  gatewayNamespace.gatewayClassName,
+		GatewayConfigName: gatewayNamespace.gatewayConfigName,
+		Listeners: []gatewayv1.Listener{
+			{
+				Name:     listenerName,
+				Port:     listenerPort,
+				Protocol: gatewayv1.HTTPSProtocolType,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{
+						{Name: gatewayv1.ObjectName(secretName)},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, live.kubeClient.Create(ctx, gateway))
+	_, err = e2ek8s.WaitForGatewayAccepted(
+		ctx,
+		live.kubeClient.Client,
+		gatewayNamespace.namespaceName,
+		gatewayName,
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = e2ek8s.WaitForGatewayProgrammed(
+		ctx,
+		live.kubeClient.Client,
+		gatewayNamespace.namespaceName,
+		gatewayName,
+		nil,
+	)
+	require.NoError(t, err)
+
+	httpRoute := e2ek8s.NewHTTPRoute(e2ek8s.HTTPRouteOptions{
+		Namespace:    gatewayNamespace.namespaceName,
+		Name:         httpRouteName,
+		GatewayName:  gatewayName,
+		ListenerName: listenerName,
+		ServiceName:  backendName,
+		ServicePort:  e2ek8s.DefaultEchoPort,
+		Hostnames:    []gatewayv1.Hostname{host},
+	})
+	require.NoError(t, live.kubeClient.Create(ctx, httpRoute))
+	grpcRoute := e2ek8s.NewGRPCRoute(e2ek8s.GRPCRouteOptions{
+		Namespace:    gatewayNamespace.namespaceName,
+		Name:         grpcRouteName,
+		GatewayName:  gatewayName,
+		ListenerName: listenerName,
+		ServiceName:  backendName,
+		ServicePort:  e2ek8s.DefaultEchoPort,
+		Hostnames:    []gatewayv1.Hostname{host},
+	})
+	require.NoError(t, live.kubeClient.Create(ctx, grpcRoute))
+
+	_, err = e2ek8s.WaitForHTTPRouteResolvedRefs(
+		ctx,
+		live.kubeClient.Client,
+		gatewayNamespace.namespaceName,
+		httpRouteName,
+		gatewayName,
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = e2ek8s.WaitForGRPCRouteResolvedRefs(
+		ctx,
+		live.kubeClient.Client,
+		gatewayNamespace.namespaceName,
+		grpcRouteName,
+		gatewayName,
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, waitForOCIListenerProtocol(
+		ctx,
+		live.ociClient,
+		cfg.OCI.LoadBalancerID,
+		string(listenerName),
+		"GRPC",
+	))
+}
+
+func waitForOCIListenerProtocol(
+	ctx context.Context,
+	client *loadbalancer.LoadBalancerClient,
+	loadBalancerID string,
+	listenerName string,
+	wantProtocol string,
+) error {
+	progressLogger := diag.NewWaitProgressLogger(nil, "wait for OCI listener protocol", 0)
+	var lastMessage string
+
+	for {
+		response, err := client.GetLoadBalancer(ctx, loadbalancer.GetLoadBalancerRequest{
+			LoadBalancerId: &loadBalancerID,
+		})
+		if err != nil {
+			return fmt.Errorf("get load balancer %q: %w", loadBalancerID, err)
+		}
+
+		listener, ok := response.LoadBalancer.Listeners[listenerName]
+		if ok && listener.Protocol != nil {
+			gotProtocol := strings.TrimSpace(*listener.Protocol)
+			if gotProtocol == wantProtocol {
+				return nil
+			}
+
+			lastMessage = fmt.Sprintf("listener %q protocol is %q, want %q", listenerName, gotProtocol, wantProtocol)
+		} else if ok {
+			lastMessage = fmt.Sprintf("listener %q protocol is empty, want %q", listenerName, wantProtocol)
+		} else {
+			lastMessage = fmt.Sprintf("listener %q not found", listenerName)
+		}
+		progressLogger.Log(ctx, lastMessage)
+
+		timer := time.NewTimer(2 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("%s: %w", lastMessage, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}

--- a/e2e/http_test.go
+++ b/e2e/http_test.go
@@ -63,6 +63,9 @@ func TestHTTP(t *testing.T) {
 	t.Run("HeaderMatchingVariants", func(t *testing.T) {
 		testHTTPHeaderMatchingVariants(t, routingFixture)
 	})
+	t.Run("GRPCSameListenerProtocol", func(t *testing.T) {
+		testHTTPGRPCSameListenerProtocol(t, liveFixture)
+	})
 	t.Run("PathExactVsPrefix", func(t *testing.T) {
 		testHTTPPathExactVsPrefix(t, routingFixture)
 	})

--- a/e2e/internal/e2ek8s/fixtures.go
+++ b/e2e/internal/e2ek8s/fixtures.go
@@ -118,6 +118,18 @@ type HTTPRouteOptions struct {
 	Annotations   map[string]string
 }
 
+type GRPCRouteOptions struct {
+	Namespace    string
+	Name         string
+	GatewayName  string
+	ListenerName gatewayv1.SectionName
+	ServiceName  string
+	ServicePort  int32
+	Hostnames    []gatewayv1.Hostname
+	Labels       map[string]string
+	Annotations  map[string]string
+}
+
 func NewGatewayClass(opts GatewayClassOptions) *gatewayv1.GatewayClass {
 	controllerName := opts.ControllerName
 	if controllerName == "" {
@@ -462,6 +474,58 @@ func NewHTTPRoute(opts HTTPRouteOptions) *gatewayv1.HTTPRoute {
 						},
 					},
 					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(opts.ServiceName),
+									Port: &portNumber,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewGRPCRoute(opts GRPCRouteOptions) *gatewayv1.GRPCRoute {
+	listenerName := opts.ListenerName
+	if listenerName == "" {
+		listenerName = DefaultHTTPSListenerName
+	}
+
+	servicePort := opts.ServicePort
+	if servicePort == 0 {
+		servicePort = DefaultEchoPort
+	}
+
+	portNumber := servicePort
+
+	return &gatewayv1.GRPCRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gatewayv1.GroupVersion.String(),
+			Kind:       "GRPCRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        opts.Name,
+			Namespace:   opts.Namespace,
+			Labels:      fixtureLabels(opts.Name, "grpc-route", opts.Labels),
+			Annotations: cloneStringMap(opts.Annotations),
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name:        gatewayv1.ObjectName(opts.GatewayName),
+						SectionName: &listenerName,
+					},
+				},
+			},
+			Hostnames: append([]gatewayv1.Hostname(nil), opts.Hostnames...),
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
 						{
 							BackendRef: gatewayv1.BackendRef{
 								BackendObjectReference: gatewayv1.BackendObjectReference{

--- a/e2e/internal/e2ek8s/wait.go
+++ b/e2e/internal/e2ek8s/wait.go
@@ -141,6 +141,25 @@ func WaitForHTTPRouteResolvedRefs(
 	)
 }
 
+func WaitForGRPCRouteResolvedRefs(
+	ctx context.Context,
+	kubeClient ctrlclient.WithWatch,
+	namespace string,
+	name string,
+	gatewayName string,
+	opts *WaitOptions,
+) (*gatewayv1.GRPCRoute, error) {
+	return waitForGRPCRouteCondition(
+		ctx,
+		kubeClient,
+		namespace,
+		name,
+		gatewayName,
+		string(gatewayv1.RouteConditionResolvedRefs),
+		opts,
+	)
+}
+
 func WaitForHTTPRouteDeleted(
 	ctx context.Context,
 	kubeClient ctrlclient.WithWatch,
@@ -456,6 +475,54 @@ func waitForHTTPRouteCondition(
 				conditionType,
 				resource.Generation,
 			)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}
+
+func waitForGRPCRouteCondition(
+	ctx context.Context,
+	kubeClient ctrlclient.WithWatch,
+	namespace string,
+	name string,
+	gatewayName string,
+	conditionType string,
+	opts *WaitOptions,
+) (*gatewayv1.GRPCRoute, error) {
+	_ = opts
+
+	resource := &gatewayv1.GRPCRoute{}
+	key := ctrlclient.ObjectKey{Namespace: namespace, Name: name}
+
+	err := waitForObject(
+		ctx,
+		fmt.Sprintf("wait for GRPCRoute %s/%s condition %s=True", namespace, name, conditionType),
+		kubeClient,
+		key,
+		func() ctrlclient.ObjectList {
+			return &gatewayv1.GRPCRouteList{}
+		},
+		func(ctx context.Context) (bool, string, error) {
+			if err := kubeClient.Get(ctx, key, resource); err != nil {
+				return false, "", err
+			}
+
+			for _, parent := range resource.Status.Parents {
+				if string(parent.ParentRef.Name) != gatewayName {
+					continue
+				}
+
+				ok, message, err := hasCondition(parent.Conditions, conditionType, resource.Generation)
+				if ok || err != nil {
+					return ok, message, err
+				}
+			}
+
+			return false, fmt.Sprintf("parent %q condition not found", gatewayName), nil
 		},
 	)
 	if err != nil {

--- a/internal/app/gateway_model_test.go
+++ b/internal/app/gateway_model_test.go
@@ -1166,8 +1166,20 @@ func TestGatewayModelImpl(t *testing.T) {
 			model := newGatewayModel(deps)
 
 			config := makeRandomGatewayConfig()
+			fake := faker.New()
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
+			firstListener := makeRandomListener(
+				randomListenerWithNameOpt(gatewayv1.SectionName("listener-"+fake.UUID().V4())),
+				randomListenerWithHTTPProtocolOpt(),
+			)
+			firstListener.Port = listenerPort
+			secondListener := makeRandomListener(
+				randomListenerWithNameOpt(gatewayv1.SectionName("listener-"+fake.UUID().V4())),
+				randomListenerWithHTTPProtocolOpt(),
+			)
+			secondListener.Port = listenerPort + 1
 			gateway := newRandomGateway(
-				randomGatewayWithRandomListenersOpt(),
+				randomGatewayWithListenersOpt(firstListener, secondListener),
 			)
 			gateway.Annotations = map[string]string{
 				GatewayProgrammedCertificatesAnnotation: "previous-cert",

--- a/internal/app/grpcroute_controller.go
+++ b/internal/app/grpcroute_controller.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/dig"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // GRPCRouteController watches GRPCRoute resources.
@@ -43,6 +44,41 @@ func (r *GRPCRouteController) SetBackendTLSPolicyEnabled(enabled bool) {
 	if model, ok := r.grpcRouteModel.(interface{ setBackendTLSPolicyEnabled(bool) }); ok {
 		model.setBackendTLSPolicyEnabled(enabled)
 	}
+}
+
+func (r *GRPCRouteController) rejectResolvedRoute(
+	ctx context.Context,
+	resolvedData resolvedGRPCRouteDetails,
+	acceptedRoute gatewayv1.GRPCRoute,
+	statusErr grpcRouteStatusError,
+) error {
+	rejectedRouteDetails := resolvedData
+	rejectedRouteDetails.grpcRoute = acceptedRoute
+	if rejectErr := r.grpcRouteModel.setRejected(ctx, rejectedRouteDetails, statusErr); rejectErr != nil {
+		return fmt.Errorf("failed to reject route: %w", rejectErr)
+	}
+	return nil
+}
+
+func (r *GRPCRouteController) handleProgramRouteError(
+	ctx context.Context,
+	resolvedData resolvedGRPCRouteDetails,
+	acceptedRoute gatewayv1.GRPCRoute,
+	err error,
+) (bool, error) {
+	var statusErr grpcRouteStatusError
+	if errors.As(err, &statusErr) {
+		return true, r.rejectResolvedRoute(ctx, resolvedData, acceptedRoute, statusErr)
+	}
+	if isParentGatewayStatusError(err) {
+		r.logger.InfoContext(ctx, "GRPCRoute parent Gateway is not programmable",
+			slog.String("grpcRoute", resolvedData.grpcRoute.Name),
+			slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
+			slog.String("reason", err.Error()),
+		)
+		return true, nil
+	}
+	return false, fmt.Errorf("failed to program route: %w", err)
 }
 
 func (r *GRPCRouteController) reconcileResolvedRoute(
@@ -99,10 +135,8 @@ func (r *GRPCRouteController) reconcileResolvedRoute(
 	if err != nil {
 		var statusErr grpcRouteStatusError
 		if errors.As(err, &statusErr) {
-			rejectedRouteDetails := resolvedData
-			rejectedRouteDetails.grpcRoute = *acceptedRoute
-			if rejectErr := r.grpcRouteModel.setRejected(ctx, rejectedRouteDetails, statusErr); rejectErr != nil {
-				return false, fmt.Errorf("failed to reject route: %w", rejectErr)
+			if rejectErr := r.rejectResolvedRoute(ctx, resolvedData, *acceptedRoute, statusErr); rejectErr != nil {
+				return false, rejectErr
 			}
 			return false, nil
 		}
@@ -117,15 +151,11 @@ func (r *GRPCRouteController) reconcileResolvedRoute(
 		knownBackends:    knownBackends,
 	})
 	if err != nil {
-		if isParentGatewayStatusError(err) {
-			r.logger.InfoContext(ctx, "GRPCRoute parent Gateway is not programmable",
-				slog.String("grpcRoute", resolvedData.grpcRoute.Name),
-				slog.String("gateway", resolvedData.gatewayDetails.gateway.Name),
-				slog.String("reason", err.Error()),
-			)
-			return false, nil
+		handled, handleErr := r.handleProgramRouteError(ctx, resolvedData, *acceptedRoute, err)
+		if handled {
+			return false, handleErr
 		}
-		return false, fmt.Errorf("failed to program route: %w", err)
+		return false, handleErr
 	}
 
 	if err = r.grpcRouteModel.setProgrammed(ctx, setGRPCRouteProgrammedParams{

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -560,6 +560,45 @@ func TestGRPCRouteController(t *testing.T) {
 		assertDriftRequeue(t, got, 2*time.Minute)
 	})
 
+	t.Run("rejects previously programmed route when backend service disappears", func(t *testing.T) {
+		fake := faker.New()
+		route := makeRoute()
+		route.Annotations = map[string]string{
+			GRPCRouteProgrammedPolicyRulesAnnotation: "grpc/rule-" + fake.Lorem().Word(),
+		}
+		resolved := makeResolved(route)
+		statusErr := newGRPCRouteBackendNotFoundStatusError(
+			"backendRef service " + route.Namespace + "/missing-" + fake.Lorem().Word() + " not found",
+		)
+		routeModel := fakeGRPCRouteModel{
+			resolveRequestFunc: func(
+				_ context.Context,
+				_ reconcile.Request,
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
+				return resolvedMap(route, resolved), nil
+			},
+			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
+			acceptRouteFunc: func(_ context.Context, details resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
+				return &details.grpcRoute, nil
+			},
+			resolveBackendRefsFunc: func(context.Context, resolveGRPCBackendRefsParams) (map[string]corev1.Service, error) {
+				return nil, statusErr
+			},
+			setRejectedFunc: func(_ context.Context, details resolvedGRPCRouteDetails, gotErr grpcRouteStatusError) error {
+				assert.Equal(t, route.Name, details.grpcRoute.Name)
+				assert.Equal(t, gatewayv1.RouteConditionResolvedRefs, gotErr.conditionType)
+				assert.Equal(t, gatewayv1.RouteReasonBackendNotFound, gotErr.reason)
+				assert.Equal(t, statusErr.message, gotErr.message)
+				return nil
+			},
+		}
+
+		got, err := newController(routeModel, NewMockhttpBackendModel(t)).Reconcile(t.Context(), reconcile.Request{})
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, got, 2*time.Minute)
+	})
+
 	t.Run("wraps rejected status update errors", func(t *testing.T) {
 		route := makeRoute()
 		resolved := makeResolved(route)

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -386,6 +386,45 @@ func TestGRPCRouteController(t *testing.T) {
 		require.ErrorIs(t, err, wantErr)
 	})
 
+	t.Run("sets rejected status for programming status errors", func(t *testing.T) {
+		route := makeRoute()
+		resolved := makeResolved(route)
+		service := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: "grpc-svc"}}
+		statusErr := grpcRouteStatusError{
+			conditionType: gatewayv1.RouteConditionResolvedRefs,
+			reason:        gatewayv1.RouteReasonInvalidKind,
+			message:       "BackendTLSPolicy is required for OCI GRPCRoute backends",
+		}
+		routeModel := fakeGRPCRouteModel{
+			resolveRequestFunc: func(
+				_ context.Context,
+				_ reconcile.Request,
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
+				return resolvedMap(route, resolved), nil
+			},
+			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
+			acceptRouteFunc: func(_ context.Context, details resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
+				return &details.grpcRoute, nil
+			},
+			resolveBackendRefsFunc: func(context.Context, resolveGRPCBackendRefsParams) (map[string]corev1.Service, error) {
+				return map[string]corev1.Service{service.Namespace + "/" + service.Name: service}, nil
+			},
+			programRouteFunc: func(context.Context, programGRPCRouteParams) (programGRPCRouteResult, error) {
+				return programGRPCRouteResult{}, statusErr
+			},
+			setRejectedFunc: func(_ context.Context, details resolvedGRPCRouteDetails, gotErr grpcRouteStatusError) error {
+				assert.Equal(t, route.Name, details.grpcRoute.Name)
+				assert.Equal(t, statusErr, gotErr)
+				return nil
+			},
+		}
+
+		got, err := newController(routeModel, NewMockhttpBackendModel(t)).Reconcile(t.Context(), reconcile.Request{})
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, got, 2*time.Minute)
+	})
+
 	t.Run("returns accept route errors", func(t *testing.T) {
 		route := makeRoute()
 		resolved := makeResolved(route)

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -133,22 +133,6 @@ func newGRPCRouteRefNotPermittedStatusError(message string) grpcRouteStatusError
 	}
 }
 
-func newGRPCRouteBackendTLSRequiredStatusError(
-	service corev1.Service,
-	backendRef gatewayv1.BackendRef,
-) grpcRouteStatusError {
-	return grpcRouteStatusError{
-		conditionType: gatewayv1.RouteConditionResolvedRefs,
-		reason:        gatewayv1.RouteReasonInvalidKind,
-		message: fmt.Sprintf(
-			"BackendTLSPolicy is required for OCI GRPCRoute backend %s/%s port %d",
-			service.Namespace,
-			service.Name,
-			lo.FromPtr(backendRef.Port),
-		),
-	}
-}
-
 type grpcRouteModelImpl struct {
 	client               k8sClient
 	logger               *slog.Logger
@@ -515,9 +499,6 @@ func (m *grpcRouteModelImpl) programRoute(
 		ruleCount:             len(params.grpcRoute.Spec.Rules),
 		policyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
 		backendSetsAnnotation: GRPCRouteProgrammedBackendSetsAnnotation,
-		backendTLSRequired: func(service corev1.Service, backendRef gatewayv1.BackendRef) error {
-			return newGRPCRouteBackendTLSRequiredStatusError(service, backendRef)
-		},
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeGRPCRoutingRule(ctx, makeGRPCRoutingRuleParams{
 				grpcRoute:          params.grpcRoute,

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -499,10 +499,11 @@ func (m *grpcRouteModelImpl) programRoute(
 		ruleCount:             len(params.grpcRoute.Spec.Rules),
 		policyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
 		backendSetsAnnotation: GRPCRouteProgrammedBackendSetsAnnotation,
-		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
+		makeRoutingRule: func(ruleIndex int, listenerPort gatewayv1.PortNumber) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeGRPCRoutingRule(ctx, makeGRPCRoutingRuleParams{
 				grpcRoute:          params.grpcRoute,
 				grpcRouteRuleIndex: ruleIndex,
+				listenerPort:       listenerPort,
 			})
 		},
 	})

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -513,12 +513,12 @@ func (m *grpcRouteModelImpl) ensureGRPCListenersProtocol(
 	params ensureGRPCListenersProtocolParams,
 ) error {
 	for _, listener := range params.matchedListeners {
-		if err := m.ociLoadBalancerModel.ensureHTTP2ListenerProtocol(ctx, ensureHTTP2ListenerProtocolParams{
+		if err := m.ociLoadBalancerModel.ensureGRPCListenerProtocol(ctx, ensureGRPCListenerProtocolParams{
 			loadBalancerID: params.config.Spec.LoadBalancerID,
 			listenerName:   string(listener.Name),
 		}); err != nil {
 			return fmt.Errorf(
-				"failed to ensure listener %s supports HTTP2: %w",
+				"failed to ensure listener %s supports GRPC: %w",
 				listener.Name,
 				err,
 			)

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -653,6 +653,18 @@ func (m *grpcRouteModelImpl) setRejected(
 	statusErr grpcRouteStatusError,
 ) error {
 	grpcRoute := routeDetails.grpcRoute.DeepCopy()
+	if programmedPolicyRulesAnnotation, ok := grpcRoute.Annotations[GRPCRouteProgrammedPolicyRulesAnnotation]; ok {
+		if err := removeL7RoutePolicyRules(
+			ctx,
+			m.ociLoadBalancerModel,
+			routeDetails.gatewayDetails.config.Spec.LoadBalancerID,
+			routeDetails.matchedListeners,
+			programmedPolicyRulesAnnotation,
+		); err != nil {
+			return fmt.Errorf("failed to remove rejected GRPCRoute policy rules: %w", err)
+		}
+	}
+
 	_, statusIndex, found := lo.FindIndexOf(
 		grpcRoute.Status.Parents,
 		func(status gatewayv1.RouteParentStatus) bool {

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -638,39 +638,18 @@ func (m *grpcRouteModelImpl) setRejected(
 	statusErr grpcRouteStatusError,
 ) error {
 	grpcRoute := routeDetails.grpcRoute.DeepCopy()
-	if programmedPolicyRulesAnnotation, ok := grpcRoute.Annotations[GRPCRouteProgrammedPolicyRulesAnnotation]; ok {
-		if err := removeL7RoutePolicyRules(
-			ctx,
-			m.ociLoadBalancerModel,
-			routeDetails.gatewayDetails.config.Spec.LoadBalancerID,
-			routeDetails.matchedListeners,
-			programmedPolicyRulesAnnotation,
-		); err != nil {
-			return fmt.Errorf("failed to remove rejected GRPCRoute policy rules: %w", err)
-		}
-	}
-
-	_, statusIndex, found := lo.FindIndexOf(
-		grpcRoute.Status.Parents,
-		func(status gatewayv1.RouteParentStatus) bool {
-			return status.ControllerName == routeDetails.gatewayDetails.gatewayClass.Spec.ControllerName &&
-				parentRefSameTarget(status.ParentRef, routeDetails.matchedRef)
-		},
-	)
-	if !found {
-		return fmt.Errorf("parent status not found for controller %s and parentRef %s",
-			routeDetails.gatewayDetails.gatewayClass.Spec.ControllerName,
-			routeDetails.matchedRef.Name,
-		)
-	}
-
-	return m.resourcesModel.setCondition(ctx, setConditionParams{
-		resource:      grpcRoute,
-		conditions:    &grpcRoute.Status.Parents[statusIndex].Conditions,
-		conditionType: string(statusErr.conditionType),
-		status:        metav1.ConditionFalse,
-		reason:        string(statusErr.reason),
-		message:       statusErr.message,
+	return setL7RouteRejected(ctx, m.resourcesModel, m.ociLoadBalancerModel, setL7RouteRejectedParams{
+		resource:                        grpcRoute,
+		parentStatuses:                  &grpcRoute.Status.Parents,
+		gatewayClass:                    routeDetails.gatewayDetails.gatewayClass,
+		matchedRef:                      routeDetails.matchedRef,
+		loadBalancerID:                  routeDetails.gatewayDetails.config.Spec.LoadBalancerID,
+		matchedListeners:                routeDetails.matchedListeners,
+		programmedPolicyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
+		routeKind:                       "GRPCRoute",
+		conditionType:                   statusErr.conditionType,
+		reason:                          statusErr.reason,
+		message:                         statusErr.message,
 	})
 }
 

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -563,26 +563,15 @@ func (m *grpcRouteModelImpl) deprovisionRoute(
 		}
 	}
 
-	processedBackendRefs := make(map[string]struct{})
-	for _, backendRef := range grpcRouteBackendRefs(params.grpcRoute) {
-		key := l7BackendRefKey(backendRef, params.grpcRoute.Namespace)
-		if _, ok := processedBackendRefs[key]; ok {
-			continue
-		}
-		err := m.ociLoadBalancerModel.deprovisionBackendSet(ctx, deprovisionBackendSetParams{
-			loadBalancerID: params.config.Spec.LoadBalancerID,
-			routeNamespace: params.grpcRoute.Namespace,
-			backendRef:     backendRef,
-		})
-		if err != nil {
-			return fmt.Errorf(
-				"failed to deprovision backend set for rule %s/%s: %w",
-				params.grpcRoute.Namespace,
-				params.grpcRoute.Name,
-				err,
-			)
-		}
-		processedBackendRefs[key] = struct{}{}
+	if err := deprovisionL7BackendSets(ctx, m.ociLoadBalancerModel, deprovisionL7BackendSetsParams{
+		loadBalancerID:      params.config.Spec.LoadBalancerID,
+		routeKind:           l7GRPCRouteKind,
+		routeNamespace:      params.grpcRoute.Namespace,
+		routeName:           params.grpcRoute.Name,
+		backendRefs:         grpcRouteBackendRefs(params.grpcRoute),
+		previousBackendSets: annotatedBackendSetNames(&params.grpcRoute, GRPCRouteProgrammedBackendSetsAnnotation),
+	}); err != nil {
+		return err
 	}
 
 	routeToUpdate := params.grpcRoute.DeepCopy()
@@ -604,6 +593,7 @@ func (m *grpcRouteModelImpl) deprovisionDetachedRoute(
 		route:                 &grpcRoute,
 		routeKind:             "GRPCRoute",
 		policyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
+		backendSetsAnnotation: GRPCRouteProgrammedBackendSetsAnnotation,
 		loadBalancerID:        grpcRoute.Annotations[L7RouteProgrammedLoadBalancerIDAnnotation],
 		backendRefs:           grpcRouteBackendRefs(grpcRoute),
 		removeFinalizer: func(ctx context.Context) error {

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -133,6 +133,22 @@ func newGRPCRouteRefNotPermittedStatusError(message string) grpcRouteStatusError
 	}
 }
 
+func newGRPCRouteBackendTLSRequiredStatusError(
+	service corev1.Service,
+	backendRef gatewayv1.BackendRef,
+) grpcRouteStatusError {
+	return grpcRouteStatusError{
+		conditionType: gatewayv1.RouteConditionResolvedRefs,
+		reason:        gatewayv1.RouteReasonInvalidKind,
+		message: fmt.Sprintf(
+			"BackendTLSPolicy is required for OCI GRPCRoute backend %s/%s port %d",
+			service.Namespace,
+			service.Name,
+			lo.FromPtr(backendRef.Port),
+		),
+	}
+}
+
 type grpcRouteModelImpl struct {
 	client               k8sClient
 	logger               *slog.Logger
@@ -499,6 +515,9 @@ func (m *grpcRouteModelImpl) programRoute(
 		ruleCount:             len(params.grpcRoute.Spec.Rules),
 		policyRulesAnnotation: GRPCRouteProgrammedPolicyRulesAnnotation,
 		backendSetsAnnotation: GRPCRouteProgrammedBackendSetsAnnotation,
+		backendTLSRequired: func(service corev1.Service, backendRef gatewayv1.BackendRef) error {
+			return newGRPCRouteBackendTLSRequiredStatusError(service, backendRef)
+		},
 		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeGRPCRoutingRule(ctx, makeGRPCRoutingRuleParams{
 				grpcRoute:          params.grpcRoute,

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -133,6 +133,14 @@ func newGRPCRouteRefNotPermittedStatusError(message string) grpcRouteStatusError
 	}
 }
 
+func newGRPCRouteBackendNotFoundStatusError(message string) grpcRouteStatusError {
+	return grpcRouteStatusError{
+		conditionType: gatewayv1.RouteConditionResolvedRefs,
+		reason:        gatewayv1.RouteReasonBackendNotFound,
+		message:       message,
+	}
+}
+
 type grpcRouteModelImpl struct {
 	client               k8sClient
 	logger               *slog.Logger
@@ -472,6 +480,11 @@ func (m *grpcRouteModelImpl) resolveBackendRefs(
 
 			var service corev1.Service
 			if getErr := m.client.Get(ctx, fullName, &service); getErr != nil {
+				if apierrors.IsNotFound(getErr) {
+					return nil, newGRPCRouteBackendNotFoundStatusError(
+						fmt.Sprintf("backendRef service %s not found", fullName.String()),
+					)
+				}
 				return nil, fmt.Errorf("failed to get service %s: %w", fullName.String(), getErr)
 			}
 

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1325,10 +1325,12 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		)
 	})
 
-	t.Run("programRoute rejects missing BackendTLSPolicy for OCI gRPC backends", func(t *testing.T) {
+	t.Run("programRoute keeps plaintext backend when BackendTLSPolicy is missing", func(t *testing.T) {
+		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
 		model.backendTLSPolicy = &stubBackendTLSPolicyModel{resolveErr: errBackendTLSPolicyNotFound}
+		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 		config := makeRandomGatewayConfig()
 		backendRef := makeGRPCBackendRef()
 		listener := gatewayv1.Listener{Name: gatewayv1.SectionName("grpc"), Port: 50051}
@@ -1340,19 +1342,43 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		service := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(backendRef.Name)},
 		}
+		ruleName := "grpc_rule_" + fake.Lorem().Word()
+		routingRule := loadbalancer.RoutingRule{Name: &ruleName}
 
-		_, err := model.programRoute(t.Context(), programGRPCRouteParams{
+		ociLBModel.EXPECT().
+			reconcileBackendSet(t.Context(), mock.MatchedBy(func(params reconcileBackendSetParams) bool {
+				return params.loadBalancerID == config.Spec.LoadBalancerID &&
+					params.service.Name == service.Name &&
+					params.backendRef.Name == backendRef.Name &&
+					params.manageSSLConfig &&
+					params.sslConfig == nil
+			})).
+			Return(nil).
+			Once()
+		ociLBModel.EXPECT().makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
+			grpcRoute:          route,
+			grpcRouteRuleIndex: 0,
+		}).Return(routingRule, nil).Once()
+		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+			loadBalancerID: config.Spec.LoadBalancerID,
+			listenerName:   string(listener.Name),
+			policyRules:    []loadbalancer.RoutingRule{routingRule},
+		}).Return(nil).Once()
+
+		got, err := model.programRoute(t.Context(), programGRPCRouteParams{
 			config:           config,
 			grpcRoute:        route,
 			knownBackends:    map[string]corev1.Service{service.Namespace + "/" + service.Name: service},
 			matchedListeners: []gatewayv1.Listener{listener},
 		})
 
-		var statusErr grpcRouteStatusError
-		require.ErrorAs(t, err, &statusErr)
-		assert.Equal(t, gatewayv1.RouteConditionResolvedRefs, statusErr.conditionType)
-		assert.Equal(t, gatewayv1.RouteReasonInvalidKind, statusErr.reason)
-		assert.Contains(t, statusErr.message, "BackendTLSPolicy")
+		require.NoError(t, err)
+		assert.Equal(t, []string{fmt.Sprintf("%s/%s", listener.Name, ruleName)}, got.programmedPolicyRules)
+		assert.Equal(
+			t,
+			[]string{ociBackendSetNameFromBackendObjectRef(route.Namespace, backendRef.BackendObjectReference)},
+			got.programmedBackendSets,
+		)
 	})
 
 	t.Run("programRoute configures backend SSL for OCI gRPC backends", func(t *testing.T) {
@@ -1607,17 +1633,11 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 				ControllerName: ControllerClassName,
 			}}
 		})
-		statusErr := newGRPCRouteBackendTLSRequiredStatusError(
-			corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: route.Namespace,
-					Name:      "svc-" + fake.Lorem().Word(),
-				},
-			},
-			gatewayv1.BackendRef{
-				BackendObjectReference: gatewayv1.BackendObjectReference{Port: lo.ToPtr(gatewayv1.PortNumber(50051))},
-			},
-		)
+		statusErr := grpcRouteStatusError{
+			conditionType: gatewayv1.RouteConditionResolvedRefs,
+			reason:        gatewayv1.RouteReasonInvalidKind,
+			message:       fake.Lorem().Sentence(8),
+		}
 
 		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
 			loadBalancerID:  gatewayData.config.Spec.LoadBalancerID,
@@ -1640,6 +1660,60 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		}, statusErr)
 
 		require.NoError(t, err)
+	})
+
+	t.Run("setRejected returns rejected policy rule cleanup errors", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newGRPCRouteModel(deps)
+		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+		listenerName := gatewayv1.SectionName("grpc")
+		ruleName := "grpc-rule-" + fake.Lorem().Word()
+		gatewayData := makeResolvedGateway(gatewayv1.Listener{Name: listenerName, Port: 50051})
+		parentRef := gatewayv1.ParentReference{Name: gatewayv1.ObjectName(gatewayData.gateway.Name)}
+		route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+			route.Annotations = map[string]string{
+				GRPCRouteProgrammedPolicyRulesAnnotation: fmt.Sprintf("%s/%s", listenerName, ruleName),
+			}
+			route.Status.Parents = []gatewayv1.RouteParentStatus{{
+				ParentRef:      parentRef,
+				ControllerName: ControllerClassName,
+			}}
+		})
+		wantErr := errors.New(fake.Lorem().Sentence(8))
+
+		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+			loadBalancerID:  gatewayData.config.Spec.LoadBalancerID,
+			listenerName:    string(listenerName),
+			policyRules:     []loadbalancer.RoutingRule{},
+			prevPolicyRules: []string{ruleName},
+		}).Return(wantErr).Once()
+
+		err := model.setRejected(t.Context(), resolvedGRPCRouteDetails{
+			gatewayDetails:   gatewayData,
+			grpcRoute:        route,
+			matchedRef:       parentRef,
+			matchedListeners: []gatewayv1.Listener{gatewayData.gateway.Spec.Listeners[0]},
+		}, newGRPCRouteRefNotPermittedStatusError(fake.Lorem().Sentence(8)))
+
+		require.ErrorIs(t, err, wantErr)
+		assert.ErrorContains(t, err, "failed to remove rejected GRPCRoute policy rules")
+	})
+
+	t.Run("setRejected returns error when parent status is missing", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newGRPCRouteModel(deps)
+		gatewayData := makeResolvedGateway()
+		parentRef := gatewayv1.ParentReference{Name: gatewayv1.ObjectName(gatewayData.gateway.Name)}
+
+		err := model.setRejected(t.Context(), resolvedGRPCRouteDetails{
+			gatewayDetails: gatewayData,
+			grpcRoute:      makeGRPCRoute(),
+			matchedRef:     parentRef,
+		}, newGRPCRouteRefNotPermittedStatusError(fake.Lorem().Sentence(8)))
+
+		require.ErrorContains(t, err, "parent status not found")
 	})
 
 	t.Run("setRejected returns status update errors", func(t *testing.T) {

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -882,6 +882,30 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			require.ErrorIs(t, err, wantErr)
 		})
 
+		t.Run("returns backend not found status errors", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newGRPCRouteModel(deps)
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			backendRef := makeGRPCBackendRef()
+			route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+				route.Spec.Rules = []gatewayv1.GRPCRouteRule{{BackendRefs: []gatewayv1.GRPCBackendRef{backendRef}}}
+			})
+			fullName := backendObjectRefName(backendRef.BackendObjectReference, route.Namespace)
+
+			k8sClient.EXPECT().
+				Get(t.Context(), fullName, mock.Anything).
+				Return(apierrors.NewNotFound(schema.GroupResource{Resource: "services"}, fullName.Name)).
+				Once()
+
+			_, err := model.resolveBackendRefs(t.Context(), resolveGRPCBackendRefsParams{grpcRoute: route})
+
+			var statusErr grpcRouteStatusError
+			require.ErrorAs(t, err, &statusErr)
+			assert.Equal(t, gatewayv1.RouteConditionResolvedRefs, statusErr.conditionType)
+			assert.Equal(t, gatewayv1.RouteReasonBackendNotFound, statusErr.reason)
+			assert.Equal(t, fmt.Sprintf("backendRef service %s not found", fullName.String()), statusErr.message)
+		})
+
 		t.Run("rejects cross namespace backend without reference grant", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1252,6 +1252,14 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
+		sslConfig := &loadbalancer.SslConfigurationDetails{
+			CertificateName: new("cert-" + fake.Lorem().Word()),
+		}
+		model.backendTLSPolicy = &stubBackendTLSPolicyModel{
+			resolveFunc: func(resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				return sslConfig, nil
+			},
+		}
 		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 		backendRef := makeGRPCBackendRef()
 		previousRuleName := "previous-grpc-rule-" + fake.Lorem().Word()
@@ -1276,12 +1284,16 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		ruleName := "grpc_rule_" + fake.Lorem().Word()
 		routingRule := loadbalancer.RoutingRule{Name: &ruleName}
 
-		ociLBModel.EXPECT().reconcileBackendSet(t.Context(), reconcileBackendSetParams{
-			loadBalancerID: config.Spec.LoadBalancerID,
-			service:        service,
-			routeNS:        route.Namespace,
-			backendRef:     backendRef.BackendRef,
-		}).Return(nil).Once()
+		ociLBModel.EXPECT().
+			reconcileBackendSet(t.Context(), mock.MatchedBy(func(params reconcileBackendSetParams) bool {
+				return params.loadBalancerID == config.Spec.LoadBalancerID &&
+					params.service.Name == service.Name &&
+					params.backendRef.Name == backendRef.Name &&
+					params.manageSSLConfig &&
+					params.sslConfig == sslConfig
+			})).
+			Return(nil).
+			Once()
 		ociLBModel.EXPECT().makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
 			grpcRoute:          route,
 			grpcRouteRuleIndex: 0,
@@ -1313,12 +1325,10 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		)
 	})
 
-	t.Run("programRoute clears backend SSL config when BackendTLSPolicy no longer matches", func(t *testing.T) {
-		fake := faker.New()
+	t.Run("programRoute rejects missing BackendTLSPolicy for OCI gRPC backends", func(t *testing.T) {
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
 		model.backendTLSPolicy = &stubBackendTLSPolicyModel{resolveErr: errBackendTLSPolicyNotFound}
-		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 		config := makeRandomGatewayConfig()
 		backendRef := makeGRPCBackendRef()
 		listener := gatewayv1.Listener{Name: gatewayv1.SectionName("grpc"), Port: 50051}
@@ -1326,6 +1336,48 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			route.Spec.Rules = []gatewayv1.GRPCRouteRule{{
 				BackendRefs: []gatewayv1.GRPCBackendRef{backendRef},
 			}}
+		})
+		service := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(backendRef.Name)},
+		}
+
+		_, err := model.programRoute(t.Context(), programGRPCRouteParams{
+			config:           config,
+			grpcRoute:        route,
+			knownBackends:    map[string]corev1.Service{service.Namespace + "/" + service.Name: service},
+			matchedListeners: []gatewayv1.Listener{listener},
+		})
+
+		var statusErr grpcRouteStatusError
+		require.ErrorAs(t, err, &statusErr)
+		assert.Equal(t, gatewayv1.RouteConditionResolvedRefs, statusErr.conditionType)
+		assert.Equal(t, gatewayv1.RouteReasonInvalidKind, statusErr.reason)
+		assert.Contains(t, statusErr.message, "BackendTLSPolicy")
+	})
+
+	t.Run("programRoute configures backend SSL for OCI gRPC backends", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		sslConfig := &loadbalancer.SslConfigurationDetails{
+			CertificateName: new("cert-" + fake.Lorem().Word()),
+			CipherSuiteName: new("suite-" + fake.Lorem().Word()),
+			Protocols:       []string{"TLSv1.2"},
+		}
+		model := newGRPCRouteModel(deps)
+		model.backendTLSPolicy = &stubBackendTLSPolicyModel{
+			resolveFunc: func(params resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				assert.Equal(t, "svc", string(params.backendRef.Name))
+				return sslConfig, nil
+			},
+		}
+		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+		config := makeRandomGatewayConfig()
+		backendRef := makeGRPCBackendRef(func(ref *gatewayv1.GRPCBackendRef) {
+			ref.Name = "svc"
+		})
+		listener := gatewayv1.Listener{Name: gatewayv1.SectionName("grpc"), Port: 50051}
+		route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+			route.Spec.Rules = []gatewayv1.GRPCRouteRule{{BackendRefs: []gatewayv1.GRPCBackendRef{backendRef}}}
 		})
 		service := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(backendRef.Name)},
@@ -1339,7 +1391,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 					params.service.Name == service.Name &&
 					params.backendRef.Name == backendRef.Name &&
 					params.manageSSLConfig &&
-					params.sslConfig == nil
+					params.sslConfig == sslConfig
 			})).
 			Return(nil).
 			Once()
@@ -1353,7 +1405,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			policyRules:    []loadbalancer.RoutingRule{routingRule},
 		}).Return(nil).Once()
 
-		_, err := model.programRoute(t.Context(), programGRPCRouteParams{
+		got, err := model.programRoute(t.Context(), programGRPCRouteParams{
 			config:           config,
 			grpcRoute:        route,
 			knownBackends:    map[string]corev1.Service{service.Namespace + "/" + service.Name: service},
@@ -1361,12 +1413,19 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		})
 
 		require.NoError(t, err)
+		assert.Equal(t, []string{fmt.Sprintf("%s/%s", listener.Name, ruleName)}, got.programmedPolicyRules)
+		assert.Equal(
+			t,
+			[]string{ociBackendSetNameFromBackendObjectRef(route.Namespace, backendRef.BackendObjectReference)},
+			got.programmedBackendSets,
+		)
 	})
 
 	t.Run("ensureGRPCListenersProtocol updates matched listeners to HTTP2", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
+		model.backendTLSDisabled = true
 		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 		config := makeRandomGatewayConfig()
 		listeners := []gatewayv1.Listener{
@@ -1393,6 +1452,13 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
+		model.backendTLSPolicy = &stubBackendTLSPolicyModel{
+			resolveFunc: func(resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				return &loadbalancer.SslConfigurationDetails{
+					CertificateName: new("cert-" + fake.Lorem().Word()),
+				}, nil
+			},
+		}
 		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 		config := makeRandomGatewayConfig()
 		listener := gatewayv1.Listener{Name: gatewayv1.SectionName("grpc"), Port: 50051}
@@ -1415,6 +1481,13 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
+		model.backendTLSPolicy = &stubBackendTLSPolicyModel{
+			resolveFunc: func(resolveBackendTLSPolicyParams) (*loadbalancer.SslConfigurationDetails, error) {
+				return &loadbalancer.SslConfigurationDetails{
+					CertificateName: new("cert-" + fake.Lorem().Word()),
+				}, nil
+			},
+		}
 		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 		backendRef := makeGRPCBackendRef()
 		route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1447,7 +1447,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		)
 	})
 
-	t.Run("ensureGRPCListenersProtocol updates matched listeners to HTTP2", func(t *testing.T) {
+	t.Run("ensureGRPCListenersProtocol updates matched listeners to GRPC", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)
 		model := newGRPCRouteModel(deps)
@@ -1460,7 +1460,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		}
 
 		for _, listener := range listeners {
-			ociLBModel.EXPECT().ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+			ociLBModel.EXPECT().ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 				loadBalancerID: config.Spec.LoadBalancerID,
 				listenerName:   string(listener.Name),
 			}).Return(nil).Once()
@@ -1490,7 +1490,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		listener := gatewayv1.Listener{Name: gatewayv1.SectionName("grpc"), Port: 50051}
 		wantErr := errors.New(fake.Lorem().Sentence(10))
 
-		ociLBModel.EXPECT().ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		ociLBModel.EXPECT().ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: config.Spec.LoadBalancerID,
 			listenerName:   string(listener.Name),
 		}).Return(wantErr).Once()

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1297,6 +1297,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		ociLBModel.EXPECT().makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
 			grpcRoute:          route,
 			grpcRouteRuleIndex: 0,
+			listenerPort:       listener.Port,
 		}).Return(routingRule, nil).Once()
 		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
 			loadBalancerID:  config.Spec.LoadBalancerID,
@@ -1358,6 +1359,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		ociLBModel.EXPECT().makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
 			grpcRoute:          route,
 			grpcRouteRuleIndex: 0,
+			listenerPort:       listener.Port,
 		}).Return(routingRule, nil).Once()
 		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
 			loadBalancerID: config.Spec.LoadBalancerID,
@@ -1424,6 +1426,7 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		ociLBModel.EXPECT().makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
 			grpcRoute:          route,
 			grpcRouteRuleIndex: 0,
+			listenerPort:       listener.Port,
 		}).Return(routingRule, nil).Once()
 		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
 			loadBalancerID: config.Spec.LoadBalancerID,
@@ -1523,11 +1526,16 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		service := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(backendRef.Name)},
 		}
+		listener := makeRandomListener()
 		wantErr := errors.New(fake.Lorem().Sentence(10))
 
 		ociLBModel.EXPECT().reconcileBackendSet(t.Context(), mock.Anything).Return(nil).Once()
 		ociLBModel.EXPECT().
-			makeGRPCRoutingRule(t.Context(), mock.Anything).
+			makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
+				grpcRoute:          route,
+				grpcRouteRuleIndex: 0,
+				listenerPort:       listener.Port,
+			}).
 			Return(loadbalancer.RoutingRule{}, wantErr).
 			Once()
 
@@ -1535,6 +1543,9 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 			config:        config,
 			grpcRoute:     route,
 			knownBackends: map[string]corev1.Service{service.Namespace + "/" + service.Name: service},
+			matchedListeners: []gatewayv1.Listener{
+				listener,
+			},
 		})
 
 		require.ErrorIs(t, err, wantErr)

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1588,6 +1588,60 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("setRejected removes previously programmed policy rules", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newGRPCRouteModel(deps)
+		resourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+		listenerName := gatewayv1.SectionName("grpc")
+		ruleName := "grpc-rule-" + fake.Lorem().Word()
+		gatewayData := makeResolvedGateway(gatewayv1.Listener{Name: listenerName, Port: 50051})
+		parentRef := gatewayv1.ParentReference{Name: gatewayv1.ObjectName(gatewayData.gateway.Name)}
+		route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+			route.Annotations = map[string]string{
+				GRPCRouteProgrammedPolicyRulesAnnotation: fmt.Sprintf("%s/%s", listenerName, ruleName),
+			}
+			route.Status.Parents = []gatewayv1.RouteParentStatus{{
+				ParentRef:      parentRef,
+				ControllerName: ControllerClassName,
+			}}
+		})
+		statusErr := newGRPCRouteBackendTLSRequiredStatusError(
+			corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: route.Namespace,
+					Name:      "svc-" + fake.Lorem().Word(),
+				},
+			},
+			gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{Port: lo.ToPtr(gatewayv1.PortNumber(50051))},
+			},
+		)
+
+		ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+			loadBalancerID:  gatewayData.config.Spec.LoadBalancerID,
+			listenerName:    string(listenerName),
+			policyRules:     []loadbalancer.RoutingRule{},
+			prevPolicyRules: []string{ruleName},
+		}).Return(nil).Once()
+		resourcesModel.EXPECT().setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+			return params.conditionType == string(gatewayv1.RouteConditionResolvedRefs) &&
+				params.status == metav1.ConditionFalse &&
+				params.reason == string(gatewayv1.RouteReasonInvalidKind) &&
+				params.message == statusErr.message
+		})).Return(nil).Once()
+
+		err := model.setRejected(t.Context(), resolvedGRPCRouteDetails{
+			gatewayDetails:   gatewayData,
+			grpcRoute:        route,
+			matchedRef:       parentRef,
+			matchedListeners: []gatewayv1.Listener{gatewayData.gateway.Spec.Listeners[0]},
+		}, statusErr)
+
+		require.NoError(t, err)
+	})
+
 	t.Run("setRejected returns status update errors", func(t *testing.T) {
 		fake := faker.New()
 		deps := newMockDeps(t)

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -43,6 +44,20 @@ func (r *HTTPRouteController) SetBackendTLSPolicyEnabled(enabled bool) {
 	if model, ok := r.httpRouteModel.(interface{ setBackendTLSPolicyEnabled(bool) }); ok {
 		model.setBackendTLSPolicyEnabled(enabled)
 	}
+}
+
+func (r *HTTPRouteController) rejectResolvedRoute(
+	ctx context.Context,
+	resolvedData resolvedRouteDetails,
+	acceptedRoute gatewayv1.HTTPRoute,
+	statusErr httpRouteStatusError,
+) error {
+	rejectedRouteDetails := resolvedData
+	rejectedRouteDetails.httpRoute = acceptedRoute
+	if rejectErr := r.httpRouteModel.setRejected(ctx, rejectedRouteDetails, statusErr); rejectErr != nil {
+		return fmt.Errorf("failed to reject route: %w", rejectErr)
+	}
+	return nil
 }
 
 // Returns true if backends sync is required.
@@ -90,6 +105,10 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 		httpRoute: *acceptedRoute,
 	})
 	if err != nil {
+		var statusErr httpRouteStatusError
+		if errors.As(err, &statusErr) {
+			return false, r.rejectResolvedRoute(ctx, resolvedData, *acceptedRoute, statusErr)
+		}
 		return false, fmt.Errorf("failed to resolve backend refs: %w", err)
 	}
 

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -392,6 +392,62 @@ func TestHTTPRouteController(t *testing.T) {
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 
+		t.Run("RejectsRouteWhenBackendServiceDisappears", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			controller := NewHTTPRouteController(deps)
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: fake.Internet().Domain(),
+					Name:      fake.Lorem().Word(),
+				},
+			}
+			wantResolvedData := resolvedRouteDetails{
+				httpRoute: makeRandomHTTPRoute(),
+				gatewayDetails: resolvedGatewayDetails{
+					gateway: *newRandomGateway(),
+					config:  makeRandomGatewayConfig(),
+				},
+			}
+			wantAcceptedRoute := makeRandomHTTPRoute()
+			wantAcceptedRoute.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation: "https/rule-" + fake.Lorem().Word(),
+			}
+			statusErr := newHTTPRouteBackendNotFoundStatusError(
+				"backendRef service " + wantAcceptedRoute.Namespace + "/missing-" + fake.Lorem().Word() + " not found",
+			)
+
+			mockModel, _ := deps.HTTPRouteModel.(*MockhttpRouteModel)
+			mockModel.EXPECT().resolveRequest(t.Context(), req).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
+			}, (error)(nil))
+			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
+			mockModel.EXPECT().acceptRoute(t.Context(), wantResolvedData).Return(&wantAcceptedRoute, nil)
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
+			mockModel.EXPECT().resolveBackendRefs(
+				t.Context(),
+				resolveBackendRefsParams{httpRoute: wantAcceptedRoute},
+			).Return(nil, statusErr)
+			mockModel.EXPECT().setRejected(
+				t.Context(),
+				mock.MatchedBy(func(details resolvedRouteDetails) bool {
+					return details.httpRoute.Name == wantAcceptedRoute.Name &&
+						details.httpRoute.Namespace == wantAcceptedRoute.Namespace
+				}),
+				mock.MatchedBy(func(gotErr httpRouteStatusError) bool {
+					return gotErr.conditionType == gatewayv1.RouteConditionResolvedRefs &&
+						gotErr.reason == gatewayv1.RouteReasonBackendNotFound &&
+						gotErr.message == statusErr.message
+				}),
+			).Return(nil)
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assertDriftRequeue(t, result, controller.driftInterval)
+		})
+
 		t.Run("SetPendingError", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -139,6 +139,7 @@ type programL7RoutePolicyParams struct {
 	makeRoutingRule     func(ruleIndex int) (loadbalancer.RoutingRule, error)
 	backendTLSPolicy    backendTLSPolicyModel
 	backendTLSDisabled  bool
+	backendTLSRequired  func(service v1.Service, backendRef gatewayv1.BackendRef) error
 }
 
 type programL7RouteParams struct {
@@ -155,6 +156,7 @@ type programL7RouteParams struct {
 	policyRulesAnnotation string
 	backendSetsAnnotation string
 	makeRoutingRule       func(ruleIndex int) (loadbalancer.RoutingRule, error)
+	backendTLSRequired    func(service v1.Service, backendRef gatewayv1.BackendRef) error
 }
 
 type setL7RouteProgrammedParams struct {
@@ -1241,6 +1243,7 @@ func programL7Route(
 		previousBackendSets: previousBackendSets,
 		backendTLSPolicy:    params.backendTLSPolicy,
 		backendTLSDisabled:  params.backendTLSDisabled,
+		backendTLSRequired:  params.backendTLSRequired,
 		ruleCount:           params.ruleCount,
 		makeRoutingRule:     params.makeRoutingRule,
 	})
@@ -1361,6 +1364,9 @@ func resolveL7BackendSSLConfig(
 	backendRef gatewayv1.BackendRef,
 ) (*loadbalancer.SslConfigurationDetails, bool, error) {
 	if params.backendTLSDisabled || params.backendTLSPolicy == nil {
+		if params.backendTLSRequired != nil {
+			return nil, false, params.backendTLSRequired(service, backendRef)
+		}
 		return nil, false, nil
 	}
 	sslConfig, err := params.backendTLSPolicy.resolveForBackendRef(ctx, resolveBackendTLSPolicyParams{
@@ -1370,11 +1376,20 @@ func resolveL7BackendSSLConfig(
 		backendRef: backendRef,
 	})
 	if errors.Is(err, errBackendTLSPolicyNotFound) {
+		if params.backendTLSRequired != nil {
+			return nil, true, params.backendTLSRequired(service, backendRef)
+		}
 		return nil, true, nil
 	}
 	var statusErr backendTLSPolicyStatusError
 	if errors.As(err, &statusErr) {
+		if params.backendTLSRequired != nil {
+			return nil, true, params.backendTLSRequired(service, backendRef)
+		}
 		return nil, true, nil
+	}
+	if err == nil && sslConfig == nil && params.backendTLSRequired != nil {
+		return nil, true, params.backendTLSRequired(service, backendRef)
 	}
 	return sslConfig, true, err
 }

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -71,6 +71,20 @@ type setProgrammedParams struct {
 	programmedBackendSets []string
 }
 
+type setL7RouteRejectedParams struct {
+	resource                        client.Object
+	parentStatuses                  *[]gatewayv1.RouteParentStatus
+	gatewayClass                    gatewayv1.GatewayClass
+	matchedRef                      gatewayv1.ParentReference
+	loadBalancerID                  string
+	matchedListeners                []gatewayv1.Listener
+	programmedPolicyRulesAnnotation string
+	routeKind                       string
+	conditionType                   gatewayv1.RouteConditionType
+	reason                          gatewayv1.RouteConditionReason
+	message                         string
+}
+
 type programmedHTTPRoutePolicyRule struct {
 	listenerName string
 	ruleName     string
@@ -248,6 +262,12 @@ type httpRouteModel interface {
 		params deprovisionRouteParams,
 	) error
 
+	setRejected(
+		ctx context.Context,
+		routeDetails resolvedRouteDetails,
+		statusErr httpRouteStatusError,
+	) error
+
 	// setProgrammed marks the route as successfully programmed by updating its status.
 	setProgrammed(
 		ctx context.Context,
@@ -259,6 +279,24 @@ type httpRouteModel interface {
 		ctx context.Context,
 		params setProgrammedParams,
 	) error
+}
+
+type httpRouteStatusError struct {
+	conditionType gatewayv1.RouteConditionType
+	reason        gatewayv1.RouteConditionReason
+	message       string
+}
+
+func (e httpRouteStatusError) Error() string {
+	return e.message
+}
+
+func newHTTPRouteBackendNotFoundStatusError(message string) httpRouteStatusError {
+	return httpRouteStatusError{
+		conditionType: gatewayv1.RouteConditionResolvedRefs,
+		reason:        gatewayv1.RouteReasonBackendNotFound,
+		message:       message,
+	}
 }
 
 // parentRefSameTarget checks if two parent references target the same resource.
@@ -1114,6 +1152,27 @@ func (m *httpRouteModelImpl) rejectRoute(
 	})
 }
 
+func (m *httpRouteModelImpl) setRejected(
+	ctx context.Context,
+	routeDetails resolvedRouteDetails,
+	statusErr httpRouteStatusError,
+) error {
+	httpRoute := routeDetails.httpRoute.DeepCopy()
+	return setL7RouteRejected(ctx, m.resourcesModel, m.ociLoadBalancerModel, setL7RouteRejectedParams{
+		resource:                        httpRoute,
+		parentStatuses:                  &httpRoute.Status.Parents,
+		gatewayClass:                    routeDetails.gatewayDetails.gatewayClass,
+		matchedRef:                      routeDetails.matchedRef,
+		loadBalancerID:                  routeDetails.gatewayDetails.config.Spec.LoadBalancerID,
+		matchedListeners:                routeDetails.matchedListeners,
+		programmedPolicyRulesAnnotation: HTTPRouteProgrammedPolicyRulesAnnotation,
+		routeKind:                       "HTTPRoute",
+		conditionType:                   statusErr.conditionType,
+		reason:                          statusErr.reason,
+		message:                         statusErr.message,
+	})
+}
+
 func (m *httpRouteModelImpl) resolveBackendRefs(
 	ctx context.Context,
 	params resolveBackendRefsParams,
@@ -1125,6 +1184,11 @@ func (m *httpRouteModelImpl) resolveBackendRefs(
 
 			var service v1.Service
 			if err := m.client.Get(ctx, fullName, &service); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil, newHTTPRouteBackendNotFoundStatusError(
+						fmt.Sprintf("backendRef service %s not found", fullName.String()),
+					)
+				}
 				return nil, fmt.Errorf("failed to get service %s: %w", fullName.String(), err)
 			}
 
@@ -1711,6 +1775,48 @@ func setL7RouteProgrammed(
 			L7RouteProgrammedLoadBalancerIDAnnotation: params.loadBalancerID,
 		},
 		finalizer: params.finalizer,
+	})
+}
+
+func setL7RouteRejected(
+	ctx context.Context,
+	resourcesModel resourcesModel,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	params setL7RouteRejectedParams,
+) error {
+	if programmedPolicyRulesAnnotation, ok := params.resource.GetAnnotations()[params.programmedPolicyRulesAnnotation]; ok {
+		if err := removeL7RoutePolicyRules(
+			ctx,
+			ociLoadBalancerModel,
+			params.loadBalancerID,
+			params.matchedListeners,
+			programmedPolicyRulesAnnotation,
+		); err != nil {
+			return fmt.Errorf("failed to remove rejected %s policy rules: %w", params.routeKind, err)
+		}
+	}
+
+	_, statusIndex, found := lo.FindIndexOf(
+		*params.parentStatuses,
+		func(status gatewayv1.RouteParentStatus) bool {
+			return status.ControllerName == params.gatewayClass.Spec.ControllerName &&
+				parentRefSameTarget(status.ParentRef, params.matchedRef)
+		},
+	)
+	if !found {
+		return fmt.Errorf("parent status not found for controller %s and parentRef %s",
+			params.gatewayClass.Spec.ControllerName,
+			params.matchedRef.Name,
+		)
+	}
+
+	return resourcesModel.setCondition(ctx, setConditionParams{
+		resource:      params.resource,
+		conditions:    &(*params.parentStatuses)[statusIndex].Conditions,
+		conditionType: string(params.conditionType),
+		status:        metav1.ConditionFalse,
+		reason:        string(params.reason),
+		message:       params.message,
 	})
 }
 

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -136,7 +136,7 @@ type programL7RoutePolicyParams struct {
 	previousPolicyRules []programmedHTTPRoutePolicyRule
 	previousBackendSets map[string]struct{}
 	ruleCount           int
-	makeRoutingRule     func(ruleIndex int) (loadbalancer.RoutingRule, error)
+	makeRoutingRule     func(ruleIndex int, listenerPort gatewayv1.PortNumber) (loadbalancer.RoutingRule, error)
 	backendTLSPolicy    backendTLSPolicyModel
 	backendTLSDisabled  bool
 	backendTLSRequired  func(service v1.Service, backendRef gatewayv1.BackendRef) error
@@ -155,7 +155,7 @@ type programL7RouteParams struct {
 	ruleCount             int
 	policyRulesAnnotation string
 	backendSetsAnnotation string
-	makeRoutingRule       func(ruleIndex int) (loadbalancer.RoutingRule, error)
+	makeRoutingRule       func(ruleIndex int, listenerPort gatewayv1.PortNumber) (loadbalancer.RoutingRule, error)
 	backendTLSRequired    func(service v1.Service, backendRef gatewayv1.BackendRef) error
 }
 
@@ -1154,20 +1154,13 @@ func programL7RoutePolicy(
 		return nil, nil, reconcileErr
 	}
 
-	policyRules := make([]loadbalancer.RoutingRule, 0, params.ruleCount)
 	policyRuleNames := make([]string, 0, params.ruleCount)
-	for ruleIndex := range params.ruleCount {
-		rule, err := params.makeRoutingRule(ruleIndex)
-		if err != nil {
-			return nil, nil, fmt.Errorf(
-				"failed to make routing rule %d for route %s: %w",
-				ruleIndex,
-				params.routeName,
-				err,
-			)
+	recordPolicyRuleName := func(rule loadbalancer.RoutingRule) {
+		ruleName := lo.FromPtr(rule.Name)
+		if ruleName == "" || lo.Contains(policyRuleNames, ruleName) {
+			return
 		}
-		policyRules = append(policyRules, rule)
-		policyRuleNames = append(policyRuleNames, *rule.Name)
+		policyRuleNames = append(policyRuleNames, ruleName)
 	}
 
 	prevRulesByListener := previousPolicyRulesByListener(params.previousPolicyRules, params.matchedListeners)
@@ -1179,6 +1172,21 @@ func programL7RoutePolicy(
 	)
 
 	for _, listener := range params.matchedListeners {
+		policyRules := make([]loadbalancer.RoutingRule, 0, params.ruleCount)
+		for ruleIndex := range params.ruleCount {
+			rule, err := params.makeRoutingRule(ruleIndex, listener.Port)
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"failed to make routing rule %d for route %s: %w",
+					ruleIndex,
+					params.routeName,
+					err,
+				)
+			}
+			policyRules = append(policyRules, rule)
+			recordPolicyRuleName(rule)
+		}
+
 		listenerName := string(listener.Name)
 		err := ociLoadBalancerModel.commitRoutingPolicy(ctx, commitRoutingPolicyParams{
 			loadBalancerID:  params.loadBalancerID,
@@ -1411,10 +1419,11 @@ func (m *httpRouteModelImpl) programRoute(
 		ruleCount:             len(params.httpRoute.Spec.Rules),
 		policyRulesAnnotation: HTTPRouteProgrammedPolicyRulesAnnotation,
 		backendSetsAnnotation: HTTPRouteProgrammedBackendSetsAnnotation,
-		makeRoutingRule: func(ruleIndex int) (loadbalancer.RoutingRule, error) {
+		makeRoutingRule: func(ruleIndex int, listenerPort gatewayv1.PortNumber) (loadbalancer.RoutingRule, error) {
 			return m.ociLoadBalancerModel.makeRoutingRule(ctx, makeRoutingRuleParams{
 				httpRoute:          params.httpRoute,
 				httpRouteRuleIndex: ruleIndex,
+				listenerPort:       listenerPort,
 			})
 		},
 	})

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -153,7 +153,6 @@ type programL7RoutePolicyParams struct {
 	makeRoutingRule     func(ruleIndex int, listenerPort gatewayv1.PortNumber) (loadbalancer.RoutingRule, error)
 	backendTLSPolicy    backendTLSPolicyModel
 	backendTLSDisabled  bool
-	backendTLSRequired  func(service v1.Service, backendRef gatewayv1.BackendRef) error
 }
 
 type programL7RouteParams struct {
@@ -170,7 +169,6 @@ type programL7RouteParams struct {
 	policyRulesAnnotation string
 	backendSetsAnnotation string
 	makeRoutingRule       func(ruleIndex int, listenerPort gatewayv1.PortNumber) (loadbalancer.RoutingRule, error)
-	backendTLSRequired    func(service v1.Service, backendRef gatewayv1.BackendRef) error
 }
 
 type setL7RouteProgrammedParams struct {
@@ -1315,7 +1313,6 @@ func programL7Route(
 		previousBackendSets: previousBackendSets,
 		backendTLSPolicy:    params.backendTLSPolicy,
 		backendTLSDisabled:  params.backendTLSDisabled,
-		backendTLSRequired:  params.backendTLSRequired,
 		ruleCount:           params.ruleCount,
 		makeRoutingRule:     params.makeRoutingRule,
 	})
@@ -1436,9 +1433,6 @@ func resolveL7BackendSSLConfig(
 	backendRef gatewayv1.BackendRef,
 ) (*loadbalancer.SslConfigurationDetails, bool, error) {
 	if params.backendTLSDisabled || params.backendTLSPolicy == nil {
-		if params.backendTLSRequired != nil {
-			return nil, false, params.backendTLSRequired(service, backendRef)
-		}
 		return nil, false, nil
 	}
 	sslConfig, err := params.backendTLSPolicy.resolveForBackendRef(ctx, resolveBackendTLSPolicyParams{
@@ -1448,20 +1442,11 @@ func resolveL7BackendSSLConfig(
 		backendRef: backendRef,
 	})
 	if errors.Is(err, errBackendTLSPolicyNotFound) {
-		if params.backendTLSRequired != nil {
-			return nil, true, params.backendTLSRequired(service, backendRef)
-		}
 		return nil, true, nil
 	}
 	var statusErr backendTLSPolicyStatusError
 	if errors.As(err, &statusErr) {
-		if params.backendTLSRequired != nil {
-			return nil, true, params.backendTLSRequired(service, backendRef)
-		}
 		return nil, true, nil
-	}
-	if err == nil && sslConfig == nil && params.backendTLSRequired != nil {
-		return nil, true, params.backendTLSRequired(service, backendRef)
 	}
 	return sslConfig, true, err
 }

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -1478,23 +1478,15 @@ func (m *httpRouteModelImpl) deprovisionRoute(
 		}
 	}
 
-	// TODO: Dedup and filter-out non service refs
-	for _, rule := range params.httpRoute.Spec.Rules {
-		for _, backendRef := range rule.BackendRefs {
-			err := m.ociLoadBalancerModel.deprovisionBackendSet(ctx, deprovisionBackendSetParams{
-				loadBalancerID: params.config.Spec.LoadBalancerID,
-				routeNamespace: params.httpRoute.Namespace,
-				backendRef:     backendRef.BackendRef,
-			})
-			if err != nil {
-				return fmt.Errorf(
-					"failed to deprovision backend set for rule %s/%s: %w",
-					params.httpRoute.Namespace,
-					params.httpRoute.Name,
-					err,
-				)
-			}
-		}
+	if err := deprovisionL7BackendSets(ctx, m.ociLoadBalancerModel, deprovisionL7BackendSetsParams{
+		loadBalancerID:      params.config.Spec.LoadBalancerID,
+		routeKind:           l7HTTPRouteKind,
+		routeNamespace:      params.httpRoute.Namespace,
+		routeName:           params.httpRoute.Name,
+		backendRefs:         httpRouteBackendRefs(params.httpRoute),
+		previousBackendSets: annotatedBackendSetNames(&params.httpRoute, HTTPRouteProgrammedBackendSetsAnnotation),
+	}); err != nil {
+		return err
 	}
 
 	routeToUpdate := params.httpRoute.DeepCopy()
@@ -1515,6 +1507,7 @@ type deprovisionDetachedL7RouteParams struct {
 	route                 client.Object
 	routeKind             string
 	policyRulesAnnotation string
+	backendSetsAnnotation string
 	loadBalancerID        string
 	backendRefs           []gatewayv1.BackendRef
 	removeFinalizer       func(context.Context) error
@@ -1536,25 +1529,77 @@ func deprovisionDetachedL7Route(
 		}
 	}
 
+	if err := deprovisionL7BackendSets(ctx, ociLoadBalancerModel, deprovisionL7BackendSetsParams{
+		loadBalancerID: params.loadBalancerID,
+		routeKind:      l7RouteKind(params.routeKind),
+		routeNamespace: params.route.GetNamespace(),
+		routeName:      params.route.GetName(),
+		backendRefs:    params.backendRefs,
+		previousBackendSets: annotatedBackendSetNames(
+			params.route,
+			params.backendSetsAnnotation,
+		),
+	}); err != nil {
+		return fmt.Errorf("failed to deprovision detached %s backend sets: %w", params.routeKind, err)
+	}
+
+	return params.removeFinalizer(ctx)
+}
+
+type deprovisionL7BackendSetsParams struct {
+	loadBalancerID      string
+	routeKind           l7RouteKind
+	routeNamespace      string
+	routeName           string
+	backendRefs         []gatewayv1.BackendRef
+	previousBackendSets map[string]struct{}
+}
+
+func deprovisionL7BackendSets(
+	ctx context.Context,
+	ociLoadBalancerModel ociLoadBalancerModel,
+	params deprovisionL7BackendSetsParams,
+) error {
 	processedBackendRefs := make(map[string]struct{})
 	for _, backendRef := range params.backendRefs {
-		key := l7BackendRefKey(backendRef, params.route.GetNamespace())
+		key := l7BackendRefKey(backendRef, params.routeNamespace)
 		if _, ok := processedBackendRefs[key]; ok {
 			continue
 		}
+
+		backendSetName := ociBackendSetNameFromBackendObjectRef(
+			params.routeNamespace,
+			backendRef.BackendObjectReference,
+		)
+		if _, previouslyProgrammed := params.previousBackendSets[backendSetName]; previouslyProgrammed {
+			referenced, err := ociLoadBalancerModel.backendSetReferenced(ctx, params.loadBalancerID, backendSetName)
+			if err != nil {
+				return fmt.Errorf("failed to check backend set %s references: %w", backendSetName, err)
+			}
+			if referenced {
+				processedBackendRefs[key] = struct{}{}
+				continue
+			}
+		}
+
 		err := ociLoadBalancerModel.deprovisionBackendSet(ctx, deprovisionBackendSetParams{
 			loadBalancerID: params.loadBalancerID,
-			routeNamespace: params.route.GetNamespace(),
+			routeNamespace: params.routeNamespace,
 			backendRef:     backendRef,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to deprovision detached %s backend set %s: %w",
-				params.routeKind, key, err)
+			return fmt.Errorf(
+				"failed to deprovision backend set for %s %s/%s: %w",
+				params.routeKind,
+				params.routeNamespace,
+				params.routeName,
+				err,
+			)
 		}
 		processedBackendRefs[key] = struct{}{}
 	}
 
-	return params.removeFinalizer(ctx)
+	return nil
 }
 
 func (m *httpRouteModelImpl) deprovisionDetachedRoute(
@@ -1565,6 +1610,7 @@ func (m *httpRouteModelImpl) deprovisionDetachedRoute(
 		route:                 &httpRoute,
 		routeKind:             "HTTPRoute",
 		policyRulesAnnotation: HTTPRouteProgrammedPolicyRulesAnnotation,
+		backendSetsAnnotation: HTTPRouteProgrammedBackendSetsAnnotation,
 		loadBalancerID:        httpRoute.Annotations[L7RouteProgrammedLoadBalancerIDAnnotation],
 		backendRefs:           httpRouteBackendRefs(httpRoute),
 		removeFinalizer: func(ctx context.Context) error {

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1609,6 +1609,41 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("setRejected sets resolved refs condition false", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+			resourcesModel, _ := deps.ResourcesModel.(*MockresourcesModel)
+			gatewayClass := newRandomGatewayClass()
+			parentRef := makeRandomParentRef()
+			httpRoute := makeRandomHTTPRoute(
+				func(route *gatewayv1.HTTPRoute) {
+					route.Status.Parents = []gatewayv1.RouteParentStatus{{
+						ParentRef:      parentRef,
+						ControllerName: gatewayClass.Spec.ControllerName,
+					}}
+				},
+			)
+			statusErr := newHTTPRouteBackendNotFoundStatusError(fake.Lorem().Sentence(8))
+
+			resourcesModel.EXPECT().setCondition(t.Context(), mock.MatchedBy(func(params setConditionParams) bool {
+				return params.conditionType == string(gatewayv1.RouteConditionResolvedRefs) &&
+					params.status == metav1.ConditionFalse &&
+					params.reason == string(gatewayv1.RouteReasonBackendNotFound) &&
+					params.message == statusErr.message
+			})).Return(nil).Once()
+
+			err := model.setRejected(t.Context(), resolvedRouteDetails{
+				gatewayDetails: resolvedGatewayDetails{
+					gatewayClass: *gatewayClass,
+				},
+				httpRoute:  httpRoute,
+				matchedRef: parentRef,
+			}, statusErr)
+
+			require.NoError(t, err)
+		})
+
 		t.Run("set condition of existing parent", func(t *testing.T) {
 			deps := newMockDeps(t)
 			model := newHTTPRouteModel(deps)
@@ -1902,6 +1937,38 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			require.Error(t, err)
 			require.ErrorIs(t, err, expectedErr)
+		})
+
+		t.Run("backend service not found returns status error", func(t *testing.T) {
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			backendRef := makeRandomBackendRef()
+			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(
+					makeRandomHTTPRouteRule(
+						randomHTTPRouteRuleWithRandomBackendRefsOpt(backendRef),
+					),
+				),
+			)
+
+			mockK8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			serviceName := string(backendRef.BackendObjectReference.Name)
+			expectedErr := apierrors.NewNotFound(schema.GroupResource{Resource: "services"}, serviceName)
+			mockK8sClient.EXPECT().Get(t.Context(), mock.Anything, mock.Anything).Return(expectedErr)
+
+			_, err := model.resolveBackendRefs(t.Context(), resolveBackendRefsParams{
+				httpRoute: httpRoute,
+			})
+
+			require.Error(t, err)
+			var statusErr httpRouteStatusError
+			require.ErrorAs(t, err, &statusErr)
+			assert.Equal(t, gatewayv1.RouteConditionResolvedRefs, statusErr.conditionType)
+			assert.Equal(t, gatewayv1.RouteReasonBackendNotFound, statusErr.reason)
+			assert.Contains(t, statusErr.message, serviceName)
+			assert.Contains(t, statusErr.message, "not found")
+			assert.NotErrorIs(t, err, expectedErr)
 		})
 	})
 

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -3363,6 +3363,60 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("does not delete backend set still used by another routing policy", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			config := makeRandomGatewayConfig()
+			listener := makeRandomListener()
+			previousRule := "rule-" + fake.Lorem().Word()
+			backendRef := makeRandomBackendRef()
+			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(makeRandomHTTPRouteRule(
+					randomHTTPRouteRuleWithRandomBackendRefsOpt(backendRef),
+				)),
+			)
+			backendSetName := ociBackendSetNameFromBackendObjectRef(
+				httpRoute.Namespace,
+				backendRef.BackendObjectReference,
+			)
+			httpRoute.Finalizers = []string{HTTPRouteProgrammedFinalizer}
+			httpRoute.Annotations = map[string]string{
+				HTTPRouteProgrammedPolicyRulesAnnotation: fmt.Sprintf("%s/%s", listener.Name, previousRule),
+				HTTPRouteProgrammedBackendSetsAnnotation: backendSetName,
+			}
+
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID:  config.Spec.LoadBalancerID,
+				listenerName:    string(listener.Name),
+				policyRules:     []loadbalancer.RoutingRule{},
+				prevPolicyRules: []string{previousRule},
+			}).Return(nil).Once()
+			ociLBModel.EXPECT().
+				backendSetReferenced(t.Context(), config.Spec.LoadBalancerID, backendSetName).
+				Return(true, nil).
+				Once()
+
+			k8sClient, _ := deps.K8sClient.(*Mockk8sClient)
+			k8sClient.EXPECT().Update(t.Context(), mock.MatchedBy(func(obj client.Object) bool {
+				updatedRoute, ok := obj.(*gatewayv1.HTTPRoute)
+				return ok &&
+					updatedRoute.Name == httpRoute.Name &&
+					!controllerutil.ContainsFinalizer(updatedRoute, HTTPRouteProgrammedFinalizer)
+			})).Return(nil).Once()
+
+			err := model.deprovisionRoute(t.Context(), deprovisionRouteParams{
+				gateway:          *newRandomGateway(),
+				config:           config,
+				httpRoute:        httpRoute,
+				matchedListeners: []gatewayv1.Listener{listener},
+			})
+
+			require.NoError(t, err)
+		})
+
 		t.Run("ignores not found when removing finalizer after cleanup", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -1960,20 +1960,19 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				}).Return(nil)
 			}
 
-			// Create expected routing rules for each HTTP route rule
-			expectedRules := make([]loadbalancer.RoutingRule, 0, len(httpRoute.Spec.Rules))
-			for i := range httpRoute.Spec.Rules {
-				rule := makeRandomOCIRoutingRule()
-				expectedRules = append(expectedRules, rule)
-
-				ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
-					httpRoute:          httpRoute,
-					httpRouteRuleIndex: i,
-				}).Return(rule, nil)
-			}
-
 			// Expect commitRoutingPolicyV2 to be called for each listener
 			for _, listener := range listeners {
+				expectedRules := make([]loadbalancer.RoutingRule, 0, len(httpRoute.Spec.Rules))
+				for i := range httpRoute.Spec.Rules {
+					rule := makeRandomOCIRoutingRule()
+					expectedRules = append(expectedRules, rule)
+
+					ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
+						httpRoute:          httpRoute,
+						httpRouteRuleIndex: i,
+						listenerPort:       listener.Port,
+					}).Return(rule, nil)
+				}
 				ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
 					loadBalancerID: config.Spec.LoadBalancerID,
 					listenerName:   string(listener.Name),
@@ -2041,6 +2040,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
 					httpRoute:          httpRoute,
 					httpRouteRuleIndex: i,
+					listenerPort:       listener.Port,
 				}).Return(rule, nil).Once()
 			}
 			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
@@ -2109,6 +2109,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
 				httpRoute:          httpRoute,
 				httpRouteRuleIndex: 0,
+				listenerPort:       listener.Port,
 			}).Return(rule, nil).Once()
 			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
 				loadBalancerID: config.Spec.LoadBalancerID,
@@ -2174,7 +2175,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				matchedListeners: []gatewayv1.Listener{listener},
 				backendTLSPolicy: &stubBackendTLSPolicyModel{resolveErr: errBackendTLSPolicyNotFound},
 				ruleCount:        1,
-				makeRoutingRule: func(int) (loadbalancer.RoutingRule, error) {
+				makeRoutingRule: func(int, gatewayv1.PortNumber) (loadbalancer.RoutingRule, error) {
 					return rule, nil
 				},
 			})
@@ -2214,6 +2215,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
 					httpRoute:          httpRoute,
 					httpRouteRuleIndex: i,
+					listenerPort:       listener.Port,
 				}).Return(rule, nil).Once()
 			}
 			ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
@@ -2326,21 +2328,20 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 				}).Return(nil)
 			}
 
-			// Create expected routing rules for each HTTP route rule
-			expectedRules := make([]loadbalancer.RoutingRule, 0, len(httpRoute.Spec.Rules))
-			for i := range httpRoute.Spec.Rules {
-				rule := makeRandomOCIRoutingRule()
-				rule.Name = new(ociListerPolicyRuleName(httpRoute, i))
-				expectedRules = append(expectedRules, rule)
-
-				ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
-					httpRoute:          httpRoute,
-					httpRouteRuleIndex: i,
-				}).Return(rule, nil).Once()
-			}
-
 			// Expect commitRoutingPolicyV2 to be called for each listener
 			for _, listener := range listeners {
+				expectedRules := make([]loadbalancer.RoutingRule, 0, len(httpRoute.Spec.Rules))
+				for i := range httpRoute.Spec.Rules {
+					rule := makeRandomOCIRoutingRule()
+					rule.Name = new(ociListerPolicyRuleName(httpRoute, i))
+					expectedRules = append(expectedRules, rule)
+
+					ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
+						httpRoute:          httpRoute,
+						httpRouteRuleIndex: i,
+						listenerPort:       listener.Port,
+					}).Return(rule, nil).Once()
+				}
 				ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
 					loadBalancerID:  config.Spec.LoadBalancerID,
 					listenerName:    string(listener.Name),
@@ -2409,6 +2410,7 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			ociLBModel.EXPECT().makeRoutingRule(t.Context(), makeRoutingRuleParams{
 				httpRoute:          httpRoute,
 				httpRouteRuleIndex: 0,
+				listenerPort:       currentListener.Port,
 			}).Return(rule, nil)
 
 			currentCommit := ociLBModel.EXPECT().commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{

--- a/internal/app/mock_http_route_model.go
+++ b/internal/app/mock_http_route_model.go
@@ -377,6 +377,66 @@ func (_c *MockhttpRouteModel_resolveRequest_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// setRejected provides a mock function with given fields: ctx, routeDetails, statusErr
+func (_m *MockhttpRouteModel) setRejected(
+	ctx context.Context,
+	routeDetails resolvedRouteDetails,
+	statusErr httpRouteStatusError,
+) error {
+	ret := _m.Called(ctx, routeDetails, statusErr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for setRejected")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, resolvedRouteDetails, httpRouteStatusError) error); ok {
+		r0 = rf(ctx, routeDetails, statusErr)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockhttpRouteModel_setRejected_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'setRejected'
+type MockhttpRouteModel_setRejected_Call struct {
+	*mock.Call
+}
+
+// setRejected is a helper method to define mock.On call
+//   - ctx context.Context
+//   - routeDetails resolvedRouteDetails
+//   - statusErr httpRouteStatusError
+func (_e *MockhttpRouteModel_Expecter) setRejected(
+	ctx interface{},
+	routeDetails interface{},
+	statusErr interface{},
+) *MockhttpRouteModel_setRejected_Call {
+	return &MockhttpRouteModel_setRejected_Call{Call: _e.mock.On("setRejected", ctx, routeDetails, statusErr)}
+}
+
+func (_c *MockhttpRouteModel_setRejected_Call) Run(
+	run func(ctx context.Context, routeDetails resolvedRouteDetails, statusErr httpRouteStatusError),
+) *MockhttpRouteModel_setRejected_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(resolvedRouteDetails), args[2].(httpRouteStatusError))
+	})
+	return _c
+}
+
+func (_c *MockhttpRouteModel_setRejected_Call) Return(_a0 error) *MockhttpRouteModel_setRejected_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockhttpRouteModel_setRejected_Call) RunAndReturn(
+	run func(context.Context, resolvedRouteDetails, httpRouteStatusError) error,
+) *MockhttpRouteModel_setRejected_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // setProgrammed provides a mock function with given fields: ctx, params
 func (_m *MockhttpRouteModel) setProgrammed(ctx context.Context, params setProgrammedParams) error {
 	ret := _m.Called(ctx, params)

--- a/internal/app/mock_oci_load_balancer_model.go
+++ b/internal/app/mock_oci_load_balancer_model.go
@@ -166,16 +166,16 @@ func (_c *MockociLoadBalancerModel_deprovisionBackendSetByName_Call) RunAndRetur
 	return _c
 }
 
-// ensureHTTP2ListenerProtocol provides a mock function with given fields: ctx, params
-func (_m *MockociLoadBalancerModel) ensureHTTP2ListenerProtocol(ctx context.Context, params ensureHTTP2ListenerProtocolParams) error {
+// ensureGRPCListenerProtocol provides a mock function with given fields: ctx, params
+func (_m *MockociLoadBalancerModel) ensureGRPCListenerProtocol(ctx context.Context, params ensureGRPCListenerProtocolParams) error {
 	ret := _m.Called(ctx, params)
 
 	if len(ret) == 0 {
-		panic("no return value specified for ensureHTTP2ListenerProtocol")
+		panic("no return value specified for ensureGRPCListenerProtocol")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, ensureHTTP2ListenerProtocolParams) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, ensureGRPCListenerProtocolParams) error); ok {
 		r0 = rf(ctx, params)
 	} else {
 		r0 = ret.Error(0)
@@ -184,31 +184,31 @@ func (_m *MockociLoadBalancerModel) ensureHTTP2ListenerProtocol(ctx context.Cont
 	return r0
 }
 
-// MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ensureHTTP2ListenerProtocol'
-type MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call struct {
+// MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ensureGRPCListenerProtocol'
+type MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call struct {
 	*mock.Call
 }
 
-// ensureHTTP2ListenerProtocol is a helper method to define mock.On call
+// ensureGRPCListenerProtocol is a helper method to define mock.On call
 //   - ctx context.Context
-//   - params ensureHTTP2ListenerProtocolParams
-func (_e *MockociLoadBalancerModel_Expecter) ensureHTTP2ListenerProtocol(ctx interface{}, params interface{}) *MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call {
-	return &MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call{Call: _e.mock.On("ensureHTTP2ListenerProtocol", ctx, params)}
+//   - params ensureGRPCListenerProtocolParams
+func (_e *MockociLoadBalancerModel_Expecter) ensureGRPCListenerProtocol(ctx interface{}, params interface{}) *MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call {
+	return &MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call{Call: _e.mock.On("ensureGRPCListenerProtocol", ctx, params)}
 }
 
-func (_c *MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call) Run(run func(ctx context.Context, params ensureHTTP2ListenerProtocolParams)) *MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call {
+func (_c *MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call) Run(run func(ctx context.Context, params ensureGRPCListenerProtocolParams)) *MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(ensureHTTP2ListenerProtocolParams))
+		run(args[0].(context.Context), args[1].(ensureGRPCListenerProtocolParams))
 	})
 	return _c
 }
 
-func (_c *MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call) Return(_a0 error) *MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call {
+func (_c *MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call) Return(_a0 error) *MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call) RunAndReturn(run func(context.Context, ensureHTTP2ListenerProtocolParams) error) *MockociLoadBalancerModel_ensureHTTP2ListenerProtocol_Call {
+func (_c *MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call) RunAndReturn(run func(context.Context, ensureGRPCListenerProtocolParams) error) *MockociLoadBalancerModel_ensureGRPCListenerProtocol_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/app/mock_oci_load_balancer_model.go
+++ b/internal/app/mock_oci_load_balancer_model.go
@@ -166,6 +166,61 @@ func (_c *MockociLoadBalancerModel_deprovisionBackendSetByName_Call) RunAndRetur
 	return _c
 }
 
+// backendSetReferenced provides a mock function with given fields: ctx, loadBalancerID, backendSetName
+func (_m *MockociLoadBalancerModel) backendSetReferenced(ctx context.Context, loadBalancerID string, backendSetName string) (bool, error) {
+	ret := _m.Called(ctx, loadBalancerID, backendSetName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for backendSetReferenced")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = rf(ctx, loadBalancerID, backendSetName)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, loadBalancerID, backendSetName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockociLoadBalancerModel_backendSetReferenced_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'backendSetReferenced'
+type MockociLoadBalancerModel_backendSetReferenced_Call struct {
+	*mock.Call
+}
+
+// backendSetReferenced is a helper method to define mock.On call
+//   - ctx context.Context
+//   - loadBalancerID string
+//   - backendSetName string
+func (_e *MockociLoadBalancerModel_Expecter) backendSetReferenced(ctx interface{}, loadBalancerID interface{}, backendSetName interface{}) *MockociLoadBalancerModel_backendSetReferenced_Call {
+	return &MockociLoadBalancerModel_backendSetReferenced_Call{Call: _e.mock.On("backendSetReferenced", ctx, loadBalancerID, backendSetName)}
+}
+
+func (_c *MockociLoadBalancerModel_backendSetReferenced_Call) Run(run func(ctx context.Context, loadBalancerID string, backendSetName string)) *MockociLoadBalancerModel_backendSetReferenced_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockociLoadBalancerModel_backendSetReferenced_Call) Return(_a0 bool, _a1 error) *MockociLoadBalancerModel_backendSetReferenced_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockociLoadBalancerModel_backendSetReferenced_Call) RunAndReturn(run func(context.Context, string, string) (bool, error)) *MockociLoadBalancerModel_backendSetReferenced_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ensureGRPCListenerProtocol provides a mock function with given fields: ctx, params
 func (_m *MockociLoadBalancerModel) ensureGRPCListenerProtocol(ctx context.Context, params ensureGRPCListenerProtocolParams) error {
 	ret := _m.Called(ctx, params)

--- a/internal/app/mock_oci_load_balancer_routing_rules_mapper.go
+++ b/internal/app/mock_oci_load_balancer_routing_rules_mapper.go
@@ -134,9 +134,9 @@ func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteMatchesToCondition_C
 	return _c
 }
 
-// mapHTTPRouteHostnamesAndMatchesToCondition provides a mock function with given fields: hostnames, matches
-func (_m *MockociLoadBalancerRoutingRulesMapper) mapHTTPRouteHostnamesAndMatchesToCondition(hostnames []v1.Hostname, matches []v1.HTTPRouteMatch) (string, error) {
-	ret := _m.Called(hostnames, matches)
+// mapHTTPRouteHostnamesAndMatchesToCondition provides a mock function with given fields: hostnames, listenerPort, matches
+func (_m *MockociLoadBalancerRoutingRulesMapper) mapHTTPRouteHostnamesAndMatchesToCondition(hostnames []v1.Hostname, listenerPort v1.PortNumber, matches []v1.HTTPRouteMatch) (string, error) {
+	ret := _m.Called(hostnames, listenerPort, matches)
 
 	if len(ret) == 0 {
 		panic("no return value specified for mapHTTPRouteHostnamesAndMatchesToCondition")
@@ -144,17 +144,17 @@ func (_m *MockociLoadBalancerRoutingRulesMapper) mapHTTPRouteHostnamesAndMatches
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]v1.Hostname, []v1.HTTPRouteMatch) (string, error)); ok {
-		return rf(hostnames, matches)
+	if rf, ok := ret.Get(0).(func([]v1.Hostname, v1.PortNumber, []v1.HTTPRouteMatch) (string, error)); ok {
+		return rf(hostnames, listenerPort, matches)
 	}
-	if rf, ok := ret.Get(0).(func([]v1.Hostname, []v1.HTTPRouteMatch) string); ok {
-		r0 = rf(hostnames, matches)
+	if rf, ok := ret.Get(0).(func([]v1.Hostname, v1.PortNumber, []v1.HTTPRouteMatch) string); ok {
+		r0 = rf(hostnames, listenerPort, matches)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func([]v1.Hostname, []v1.HTTPRouteMatch) error); ok {
-		r1 = rf(hostnames, matches)
+	if rf, ok := ret.Get(1).(func([]v1.Hostname, v1.PortNumber, []v1.HTTPRouteMatch) error); ok {
+		r1 = rf(hostnames, listenerPort, matches)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -169,14 +169,15 @@ type MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCond
 
 // mapHTTPRouteHostnamesAndMatchesToCondition is a helper method to define mock.On call
 //   - hostnames []v1.Hostname
+//   - listenerPort v1.PortNumber
 //   - matches []v1.HTTPRouteMatch
-func (_e *MockociLoadBalancerRoutingRulesMapper_Expecter) mapHTTPRouteHostnamesAndMatchesToCondition(hostnames interface{}, matches interface{}) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
-	return &MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call{Call: _e.mock.On("mapHTTPRouteHostnamesAndMatchesToCondition", hostnames, matches)}
+func (_e *MockociLoadBalancerRoutingRulesMapper_Expecter) mapHTTPRouteHostnamesAndMatchesToCondition(hostnames interface{}, listenerPort interface{}, matches interface{}) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
+	return &MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call{Call: _e.mock.On("mapHTTPRouteHostnamesAndMatchesToCondition", hostnames, listenerPort, matches)}
 }
 
-func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call) Run(run func(hostnames []v1.Hostname, matches []v1.HTTPRouteMatch)) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
+func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call) Run(run func(hostnames []v1.Hostname, listenerPort v1.PortNumber, matches []v1.HTTPRouteMatch)) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]v1.Hostname), args[1].([]v1.HTTPRouteMatch))
+		run(args[0].([]v1.Hostname), args[1].(v1.PortNumber), args[2].([]v1.HTTPRouteMatch))
 	})
 	return _c
 }
@@ -186,14 +187,14 @@ func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesT
 	return _c
 }
 
-func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call) RunAndReturn(run func([]v1.Hostname, []v1.HTTPRouteMatch) (string, error)) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
+func (_c *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call) RunAndReturn(run func([]v1.Hostname, v1.PortNumber, []v1.HTTPRouteMatch) (string, error)) *MockociLoadBalancerRoutingRulesMapper_mapHTTPRouteHostnamesAndMatchesToCondition_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// mapGRPCRouteHostnamesAndMatchesToCondition provides a mock function with given fields: hostnames, matches
-func (_m *MockociLoadBalancerRoutingRulesMapper) mapGRPCRouteHostnamesAndMatchesToCondition(hostnames []v1.Hostname, matches []v1.GRPCRouteMatch) (string, error) {
-	ret := _m.Called(hostnames, matches)
+// mapGRPCRouteHostnamesAndMatchesToCondition provides a mock function with given fields: hostnames, listenerPort, matches
+func (_m *MockociLoadBalancerRoutingRulesMapper) mapGRPCRouteHostnamesAndMatchesToCondition(hostnames []v1.Hostname, listenerPort v1.PortNumber, matches []v1.GRPCRouteMatch) (string, error) {
+	ret := _m.Called(hostnames, listenerPort, matches)
 
 	if len(ret) == 0 {
 		panic("no return value specified for mapGRPCRouteHostnamesAndMatchesToCondition")
@@ -201,17 +202,17 @@ func (_m *MockociLoadBalancerRoutingRulesMapper) mapGRPCRouteHostnamesAndMatches
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]v1.Hostname, []v1.GRPCRouteMatch) (string, error)); ok {
-		return rf(hostnames, matches)
+	if rf, ok := ret.Get(0).(func([]v1.Hostname, v1.PortNumber, []v1.GRPCRouteMatch) (string, error)); ok {
+		return rf(hostnames, listenerPort, matches)
 	}
-	if rf, ok := ret.Get(0).(func([]v1.Hostname, []v1.GRPCRouteMatch) string); ok {
-		r0 = rf(hostnames, matches)
+	if rf, ok := ret.Get(0).(func([]v1.Hostname, v1.PortNumber, []v1.GRPCRouteMatch) string); ok {
+		r0 = rf(hostnames, listenerPort, matches)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func([]v1.Hostname, []v1.GRPCRouteMatch) error); ok {
-		r1 = rf(hostnames, matches)
+	if rf, ok := ret.Get(1).(func([]v1.Hostname, v1.PortNumber, []v1.GRPCRouteMatch) error); ok {
+		r1 = rf(hostnames, listenerPort, matches)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -226,14 +227,15 @@ type MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCond
 
 // mapGRPCRouteHostnamesAndMatchesToCondition is a helper method to define mock.On call
 //   - hostnames []v1.Hostname
+//   - listenerPort v1.PortNumber
 //   - matches []v1.GRPCRouteMatch
-func (_e *MockociLoadBalancerRoutingRulesMapper_Expecter) mapGRPCRouteHostnamesAndMatchesToCondition(hostnames interface{}, matches interface{}) *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call {
-	return &MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call{Call: _e.mock.On("mapGRPCRouteHostnamesAndMatchesToCondition", hostnames, matches)}
+func (_e *MockociLoadBalancerRoutingRulesMapper_Expecter) mapGRPCRouteHostnamesAndMatchesToCondition(hostnames interface{}, listenerPort interface{}, matches interface{}) *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call {
+	return &MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call{Call: _e.mock.On("mapGRPCRouteHostnamesAndMatchesToCondition", hostnames, listenerPort, matches)}
 }
 
-func (_c *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call) Run(run func(hostnames []v1.Hostname, matches []v1.GRPCRouteMatch)) *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call {
+func (_c *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call) Run(run func(hostnames []v1.Hostname, listenerPort v1.PortNumber, matches []v1.GRPCRouteMatch)) *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]v1.Hostname), args[1].([]v1.GRPCRouteMatch))
+		run(args[0].([]v1.Hostname), args[1].(v1.PortNumber), args[2].([]v1.GRPCRouteMatch))
 	})
 	return _c
 }
@@ -243,7 +245,7 @@ func (_c *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesT
 	return _c
 }
 
-func (_c *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call) RunAndReturn(run func([]v1.Hostname, []v1.GRPCRouteMatch) (string, error)) *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call {
+func (_c *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call) RunAndReturn(run func([]v1.Hostname, v1.PortNumber, []v1.GRPCRouteMatch) (string, error)) *MockociLoadBalancerRoutingRulesMapper_mapGRPCRouteHostnamesAndMatchesToCondition_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -176,6 +176,12 @@ type ociLoadBalancerModel interface {
 		backendSetName string,
 	) error
 
+	backendSetReferenced(
+		ctx context.Context,
+		loadBalancerID string,
+		backendSetName string,
+	) (bool, error)
+
 	// makeRoutingRule appends a new routing rule to the routing policy.
 	makeRoutingRule(
 		ctx context.Context,
@@ -1323,6 +1329,28 @@ func (m *ociLoadBalancerModelImpl) deprovisionBackendSetByName(
 		slog.String("backendSetName", backendSetName),
 	)
 	return nil
+}
+
+func (m *ociLoadBalancerModelImpl) backendSetReferenced(
+	ctx context.Context,
+	loadBalancerID string,
+	backendSetName string,
+) (bool, error) {
+	response, err := m.ociClient.GetLoadBalancer(ctx, loadbalancer.GetLoadBalancerRequest{
+		LoadBalancerId: &loadBalancerID,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to get load balancer %s: %w", loadBalancerID, err)
+	}
+
+	for _, policy := range response.LoadBalancer.RoutingPolicies {
+		for _, rule := range policy.Rules {
+			if routingRuleForwardsToBackendSet(rule, backendSetName) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func (m *ociLoadBalancerModelImpl) makeRoutingRule(

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -37,6 +37,7 @@ const maxListenerPolicyNameLength = 32
 const listenerPolicyNameHashLength = 16
 const ociListenerProtocolHTTP = "HTTP"
 const ociListenerProtocolHTTP2 = "HTTP2"
+const ociListenerProtocolGRPC = "GRPC"
 
 type reconcileDefaultBackendParams struct {
 	loadBalancerID   string
@@ -152,9 +153,9 @@ type ociLoadBalancerModel interface {
 		params reconcileHTTPListenerParams,
 	) error
 
-	ensureHTTP2ListenerProtocol(
+	ensureGRPCListenerProtocol(
 		ctx context.Context,
-		params ensureHTTP2ListenerProtocolParams,
+		params ensureGRPCListenerProtocolParams,
 	) error
 
 	reconcileBackendSet(
@@ -214,7 +215,7 @@ type ociLoadBalancerModelImpl struct {
 	certificateLocks    loadBalancerCertificateLocks
 }
 
-type ensureHTTP2ListenerProtocolParams struct {
+type ensureGRPCListenerProtocolParams struct {
 	loadBalancerID string
 	listenerName   string
 }
@@ -1048,7 +1049,7 @@ func (m *ociLoadBalancerModelImpl) reconcileExistingHTTPListener(
 		listenerSpec:          params.listenerSpec,
 		defaultBackendSetName: params.defaultBackendSetName,
 		sslConfig:             sslConfig,
-		preserveHTTP2: listenerPolicyContainsGRPCRules(
+		preserveGRPC: listenerPolicyContainsGRPCRules(
 			params.knownRoutingPolicies[listenerPolicyName(listenerName)],
 		),
 	})
@@ -1118,9 +1119,9 @@ func (m *ociLoadBalancerModelImpl) createHTTPListener(
 	return nil
 }
 
-func (m *ociLoadBalancerModelImpl) ensureHTTP2ListenerProtocol(
+func (m *ociLoadBalancerModelImpl) ensureGRPCListenerProtocol(
 	ctx context.Context,
-	params ensureHTTP2ListenerProtocolParams,
+	params ensureGRPCListenerProtocolParams,
 ) error {
 	getRes, err := m.ociClient.GetLoadBalancer(ctx, loadbalancer.GetLoadBalancerRequest{
 		LoadBalancerId: new(params.loadBalancerID),
@@ -1133,11 +1134,11 @@ func (m *ociLoadBalancerModelImpl) ensureHTTP2ListenerProtocol(
 	if !ok {
 		return fmt.Errorf("listener %s not found", params.listenerName)
 	}
-	if lo.FromPtr(listener.Protocol) == ociListenerProtocolHTTP2 {
+	if lo.FromPtr(listener.Protocol) == ociListenerProtocolGRPC {
 		return nil
 	}
 
-	m.logger.InfoContext(ctx, "Updating listener protocol to HTTP2",
+	m.logger.InfoContext(ctx, "Updating listener protocol to GRPC",
 		slog.String("loadBalancerId", params.loadBalancerID),
 		slog.String("listenerName", params.listenerName),
 		slog.String("currentProtocol", lo.FromPtr(listener.Protocol)),
@@ -1146,7 +1147,7 @@ func (m *ociLoadBalancerModelImpl) ensureHTTP2ListenerProtocol(
 	updateDetails := loadbalancer.UpdateListenerDetails{
 		DefaultBackendSetName:   listener.DefaultBackendSetName,
 		Port:                    listener.Port,
-		Protocol:                new(ociListenerProtocolHTTP2),
+		Protocol:                new(ociListenerProtocolGRPC),
 		HostnameNames:           listener.HostnameNames,
 		PathRouteSetName:        listener.PathRouteSetName,
 		RoutingPolicyName:       listener.RoutingPolicyName,
@@ -1161,11 +1162,11 @@ func (m *ociLoadBalancerModelImpl) ensureHTTP2ListenerProtocol(
 		UpdateListenerDetails: updateDetails,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update listener %s protocol to HTTP2: %w", params.listenerName, err)
+		return fmt.Errorf("failed to update listener %s protocol to GRPC: %w", params.listenerName, err)
 	}
 	if updateRes.OpcWorkRequestId == nil {
 		return fmt.Errorf(
-			"failed to update listener %s protocol to HTTP2: missing work request id",
+			"failed to update listener %s protocol to GRPC: missing work request id",
 			params.listenerName,
 		)
 	}
@@ -2198,13 +2199,13 @@ type makeOciListenerUpdateDetailsParams struct {
 	listenerSpec          *gatewayv1.Listener
 	defaultBackendSetName string
 	sslConfig             *loadbalancer.SslConfigurationDetails
-	preserveHTTP2         bool
+	preserveGRPC          bool
 }
 
 func makeOciListenerUpdateDetails(
 	params makeOciListenerUpdateDetailsParams,
 ) (loadbalancer.UpdateListenerDetails, bool) {
-	expectedProtocol := expectedHTTPListenerProtocol(params.preserveHTTP2)
+	expectedProtocol := expectedHTTPListenerProtocol(params.preserveGRPC)
 	hasChanges := params.existingListenerData.Protocol == nil ||
 		*params.existingListenerData.Protocol != expectedProtocol
 
@@ -2241,9 +2242,9 @@ func makeOciListenerUpdateDetails(
 	}, true
 }
 
-func expectedHTTPListenerProtocol(preserveHTTP2 bool) string {
-	if preserveHTTP2 {
-		return ociListenerProtocolHTTP2
+func expectedHTTPListenerProtocol(preserveGRPC bool) string {
+	if preserveGRPC {
+		return ociListenerProtocolGRPC
 	}
 	return ociListenerProtocolHTTP
 }

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -93,11 +93,13 @@ type reconcileListenersCertificatesResult struct {
 type makeRoutingRuleParams struct {
 	httpRoute          gatewayv1.HTTPRoute
 	httpRouteRuleIndex int
+	listenerPort       gatewayv1.PortNumber
 }
 
 type makeGRPCRoutingRuleParams struct {
 	grpcRoute          gatewayv1.GRPCRoute
 	grpcRouteRuleIndex int
+	listenerPort       gatewayv1.PortNumber
 }
 
 type makeBackendRoutingRuleParams[T any] struct {
@@ -1340,6 +1342,7 @@ func (m *ociLoadBalancerModelImpl) makeRoutingRule(
 		mapCondition: func() (string, error) {
 			return m.routingRulesMapper.mapHTTPRouteHostnamesAndMatchesToCondition(
 				params.httpRoute.Spec.Hostnames,
+				params.listenerPort,
 				rule.Matches,
 			)
 		},
@@ -1364,6 +1367,7 @@ func (m *ociLoadBalancerModelImpl) makeGRPCRoutingRule(
 		mapCondition: func() (string, error) {
 			return m.routingRulesMapper.mapGRPCRouteHostnamesAndMatchesToCondition(
 				params.grpcRoute.Spec.Hostnames,
+				params.listenerPort,
 				rule.Matches,
 			)
 		},

--- a/internal/app/oci_load_balancer_model.go
+++ b/internal/app/oci_load_balancer_model.go
@@ -768,16 +768,19 @@ func defaultCatchAllRoutingRule(defaultBackendSetName string) loadbalancer.Routi
 }
 
 func routingRuleForwardsToBackendSet(rule loadbalancer.RoutingRule, backendSetName string) bool {
-	if len(rule.Actions) != 1 {
-		return false
+	for _, action := range rule.Actions {
+		forward, ok := action.(loadbalancer.ForwardToBackendSet)
+		if ok && lo.FromPtr(forward.BackendSetName) == backendSetName {
+			return true
+		}
 	}
-	forward, ok := rule.Actions[0].(loadbalancer.ForwardToBackendSet)
-	return ok && lo.FromPtr(forward.BackendSetName) == backendSetName
+	return false
 }
 
 func defaultCatchAllRuleMatches(rule loadbalancer.RoutingRule, defaultBackendSetName string) bool {
 	return lo.FromPtr(rule.Name) == defaultCatchAllRuleName &&
 		lo.FromPtr(rule.Condition) == "any(http.request.url.path sw '/')" &&
+		len(rule.Actions) == 1 &&
 		routingRuleForwardsToBackendSet(rule, defaultBackendSetName)
 }
 

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -141,6 +141,13 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			assert.True(t, routingPolicyDefaultRuleDrifted(loadbalancer.RoutingPolicy{
 				Rules: []loadbalancer.RoutingRule{makeRandomOCIRoutingRule()},
 			}, defaultBackendSetName))
+			driftedDefaultRule := defaultCatchAllRoutingRule(defaultBackendSetName)
+			driftedDefaultRule.Actions = append(driftedDefaultRule.Actions, loadbalancer.ForwardToBackendSet{
+				BackendSetName: new("other-" + fake.Lorem().Word()),
+			})
+			assert.True(t, routingPolicyDefaultRuleDrifted(loadbalancer.RoutingPolicy{
+				Rules: []loadbalancer.RoutingRule{driftedDefaultRule},
+			}, defaultBackendSetName))
 			assert.False(t, routingPolicyDefaultRuleDrifted(loadbalancer.RoutingPolicy{
 				Rules: []loadbalancer.RoutingRule{defaultCatchAllRoutingRule(defaultBackendSetName)},
 			}, defaultBackendSetName))
@@ -4621,6 +4628,47 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 					Name: new(policyName),
 					Rules: []loadbalancer.RoutingRule{
 						defaultCatchAllRoutingRule(backendSetName),
+					},
+				},
+			}
+
+			ociLoadBalancerClient.EXPECT().GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+				LoadBalancerId: &loadBalancerID,
+			}).Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadBalancer,
+			}, nil).Once()
+
+			referenced, err := model.backendSetReferenced(t.Context(), loadBalancerID, backendSetName)
+
+			require.NoError(t, err)
+			assert.True(t, referenced)
+		})
+
+		t.Run("returns true when any routing rule action forwards to backend set", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			backendSetName := "backend-" + fake.Lorem().Word()
+			otherBackendSetName := "other-backend-" + fake.Lorem().Word()
+			policyName := "policy-" + fake.Lorem().Word()
+			ruleName := "rule-" + fake.Lorem().Word()
+			condition := "any(http.request.url.path sw '/')"
+			loadBalancer := makeRandomOCILoadBalancer()
+			loadBalancer.RoutingPolicies = map[string]loadbalancer.RoutingPolicy{
+				policyName: {
+					Name: new(policyName),
+					Rules: []loadbalancer.RoutingRule{
+						{
+							Name:      new(ruleName),
+							Condition: new(condition),
+							Actions: []loadbalancer.Action{
+								loadbalancer.ForwardToBackendSet{BackendSetName: new(otherBackendSetName)},
+								loadbalancer.ForwardToBackendSet{BackendSetName: new(backendSetName)},
+							},
+						},
 					},
 				},
 			}

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -3311,15 +3311,18 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				),
 			)
 			ruleIndex := 0
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
 
 			params := makeRoutingRuleParams{
 				httpRoute:          httpRoute,
 				httpRouteRuleIndex: ruleIndex,
+				listenerPort:       listenerPort,
 			}
 
 			expectedCondition := fake.Lorem().Sentence(10)
 			routingRulesMapper.EXPECT().mapHTTPRouteHostnamesAndMatchesToCondition(
 				httpRoute.Spec.Hostnames,
+				listenerPort,
 				httpRoute.Spec.Rules[ruleIndex].Matches,
 			).Return(expectedCondition, nil).Once()
 
@@ -3350,6 +3353,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			model := newOciLoadBalancerModel(deps)
 
 			hostname := gatewayv1.Hostname("auth-" + fake.Internet().Domain())
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
 			pathValue := "/"
 			backendRef := makeRandomBackendRef()
 			httpRoute := makeRandomHTTPRoute(
@@ -3372,6 +3376,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			actualRule, err := model.makeRoutingRule(t.Context(), makeRoutingRuleParams{
 				httpRoute:          httpRoute,
 				httpRouteRuleIndex: 0,
+				listenerPort:       listenerPort,
 			})
 
 			require.NoError(t, err)
@@ -3379,6 +3384,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			assert.Contains(t, condition, "all(")
 			assert.Contains(t, condition, "http.request.headers[(i 'host')]")
 			assert.Contains(t, condition, fmt.Sprintf("eq (i '%s')", hostname))
+			assert.Contains(t, condition, fmt.Sprintf("eq (i '%s:%d')", hostname, listenerPort))
 			assert.Contains(t, condition, fmt.Sprintf("http.request.url.path sw '%s'", pathValue))
 		})
 
@@ -3392,15 +3398,18 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				randomHTTPRouteWithRulesOpt(makeRandomHTTPRouteRule()),
 			)
 			ruleIndex := 0
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
 
 			params := makeRoutingRuleParams{
 				httpRoute:          httpRoute,
 				httpRouteRuleIndex: ruleIndex,
+				listenerPort:       listenerPort,
 			}
 
 			expectedErr := errors.New(fake.Lorem().Sentence(10))
 			routingRulesMapper.EXPECT().mapHTTPRouteHostnamesAndMatchesToCondition(
 				httpRoute.Spec.Hostnames,
+				listenerPort,
 				httpRoute.Spec.Rules[ruleIndex].Matches,
 			).Return("", expectedErr).Once()
 
@@ -3481,10 +3490,12 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				},
 			}
 			ruleIndex := 0
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
 
 			expectedCondition := fake.Lorem().Sentence(10)
 			routingRulesMapper.EXPECT().mapGRPCRouteHostnamesAndMatchesToCondition(
 				grpcRoute.Spec.Hostnames,
+				listenerPort,
 				grpcRoute.Spec.Rules[ruleIndex].Matches,
 			).Return(expectedCondition, nil).Once()
 
@@ -3505,6 +3516,7 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			actualRule, err := model.makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
 				grpcRoute:          grpcRoute,
 				grpcRouteRuleIndex: ruleIndex,
+				listenerPort:       listenerPort,
 			})
 
 			require.NoError(t, err)
@@ -3526,14 +3538,17 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 				},
 			}
 			wantErr := errors.New(fake.Lorem().Sentence(10))
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
 			routingRulesMapper.EXPECT().mapGRPCRouteHostnamesAndMatchesToCondition(
 				grpcRoute.Spec.Hostnames,
+				listenerPort,
 				grpcRoute.Spec.Rules[0].Matches,
 			).Return("", wantErr).Once()
 
 			_, err := model.makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
 				grpcRoute:          grpcRoute,
 				grpcRouteRuleIndex: 0,
+				listenerPort:       listenerPort,
 			})
 
 			require.ErrorIs(t, err, wantErr)

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -4605,6 +4605,92 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 		})
 	})
 
+	t.Run("backendSetReferenced", func(t *testing.T) {
+		t.Run("returns true when routing policy forwards to backend set", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			backendSetName := "backend-" + fake.Lorem().Word()
+			policyName := "policy-" + fake.Lorem().Word()
+			loadBalancer := makeRandomOCILoadBalancer()
+			loadBalancer.RoutingPolicies = map[string]loadbalancer.RoutingPolicy{
+				policyName: {
+					Name: new(policyName),
+					Rules: []loadbalancer.RoutingRule{
+						defaultCatchAllRoutingRule(backendSetName),
+					},
+				},
+			}
+
+			ociLoadBalancerClient.EXPECT().GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+				LoadBalancerId: &loadBalancerID,
+			}).Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadBalancer,
+			}, nil).Once()
+
+			referenced, err := model.backendSetReferenced(t.Context(), loadBalancerID, backendSetName)
+
+			require.NoError(t, err)
+			assert.True(t, referenced)
+		})
+
+		t.Run("returns false when no routing policy forwards to backend set", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			backendSetName := "backend-" + fake.Lorem().Word()
+			otherBackendSetName := "other-backend-" + fake.Lorem().Word()
+			policyName := "policy-" + fake.Lorem().Word()
+			loadBalancer := makeRandomOCILoadBalancer()
+			loadBalancer.RoutingPolicies = map[string]loadbalancer.RoutingPolicy{
+				policyName: {
+					Name: new(policyName),
+					Rules: []loadbalancer.RoutingRule{
+						defaultCatchAllRoutingRule(otherBackendSetName),
+					},
+				},
+			}
+
+			ociLoadBalancerClient.EXPECT().GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+				LoadBalancerId: &loadBalancerID,
+			}).Return(loadbalancer.GetLoadBalancerResponse{
+				LoadBalancer: loadBalancer,
+			}, nil).Once()
+
+			referenced, err := model.backendSetReferenced(t.Context(), loadBalancerID, backendSetName)
+
+			require.NoError(t, err)
+			assert.False(t, referenced)
+		})
+
+		t.Run("returns error when load balancer lookup fails", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+
+			loadBalancerID := fake.UUID().V4()
+			backendSetName := "backend-" + fake.Lorem().Word()
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+
+			ociLoadBalancerClient.EXPECT().GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+				LoadBalancerId: &loadBalancerID,
+			}).Return(loadbalancer.GetLoadBalancerResponse{}, wantErr).Once()
+
+			referenced, err := model.backendSetReferenced(t.Context(), loadBalancerID, backendSetName)
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, wantErr)
+			assert.False(t, referenced)
+		})
+	})
+
 	t.Run("removeUnusedCertificates", func(t *testing.T) {
 		makeManagedCertificate := func(namespace, name, resourceVersion string) loadbalancer.Certificate {
 			certName := fmt.Sprintf("%s-%s-rev-%s", namespace, name, resourceVersion)

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -5595,8 +5595,8 @@ func TestOciLoadBalancerModelOCICertificateIDs(t *testing.T) {
 	})
 }
 
-func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
-	t.Run("updates listener protocol to HTTP2 and preserves existing listener settings", func(t *testing.T) {
+func TestOciLoadBalancerModelImpl_ensureGRPCListenerProtocol(t *testing.T) {
+	t.Run("updates listener protocol to GRPC and preserves existing listener settings", func(t *testing.T) {
 		fake := faker.New()
 		ociLoadBalancerClient := NewMockociLoadBalancerClient(t)
 		workRequestsWatcher := NewMockworkRequestsWatcher(t)
@@ -5653,7 +5653,7 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 			UpdateListenerDetails: loadbalancer.UpdateListenerDetails{
 				DefaultBackendSetName:   new(backendSetName),
 				Port:                    new(port),
-				Protocol:                new(ociListenerProtocolHTTP2),
+				Protocol:                new(ociListenerProtocolGRPC),
 				HostnameNames:           []string{hostnameName},
 				PathRouteSetName:        new(pathRouteSetName),
 				RoutingPolicyName:       new(routingPolicyName),
@@ -5666,7 +5666,7 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 		}, nil).Once()
 		workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
 
-		err := model.ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: loadBalancerID,
 			listenerName:   listenerName,
 		})
@@ -5674,7 +5674,85 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("skips update when listener already uses HTTP2", func(t *testing.T) {
+	t.Run("updates HTTP2 listener protocol to GRPC and preserves existing listener settings", func(t *testing.T) {
+		fake := faker.New()
+		ociLoadBalancerClient := NewMockociLoadBalancerClient(t)
+		workRequestsWatcher := NewMockworkRequestsWatcher(t)
+		model := newOciLoadBalancerModel(ociLoadBalancerModelDeps{
+			RootLogger:          diag.RootTestLogger(),
+			OciClient:           ociLoadBalancerClient,
+			K8sClient:           NewMockk8sClient(t),
+			WorkRequestsWatcher: workRequestsWatcher,
+			RoutingRulesMapper:  NewMockociLoadBalancerRoutingRulesMapper(t),
+		})
+		loadBalancerID := fake.UUID().V4()
+		listenerName := "grpc-" + fake.Lorem().Word()
+		workRequestID := fake.UUID().V4()
+		backendSetName := "backend-" + fake.Lorem().Word()
+		port := rand.IntN(60000) + 1
+		routingPolicyName := listenerPolicyName(listenerName)
+		pathRouteSetName := "path-" + fake.Lorem().Word()
+		ruleSetName := "rule-" + fake.Lorem().Word()
+		hostnameName := "host-" + fake.Lorem().Word()
+		protocol := ociListenerProtocolHTTP2
+		sslConfig := &loadbalancer.SslConfiguration{
+			CertificateIds:        []string{fake.UUID().V4()},
+			CertificateName:       new("cert-" + fake.Lorem().Word()),
+			HasSessionResumption:  new(true),
+			ServerOrderPreference: loadbalancer.SslConfigurationServerOrderPreferenceEnabled,
+		}
+		connectionConfig := &loadbalancer.ConnectionConfiguration{
+			IdleTimeout: new(int64(rand.IntN(300) + 1)),
+		}
+
+		ociLoadBalancerClient.EXPECT().GetLoadBalancer(t.Context(), loadbalancer.GetLoadBalancerRequest{
+			LoadBalancerId: new(loadBalancerID),
+		}).Return(loadbalancer.GetLoadBalancerResponse{
+			LoadBalancer: loadbalancer.LoadBalancer{
+				Listeners: map[string]loadbalancer.Listener{
+					listenerName: {
+						Name:                    new(listenerName),
+						DefaultBackendSetName:   new(backendSetName),
+						Port:                    new(port),
+						Protocol:                new(protocol),
+						HostnameNames:           []string{hostnameName},
+						PathRouteSetName:        new(pathRouteSetName),
+						SslConfiguration:        sslConfig,
+						ConnectionConfiguration: connectionConfig,
+						RuleSetNames:            []string{ruleSetName},
+						RoutingPolicyName:       new(routingPolicyName),
+					},
+				},
+			},
+		}, nil).Once()
+		ociLoadBalancerClient.EXPECT().UpdateListener(t.Context(), loadbalancer.UpdateListenerRequest{
+			LoadBalancerId: new(loadBalancerID),
+			ListenerName:   new(listenerName),
+			UpdateListenerDetails: loadbalancer.UpdateListenerDetails{
+				DefaultBackendSetName:   new(backendSetName),
+				Port:                    new(port),
+				Protocol:                new(ociListenerProtocolGRPC),
+				HostnameNames:           []string{hostnameName},
+				PathRouteSetName:        new(pathRouteSetName),
+				RoutingPolicyName:       new(routingPolicyName),
+				SslConfiguration:        sslConfigurationDetailsFromBackendSet(sslConfig),
+				ConnectionConfiguration: connectionConfig,
+				RuleSetNames:            []string{ruleSetName},
+			},
+		}).Return(loadbalancer.UpdateListenerResponse{
+			OpcWorkRequestId: new(workRequestID),
+		}, nil).Once()
+		workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil).Once()
+
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
+			loadBalancerID: loadBalancerID,
+			listenerName:   listenerName,
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("skips update when listener already uses GRPC", func(t *testing.T) {
 		fake := faker.New()
 		ociLoadBalancerClient := NewMockociLoadBalancerClient(t)
 		model := newOciLoadBalancerModel(ociLoadBalancerModelDeps{
@@ -5694,13 +5772,13 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 				Listeners: map[string]loadbalancer.Listener{
 					listenerName: {
 						Name:     new(listenerName),
-						Protocol: new(ociListenerProtocolHTTP2),
+						Protocol: new(ociListenerProtocolGRPC),
 					},
 				},
 			},
 		}, nil).Once()
 
-		err := model.ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: loadBalancerID,
 			listenerName:   listenerName,
 		})
@@ -5726,7 +5804,7 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 			LoadBalancerId: new(loadBalancerID),
 		}).Return(loadbalancer.GetLoadBalancerResponse{}, wantErr).Once()
 
-		err := model.ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: loadBalancerID,
 			listenerName:   "grpc-" + fake.Lorem().Word(),
 		})
@@ -5757,7 +5835,7 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 			},
 		}, nil).Once()
 
-		err := model.ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: loadBalancerID,
 			listenerName:   listenerName,
 		})
@@ -5795,7 +5873,7 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 			Return(loadbalancer.UpdateListenerResponse{}, wantErr).
 			Once()
 
-		err := model.ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: loadBalancerID,
 			listenerName:   listenerName,
 		})
@@ -5832,7 +5910,7 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 			Return(loadbalancer.UpdateListenerResponse{}, nil).
 			Once()
 
-		err := model.ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: loadBalancerID,
 			listenerName:   listenerName,
 		})
@@ -5873,7 +5951,7 @@ func TestOciLoadBalancerModelImpl_ensureHTTP2ListenerProtocol(t *testing.T) {
 			Once()
 		workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(wantErr).Once()
 
-		err := model.ensureHTTP2ListenerProtocol(t.Context(), ensureHTTP2ListenerProtocolParams{
+		err := model.ensureGRPCListenerProtocol(t.Context(), ensureGRPCListenerProtocolParams{
 			loadBalancerID: loadBalancerID,
 			listenerName:   listenerName,
 		})
@@ -6455,10 +6533,10 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 			defaultBackendSetName := fake.UUID().V4()
 
 			return testCase{
-				name: "preserves existing HTTP2 listener protocol",
+				name: "preserves existing GRPC listener protocol",
 				params: makeOciListenerUpdateDetailsParams{
 					existingListenerData: loadbalancer.Listener{
-						Protocol:              new(ociListenerProtocolHTTP2),
+						Protocol:              new(ociListenerProtocolGRPC),
 						Port:                  new(int(listenerSpec.Port)),
 						DefaultBackendSetName: new(defaultBackendSetName),
 						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
@@ -6466,7 +6544,7 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 					listenerName:          listenerName,
 					listenerSpec:          &listenerSpec,
 					defaultBackendSetName: defaultBackendSetName,
-					preserveHTTP2:         true,
+					preserveGRPC:          true,
 				},
 				want:   loadbalancer.UpdateListenerDetails{},
 				wantOk: false,
@@ -6482,10 +6560,10 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 			newPort := listenerSpec.Port + 1
 
 			return testCase{
-				name: "preserves existing HTTP2 listener protocol while updating other fields",
+				name: "preserves existing GRPC listener protocol while updating other fields",
 				params: makeOciListenerUpdateDetailsParams{
 					existingListenerData: loadbalancer.Listener{
-						Protocol:              new(ociListenerProtocolHTTP2),
+						Protocol:              new(ociListenerProtocolGRPC),
 						Port:                  new(int(newPort)),
 						DefaultBackendSetName: new(defaultBackendSetName),
 						RoutingPolicyName:     new(listenerPolicyName(listenerName)),
@@ -6493,10 +6571,10 @@ func Test_makeOciListenerUpdateDetails(t *testing.T) {
 					listenerName:          listenerName,
 					listenerSpec:          &listenerSpec,
 					defaultBackendSetName: defaultBackendSetName,
-					preserveHTTP2:         true,
+					preserveGRPC:          true,
 				},
 				want: loadbalancer.UpdateListenerDetails{
-					Protocol:              new(ociListenerProtocolHTTP2),
+					Protocol:              new(ociListenerProtocolGRPC),
 					Port:                  new(int(listenerSpec.Port)),
 					DefaultBackendSetName: new(defaultBackendSetName),
 					RoutingPolicyName:     new(listenerPolicyName(listenerName)),

--- a/internal/app/oci_load_balancer_routing_rules.go
+++ b/internal/app/oci_load_balancer_routing_rules.go
@@ -60,6 +60,7 @@ type ociLoadBalancerRoutingRulesMapper interface {
 	// to an OCI Load Balancer routing policy condition.
 	mapHTTPRouteHostnamesAndMatchesToCondition(
 		hostnames []gatewayv1.Hostname,
+		listenerPort gatewayv1.PortNumber,
 		matches []gatewayv1.HTTPRouteMatch,
 	) (string, error)
 
@@ -67,6 +68,7 @@ type ociLoadBalancerRoutingRulesMapper interface {
 	// to an OCI Load Balancer routing policy condition.
 	mapGRPCRouteHostnamesAndMatchesToCondition(
 		hostnames []gatewayv1.Hostname,
+		listenerPort gatewayv1.PortNumber,
 		matches []gatewayv1.GRPCRouteMatch,
 	) (string, error)
 }
@@ -217,6 +219,7 @@ func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteMatchesToConditions(
 
 func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteHostnamesAndMatchesToCondition(
 	hostnames []gatewayv1.Hostname,
+	listenerPort gatewayv1.PortNumber,
 	matches []gatewayv1.HTTPRouteMatch,
 ) (string, error) {
 	if len(hostnames) == 0 {
@@ -230,13 +233,14 @@ func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteHostnamesAndMatchesT
 
 	conditions := make([]string, 0, len(hostnames)*max(1, len(matchConditions)))
 	for _, hostname := range hostnames {
-		hostCondition := fmt.Sprintf(`http.request.headers[(i 'host')] eq (i '%s')`, hostname)
-		if len(matchConditions) == 0 {
-			conditions = append(conditions, hostCondition)
-			continue
-		}
-		for _, matchCondition := range matchConditions {
-			conditions = append(conditions, "all("+hostCondition+", "+matchCondition+")")
+		for _, hostCondition := range hostConditionsForHostname(hostname, listenerPort) {
+			if len(matchConditions) == 0 {
+				conditions = append(conditions, hostCondition)
+				continue
+			}
+			for _, matchCondition := range matchConditions {
+				conditions = append(conditions, "all("+hostCondition+", "+matchCondition+")")
+			}
 		}
 	}
 
@@ -245,6 +249,7 @@ func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteHostnamesAndMatchesT
 
 func (r *ociLoadBalancerRoutingRulesMapperImpl) mapGRPCRouteHostnamesAndMatchesToCondition(
 	hostnames []gatewayv1.Hostname,
+	listenerPort gatewayv1.PortNumber,
 	matches []gatewayv1.GRPCRouteMatch,
 ) (string, error) {
 	if len(hostnames) == 0 {
@@ -258,24 +263,38 @@ func (r *ociLoadBalancerRoutingRulesMapperImpl) mapGRPCRouteHostnamesAndMatchesT
 
 	conditions := make([]string, 0, len(hostnames)*max(1, len(matchConditions))*len(grpcContentTypeConditions()))
 	for _, hostname := range hostnames {
-		hostCondition := fmt.Sprintf(`http.request.headers[(i 'host')] eq (i '%s')`, hostname)
-		if len(matchConditions) == 0 {
-			for _, contentTypeCondition := range grpcContentTypeConditions() {
-				conditions = append(conditions, allRoutingConditions(hostCondition, contentTypeCondition))
+		for _, hostCondition := range hostConditionsForHostname(hostname, listenerPort) {
+			if len(matchConditions) == 0 {
+				for _, contentTypeCondition := range grpcContentTypeConditions() {
+					conditions = append(conditions, allRoutingConditions(hostCondition, contentTypeCondition))
+				}
+				continue
 			}
-			continue
-		}
-		for _, matchCondition := range matchConditions {
-			for _, contentTypeCondition := range grpcContentTypeConditions() {
-				conditions = append(
-					conditions,
-					allRoutingConditions(hostCondition, contentTypeCondition, matchCondition),
-				)
+			for _, matchCondition := range matchConditions {
+				for _, contentTypeCondition := range grpcContentTypeConditions() {
+					conditions = append(
+						conditions,
+						allRoutingConditions(hostCondition, contentTypeCondition, matchCondition),
+					)
+				}
 			}
 		}
 	}
 
 	return fmt.Sprintf("any(%s)", strings.Join(conditions, ", ")), nil
+}
+
+func hostConditionsForHostname(hostname gatewayv1.Hostname, listenerPort gatewayv1.PortNumber) []string {
+	hostnameValue := string(hostname)
+	conditions := []string{hostHeaderEquals(hostnameValue)}
+	if listenerPort > 0 && !strings.HasPrefix(hostnameValue, "*.") && !strings.Contains(hostnameValue, ":") {
+		conditions = append(conditions, hostHeaderEquals(fmt.Sprintf("%s:%d", hostnameValue, listenerPort)))
+	}
+	return conditions
+}
+
+func hostHeaderEquals(hostname string) string {
+	return fmt.Sprintf(`http.request.headers[(i 'host')] eq (i '%s')`, hostname)
 }
 
 func grpcContentTypeCondition() string {

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -608,6 +608,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
 				nil,
+				0,
 				[]gatewayv1.HTTPRouteMatch{
 					{
 						Path: &gatewayv1.HTTPPathMatch{
@@ -631,6 +632,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
 				[]gatewayv1.Hostname{host1, host2},
+				0,
 				[]gatewayv1.HTTPRouteMatch{
 					{
 						Path: &gatewayv1.HTTPPathMatch{
@@ -667,6 +669,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
 				[]gatewayv1.Hostname{host1, host2},
+				0,
 				nil,
 			)
 
@@ -680,6 +683,41 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 				),
 				actual,
 			)
+		})
+
+		t.Run("matches hostname with listener port", func(t *testing.T) {
+			fake := faker.New()
+			hostname := gatewayv1.Hostname("api-" + fake.Internet().Domain())
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
+			pathValue := "/" + fake.Lorem().Word()
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
+				[]gatewayv1.Hostname{hostname},
+				listenerPort,
+				[]gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
+							Value: &pathValue,
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			want := fmt.Sprintf(
+				"any("+
+					"all(http.request.headers[(i 'host')] eq (i '%s'), http.request.url.path sw '%s'), "+
+					"all(http.request.headers[(i 'host')] eq (i '%s:%d'), http.request.url.path sw '%s')"+
+					")",
+				hostname,
+				pathValue,
+				hostname,
+				listenerPort,
+				pathValue,
+			)
+			assert.Equal(t, want, actual)
 		})
 	})
 
@@ -704,6 +742,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				nil,
+				0,
 				[]gatewayv1.GRPCRouteMatch{
 					{
 						Method: &gatewayv1.GRPCMethodMatch{
@@ -732,6 +771,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				nil,
+				0,
 				[]gatewayv1.GRPCRouteMatch{
 					{
 						Method: &gatewayv1.GRPCMethodMatch{
@@ -759,6 +799,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				nil,
+				0,
 				[]gatewayv1.GRPCRouteMatch{
 					{
 						Method: &gatewayv1.GRPCMethodMatch{
@@ -790,6 +831,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				[]gatewayv1.Hostname{hostname},
+				0,
 				[]gatewayv1.GRPCRouteMatch{
 					{
 						Method: &gatewayv1.GRPCMethodMatch{
@@ -830,6 +872,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				[]gatewayv1.Hostname{host1, host2},
+				0,
 				nil,
 			)
 
@@ -842,6 +885,36 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 					"any(%s, %s)",
 					grpcBranches([]string{hostCondition1}),
 					grpcBranches([]string{hostCondition2}),
+				),
+				actual,
+			)
+		})
+
+		t.Run("matches hostname with listener port", func(t *testing.T) {
+			fake := faker.New()
+			hostname := gatewayv1.Hostname("grpc-" + fake.Internet().Domain())
+			listenerPort := 8000 + fake.Int32Between(1, 1000)
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				[]gatewayv1.Hostname{hostname},
+				listenerPort,
+				nil,
+			)
+
+			require.NoError(t, err)
+			bareHostCondition := fmt.Sprintf("http.request.headers[(i 'host')] eq (i '%s')", hostname)
+			portHostCondition := fmt.Sprintf(
+				"http.request.headers[(i 'host')] eq (i '%s:%d')",
+				hostname,
+				listenerPort,
+			)
+			assert.Equal(
+				t,
+				fmt.Sprintf(
+					"any(%s, %s)",
+					grpcBranches([]string{bareHostCondition}),
+					grpcBranches([]string{portHostCondition}),
 				),
 				actual,
 			)
@@ -872,6 +945,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				[]gatewayv1.Hostname{hostname},
+				0,
 				[]gatewayv1.GRPCRouteMatch{{Method: &gatewayv1.GRPCMethodMatch{}}},
 			)
 
@@ -886,6 +960,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				nil,
+				0,
 				[]gatewayv1.GRPCRouteMatch{
 					{
 						Method: &gatewayv1.GRPCMethodMatch{
@@ -906,6 +981,7 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			rs := newOciLoadBalancerRoutingRulesMapper()
 			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
 				nil,
+				0,
 				[]gatewayv1.GRPCRouteMatch{
 					{
 						Headers: []gatewayv1.GRPCHeaderMatch{


### PR DESCRIPTION
## Summary

Adds support for running `GRPCRoute` and `HTTPRoute` on the same Gateway listener and hostname.

This updates OCI Load Balancer programming so a shared HTTPS listener can use the `GRPC` listener protocol when gRPC routes are attached, while still routing regular HTTP traffic through existing  `HTTPRoute` rules. Routing conditions now include both bare hostnames and `host:port` variants so gRPC clients that send `:authority` with the listener port are matched correctly.

Also includes cleanup improvements for rejected GRPCRoutes and shared L7 backend sets.

## Example
  ```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: api-gateway
  namespace: example
spec:
  gatewayClassName: oke-alb
  listeners:
    - name: https
      protocol: HTTPS
      port: 443
      hostname: api.example.com
      tls:
        mode: Terminate
        certificateRefs:
          - kind: Secret
            name: api-tls
      allowedRoutes:
        namespaces:
          from: Same
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: api-http
  namespace: example
spec:
  parentRefs:
    - name: api-gateway
      sectionName: https
  hostnames:
    - api.example.com
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
      backendRefs:
        - name: api-http
          port: 8080
---
apiVersion: gateway.networking.k8s.io/v1
kind: GRPCRoute
metadata:
  name: api-grpc
  namespace: example
spec:
  parentRefs:
    - name: api-gateway
      sectionName: https
  hostnames:
    - api.example.com
  rules:
    - backendRefs:
        - name: api-grpc
          port: 9090
```

With this setup:

- normal HTTP requests to https://api.example.com/ route to api-http:8080
- gRPC requests to https://api.example.com:443 route to api-grpc:9090
- both routes share the same OCI Load Balancer listener on port 443