### PR TITLE
Support OCI-compatible regex header matches for HTTPRoute and GRPCRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,24 +200,37 @@ kubectl -n oke-gw delete deployment oke-gateway-example-server
 kubectl -n oke-gw delete httproute oke-gateway-example-server
 ```
 
-## HTTPRoute matching
+## Route Matching
 
 See [deploy/manifests/examples/serverroutes.yaml](./deploy/manifests/examples/serverroutes.yaml) for a complete HTTPRoute example.
 
-Following match types are supported:
+Following HTTPRoute match types are supported:
 - path: `PathPrefix` and `Exact`
+- header: `Exact` and `RegularExpression`
+
+Following GRPCRoute match types are supported:
+- service and method: `Exact`
 - header: `Exact` and `RegularExpression`
 
 ### Notes on **RegularExpression**
 
-OCI doesn't support regexp matching, instead start with (sw) or end with (ew) matching are possible. Due to this limitations, the below patterns only are supported, they will be mapped to corresponding OCI conditions:
+OCI Load Balancer routing policies do not support arbitrary regular expressions.
+The controller supports only regex header patterns that can be translated to OCI
+starts-with (`sw`) or ends-with (`ew`) conditions. The supported patterns are:
+
 - `^foo` -> `sw 'foo'`
 - `^foo.*` -> `sw 'foo'`
+- `^foo.*$` -> `sw 'foo'`
 - `^foo\\..*` -> `sw 'foo.'`
+- `^foo\\..*$` -> `sw 'foo.'`
 - `foo$` -> `ew 'foo'`
 - `.*foo$` -> `ew 'foo'`
 
-Other patterns will result in an error.
+Other patterns will result in an error and the route will be rejected. Use route
+header matches for regex host matching; `spec.hostnames` continues to support
+only standard Gateway API exact and wildcard hostnames. See
+[deploy/manifests/examples/header-regex-matching.yaml](./deploy/manifests/examples/header-regex-matching.yaml)
+for HTTPRoute and GRPCRoute examples.
 
 ### HTTPS
 
@@ -233,7 +246,7 @@ Gateway frontend mutual TLS is supported on OCI Load Balancer HTTPS and terminat
 
 `GRPCRoute` uses the standard Gateway API CRDs and is reconciled on OCI Load Balancer with the other layer 7 routes. It is not implemented on OCI Network Load Balancer. Use `TCPRoute` if you only need gRPC passthrough to pods.
 
-The controller supports gRPC host, service, method, and exact header matching. `HTTPRoute` and `GRPCRoute` can share the same HTTPS listener and hostname; `GRPCRoute` rules require a native gRPC `content-type` and are ordered before broad `HTTPRoute` matches. Hostname conditions match both the bare host and the same host with the listener port, which covers HTTP/2 clients that send `:authority` as `api.example.com:443`.
+The controller supports gRPC host, service, method, exact header, and supported regex header matching. `HTTPRoute` and `GRPCRoute` can share the same HTTPS listener and hostname; `GRPCRoute` rules require a native gRPC `content-type` and are ordered before broad `HTTPRoute` matches. Hostname conditions match both the bare host and the same host with the listener port, which covers HTTP/2 clients that send `:authority` as `api.example.com:443`.
 
 Backend TLS is not required just because a `GRPCRoute` is present. Add a `BackendTLSPolicy` only when OCI Load Balancer should use TLS or mTLS to the backend Service port. See [deploy/manifests/examples/grpcroute.yaml](./deploy/manifests/examples/grpcroute.yaml) for a minimal route example and [deploy/manifests/examples/grpcroute-shared-listener.yaml](./deploy/manifests/examples/grpcroute-shared-listener.yaml) for HTTPRoute and GRPCRoute sharing one HTTPS listener.
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ starts-with (`sw`) or ends-with (`ew`) conditions. The supported patterns are:
 
 Other patterns will result in an error and the route will be rejected. Use route
 header matches for regex host matching; `spec.hostnames` continues to support
-only standard Gateway API exact and wildcard hostnames. See
+only standard Gateway API exact and wildcard hostnames. Translated regex header
+matches use OCI case-insensitive string literals, so supported prefix and suffix
+comparisons are case-insensitive. See
 [deploy/manifests/examples/header-regex-matching.yaml](./deploy/manifests/examples/header-regex-matching.yaml)
 for HTTPRoute and GRPCRoute examples.
 

--- a/deploy/manifests/examples/header-regex-matching.yaml
+++ b/deploy/manifests/examples/header-regex-matching.yaml
@@ -1,0 +1,65 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: regex-header-gateway
+spec:
+  gatewayClassName: oke-gateway-api
+  infrastructure:
+    parametersRef:
+      group: oke-gateway-api.gemyago.github.io
+      kind: GatewayConfig
+      name: oke-gateway-config
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.example.com"
+      tls:
+        mode: Terminate
+        options:
+          oci.oraclecloud.com/certificate-ocid: ocid1.certificate.oc1..exampleuniqueID
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: community-manager-api
+spec:
+  parentRefs:
+    - name: regex-header-gateway
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+          headers:
+            - name: Host
+              type: RegularExpression
+              value: '^community-manager-api\..*$'
+            - name: X-Tenant
+              type: RegularExpression
+              value: '-prod$'
+      backendRefs:
+        - name: community-manager-api
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: community-manager-grpc
+spec:
+  parentRefs:
+    - name: regex-header-gateway
+      sectionName: https
+  rules:
+    - matches:
+        - headers:
+            - name: Host
+              type: RegularExpression
+              value: '^community-manager-grpc\..*$'
+            - name: X-API-Version
+              type: RegularExpression
+              value: '^v1\/'
+      backendRefs:
+        - name: community-manager-grpc
+          port: 8080

--- a/internal/app/backend_tls_policy_model.go
+++ b/internal/app/backend_tls_policy_model.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/certificatesmanagement"
@@ -42,6 +43,7 @@ const (
 	backendTLSManagedByValue             = "backend-tls-policy"
 	defaultBackendTLSVerifyDepth         = 3
 	backendTLSPolicyReasonPending        = gatewayv1.PolicyConditionReason("Pending")
+	backendTLSCABundleCacheTTL           = 2 * time.Minute
 )
 
 var (
@@ -69,6 +71,7 @@ type backendTLSPolicyModelImpl struct {
 	k8sClient          k8sClient
 	loadBalancerClient ociLoadBalancerClient
 	certsClient        ociCertificatesManagementClient
+	caBundleCache      *backendTLSCABundleCache
 }
 
 type backendTLSPolicyStatusError struct {
@@ -92,6 +95,54 @@ type backendTLSPolicyCandidate struct {
 type backendTLSResolvedCARef struct {
 	ref   gatewayv1.LocalObjectReference
 	caPEM string
+}
+
+type backendTLSCABundleCache struct {
+	mu      sync.Mutex
+	entries map[backendTLSCABundleCacheKey]backendTLSCABundleCacheEntry
+}
+
+type backendTLSCABundleCacheKey struct {
+	compartmentID string
+	name          string
+	caHash        string
+}
+
+type backendTLSCABundleCacheEntry struct {
+	id        string
+	expiresAt time.Time
+}
+
+func newBackendTLSCABundleCache() *backendTLSCABundleCache {
+	return &backendTLSCABundleCache{
+		entries: map[backendTLSCABundleCacheKey]backendTLSCABundleCacheEntry{},
+	}
+}
+
+func (c *backendTLSCABundleCache) get(key backendTLSCABundleCacheKey, now time.Time) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if !now.Before(entry.expiresAt) {
+		delete(c.entries, key)
+		return "", false
+	}
+	return entry.id, true
+}
+
+func (c *backendTLSCABundleCache) set(key backendTLSCABundleCacheKey, id string, now time.Time) {
+	if id == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = backendTLSCABundleCacheEntry{
+		id:        id,
+		expiresAt: now.Add(backendTLSCABundleCacheTTL),
+	}
 }
 
 func (m *backendTLSPolicyModelImpl) resolveForBackendRef(
@@ -528,6 +579,14 @@ func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
 ) (string, error) {
 	name := backendTLSCABundleName(policy, targetRef, ref)
 	caHash := sha256Hex(caPEM)
+	cacheKey := backendTLSCABundleCacheKey{
+		compartmentID: compartmentID,
+		name:          name,
+		caHash:        caHash,
+	}
+	if caBundleID, ok := m.caBundleCache.get(cacheKey, time.Now()); ok {
+		return caBundleID, nil
+	}
 	tags := backendTLSCABundleTags(policy, caHash)
 	listResp, err := m.certsClient.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
 		CompartmentId: &compartmentID,
@@ -540,37 +599,19 @@ func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
 			err,
 		)
 	}
-	for _, bundle := range listResp.Items {
-		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted {
-			continue
-		}
-		if !isOwnedBackendTLSCABundle(bundle.FreeformTags, policy) {
-			return "", fmt.Errorf("OCI CA bundle %s already exists and is not owned by BackendTLSPolicy %s/%s",
-				name,
-				policy.Namespace,
-				policy.Name,
-			)
-		}
-		if usableErr := ensureBackendTLSCABundleUsable(bundle); usableErr != nil {
-			return "", usableErr
-		}
-		if bundle.FreeformTags[backendTLSCAHashTag] != caHash {
-			m.logger.InfoContext(ctx, "Updating OCI CA bundle for BackendTLSPolicy",
-				slog.String("policy", fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)),
-				slog.String("caBundleName", name),
-			)
-			_, err = m.certsClient.UpdateCaBundle(ctx, certificatesmanagement.UpdateCaBundleRequest{
-				CaBundleId: bundle.Id,
-				UpdateCaBundleDetails: certificatesmanagement.UpdateCaBundleDetails{
-					CaBundlePem:  &caPEM,
-					FreeformTags: tags,
-				},
-			})
-			if err != nil {
-				return "", fmt.Errorf("failed to update OCI CA bundle %s: %w", name, err)
-			}
-		}
-		return lo.FromPtr(bundle.Id), nil
+	if caBundleID, matched, resolveErr := m.resolveListedOCIManagedCABundle(
+		ctx,
+		backendTLSListedCABundleParams{
+			policy:   policy,
+			name:     name,
+			caHash:   caHash,
+			caPEM:    caPEM,
+			tags:     tags,
+			bundles:  listResp.Items,
+			cacheKey: cacheKey,
+		},
+	); resolveErr != nil || matched {
+		return caBundleID, resolveErr
 	}
 
 	m.logger.InfoContext(ctx, "Creating OCI CA bundle for BackendTLSPolicy",
@@ -587,7 +628,12 @@ func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
 	})
 	if err != nil {
 		if isBackendTLSCABundleAlreadyExists(err) {
-			return m.resolveExistingOCIManagedCABundle(ctx, policy, compartmentID, name, caHash)
+			caBundleID, resolveErr := m.resolveExistingOCIManagedCABundle(ctx, policy, compartmentID, name, caHash)
+			if resolveErr != nil {
+				return "", resolveErr
+			}
+			m.caBundleCache.set(cacheKey, caBundleID, time.Now())
+			return caBundleID, nil
 		}
 		return "", fmt.Errorf("failed to create OCI CA bundle %s: %w", name, err)
 	}
@@ -597,7 +643,60 @@ func (m *backendTLSPolicyModelImpl) ensureOCIManagedCABundle(
 			createResp.CaBundle.LifecycleState,
 		)
 	}
-	return lo.FromPtr(createResp.CaBundle.Id), nil
+	caBundleID := lo.FromPtr(createResp.CaBundle.Id)
+	m.caBundleCache.set(cacheKey, caBundleID, time.Now())
+	return caBundleID, nil
+}
+
+type backendTLSListedCABundleParams struct {
+	policy   gatewayv1.BackendTLSPolicy
+	name     string
+	caHash   string
+	caPEM    string
+	tags     map[string]string
+	bundles  []certificatesmanagement.CaBundleSummary
+	cacheKey backendTLSCABundleCacheKey
+}
+
+func (m *backendTLSPolicyModelImpl) resolveListedOCIManagedCABundle(
+	ctx context.Context,
+	params backendTLSListedCABundleParams,
+) (string, bool, error) {
+	for _, bundle := range params.bundles {
+		if bundle.LifecycleState == certificatesmanagement.CaBundleLifecycleStateDeleted {
+			continue
+		}
+		if !isOwnedBackendTLSCABundle(bundle.FreeformTags, params.policy) {
+			return "", true, fmt.Errorf("OCI CA bundle %s already exists and is not owned by BackendTLSPolicy %s/%s",
+				params.name,
+				params.policy.Namespace,
+				params.policy.Name,
+			)
+		}
+		if usableErr := ensureBackendTLSCABundleUsable(bundle); usableErr != nil {
+			return "", true, usableErr
+		}
+		if bundle.FreeformTags[backendTLSCAHashTag] != params.caHash {
+			m.logger.InfoContext(ctx, "Updating OCI CA bundle for BackendTLSPolicy",
+				slog.String("policy", fmt.Sprintf("%s/%s", params.policy.Namespace, params.policy.Name)),
+				slog.String("caBundleName", params.name),
+			)
+			_, err := m.certsClient.UpdateCaBundle(ctx, certificatesmanagement.UpdateCaBundleRequest{
+				CaBundleId: bundle.Id,
+				UpdateCaBundleDetails: certificatesmanagement.UpdateCaBundleDetails{
+					CaBundlePem:  &params.caPEM,
+					FreeformTags: params.tags,
+				},
+			})
+			if err != nil {
+				return "", true, fmt.Errorf("failed to update OCI CA bundle %s: %w", params.name, err)
+			}
+		}
+		caBundleID := lo.FromPtr(bundle.Id)
+		m.caBundleCache.set(params.cacheKey, caBundleID, time.Now())
+		return caBundleID, true, nil
+	}
+	return "", false, nil
 }
 
 func (m *backendTLSPolicyModelImpl) resolveExistingOCIManagedCABundle(
@@ -1143,5 +1242,6 @@ func newBackendTLSPolicyModel(deps backendTLSPolicyModelDeps) *backendTLSPolicyM
 		k8sClient:          deps.K8sClient,
 		loadBalancerClient: deps.OciLoadBalancerClient,
 		certsClient:        deps.OciCertificatesMgmtClient,
+		caBundleCache:      newBackendTLSCABundleCache(),
 	}
 }

--- a/internal/app/backend_tls_policy_model_test.go
+++ b/internal/app/backend_tls_policy_model_test.go
@@ -44,6 +44,7 @@ type stubCertificatesManagementClient struct {
 	createCalls        []certificatesmanagement.CreateCaBundleRequest
 	updateCalls        []certificatesmanagement.UpdateCaBundleRequest
 	deleteCalls        []certificatesmanagement.DeleteCaBundleRequest
+	listCalls          []certificatesmanagement.ListCaBundlesRequest
 	getErrByID         map[string]error
 	createErr          error
 	createErrByName    map[string]error
@@ -119,6 +120,7 @@ func (s *stubCertificatesManagementClient) ListCaBundles(
 	_ context.Context,
 	request certificatesmanagement.ListCaBundlesRequest,
 ) (certificatesmanagement.ListCaBundlesResponse, error) {
+	s.listCalls = append(s.listCalls, request)
 	if s.listErr != nil {
 		return certificatesmanagement.ListCaBundlesResponse{}, s.listErr
 	}
@@ -866,6 +868,84 @@ func TestBackendTLSPolicyModelValidationAndLifecycle(t *testing.T) {
 		assert.Equal(t, bundleID, caID)
 		assert.Empty(t, certsClient.createCalls)
 		assert.Empty(t, certsClient.updateCalls)
+	})
+
+	t.Run("caches resolved OCI CA bundle during repeated backend TLS resolution", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cache-reuse", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		caPEM := testCAPEM(t)
+		certsClient := newStubCertificatesManagementClient()
+		bundleID := "ocid1.cabundle.oc1..cachereuse"
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:           &bundleID,
+			Name:         &name,
+			FreeformTags: backendTLSCABundleTags(policy, sha256Hex(caPEM)),
+		}
+		model, _ := makeModel(t, certsClient)
+
+		firstCAID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, caPEM)
+		require.NoError(t, err)
+		secondCAID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, caPEM)
+
+		require.NoError(t, err)
+		assert.Equal(t, bundleID, firstCAID)
+		assert.Equal(t, bundleID, secondCAID)
+		assert.Len(t, certsClient.listCalls, 1)
+		assert.Empty(t, certsClient.createCalls)
+		assert.Empty(t, certsClient.updateCalls)
+	})
+
+	t.Run("re-resolves OCI CA bundle when referenced ConfigMap CA changes after cache fill", func(t *testing.T) {
+		policy := backendTLSPolicy(namespace, "cache-rotate", serviceName, "tls", baseOptions, "ca")
+		targetRef := policy.Spec.TargetRefs[0]
+		ref := policy.Spec.Validation.CACertificateRefs[0]
+		name := backendTLSCABundleName(policy, targetRef, ref)
+		oldPEM := testCAPEM(t)
+		newPEM := testCAPEM(t)
+		certsClient := newStubCertificatesManagementClient()
+		bundleID := "ocid1.cabundle.oc1..cacherotate"
+		certsClient.bundles[name] = certificatesmanagement.CaBundleSummary{
+			Id:           &bundleID,
+			Name:         &name,
+			FreeformTags: backendTLSCABundleTags(policy, sha256Hex(oldPEM)),
+		}
+		model, _ := makeModel(t, certsClient)
+
+		firstCAID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, oldPEM)
+		require.NoError(t, err)
+		secondCAID, err := model.ensureOCIManagedCABundle(t.Context(), policy, targetRef, ref, compartmentID, newPEM)
+
+		require.NoError(t, err)
+		assert.Equal(t, bundleID, firstCAID)
+		assert.Equal(t, bundleID, secondCAID)
+		assert.Len(t, certsClient.listCalls, 2)
+		assert.Len(t, certsClient.updateCalls, 1)
+		assert.Equal(t, newPEM, lo.FromPtr(certsClient.updateCalls[0].UpdateCaBundleDetails.CaBundlePem))
+	})
+
+	t.Run("expires cached OCI CA bundle entries", func(t *testing.T) {
+		cache := newBackendTLSCABundleCache()
+		key := backendTLSCABundleCacheKey{
+			compartmentID: "ocid1.compartment.oc1.." + fakeData.UUID().V4(),
+			name:          "ca-" + fakeData.Lorem().Word(),
+			caHash:        fakeData.Hash().SHA256(),
+		}
+		now := time.Now()
+		cache.set(key, "", now)
+		_, matched := cache.get(key, now)
+		require.False(t, matched)
+
+		id := "ocid1.cabundle.oc1.." + fakeData.UUID().V4()
+		cache.set(key, id, now)
+		cachedID, matched := cache.get(key, now.Add(backendTLSCABundleCacheTTL-time.Second))
+		require.True(t, matched)
+		assert.Equal(t, id, cachedID)
+
+		_, matched = cache.get(key, now.Add(backendTLSCABundleCacheTTL))
+		require.False(t, matched)
+		assert.Empty(t, cache.entries)
 	})
 
 	t.Run("waits for existing owned OCI CA bundle to become active", func(t *testing.T) {

--- a/internal/app/grpcroute_controller.go
+++ b/internal/app/grpcroute_controller.go
@@ -70,6 +70,14 @@ func (r *GRPCRouteController) handleProgramRouteError(
 	if errors.As(err, &statusErr) {
 		return true, r.rejectResolvedRoute(ctx, resolvedData, acceptedRoute, statusErr)
 	}
+	if errors.Is(err, errUnsupportedMatch) {
+		return true, r.rejectResolvedRoute(
+			ctx,
+			resolvedData,
+			acceptedRoute,
+			newGRPCRouteUnsupportedValueStatusError(err.Error()),
+		)
+	}
 	if isParentGatewayStatusError(err) {
 		r.logger.InfoContext(ctx, "GRPCRoute parent Gateway is not programmable",
 			slog.String("grpcRoute", resolvedData.grpcRoute.Name),

--- a/internal/app/grpcroute_controller_test.go
+++ b/internal/app/grpcroute_controller_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -415,6 +416,43 @@ func TestGRPCRouteController(t *testing.T) {
 			setRejectedFunc: func(_ context.Context, details resolvedGRPCRouteDetails, gotErr grpcRouteStatusError) error {
 				assert.Equal(t, route.Name, details.grpcRoute.Name)
 				assert.Equal(t, statusErr, gotErr)
+				return nil
+			},
+		}
+
+		got, err := newController(routeModel, NewMockhttpBackendModel(t)).Reconcile(t.Context(), reconcile.Request{})
+
+		require.NoError(t, err)
+		assertDriftRequeue(t, got, 2*time.Minute)
+	})
+
+	t.Run("sets rejected status for unsupported programming matches", func(t *testing.T) {
+		route := makeRoute()
+		resolved := makeResolved(route)
+		service := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: "grpc-svc"}}
+		programErr := fmt.Errorf("failed to map grpc route matches to condition: %w", errUnsupportedMatch)
+		routeModel := fakeGRPCRouteModel{
+			resolveRequestFunc: func(
+				_ context.Context,
+				_ reconcile.Request,
+			) (map[routeParentResultKey]resolvedGRPCRouteDetails, error) {
+				return resolvedMap(route, resolved), nil
+			},
+			isProgrammingRequiredFn: func(resolvedGRPCRouteDetails) bool { return true },
+			acceptRouteFunc: func(_ context.Context, details resolvedGRPCRouteDetails) (*gatewayv1.GRPCRoute, error) {
+				return &details.grpcRoute, nil
+			},
+			resolveBackendRefsFunc: func(context.Context, resolveGRPCBackendRefsParams) (map[string]corev1.Service, error) {
+				return map[string]corev1.Service{service.Namespace + "/" + service.Name: service}, nil
+			},
+			programRouteFunc: func(context.Context, programGRPCRouteParams) (programGRPCRouteResult, error) {
+				return programGRPCRouteResult{}, programErr
+			},
+			setRejectedFunc: func(_ context.Context, details resolvedGRPCRouteDetails, gotErr grpcRouteStatusError) error {
+				assert.Equal(t, route.Name, details.grpcRoute.Name)
+				assert.Equal(t, gatewayv1.RouteConditionAccepted, gotErr.conditionType)
+				assert.Equal(t, gatewayv1.RouteReasonUnsupportedValue, gotErr.reason)
+				assert.Equal(t, programErr.Error(), gotErr.message)
 				return nil
 			},
 		}

--- a/internal/app/grpcroute_model.go
+++ b/internal/app/grpcroute_model.go
@@ -141,6 +141,14 @@ func newGRPCRouteBackendNotFoundStatusError(message string) grpcRouteStatusError
 	}
 }
 
+func newGRPCRouteUnsupportedValueStatusError(message string) grpcRouteStatusError {
+	return grpcRouteStatusError{
+		conditionType: gatewayv1.RouteConditionAccepted,
+		reason:        gatewayv1.RouteReasonUnsupportedValue,
+		message:       message,
+	}
+}
+
 type grpcRouteModelImpl struct {
 	client               k8sClient
 	logger               *slog.Logger

--- a/internal/app/grpcroute_model_test.go
+++ b/internal/app/grpcroute_model_test.go
@@ -1553,7 +1553,6 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		listener := makeRandomListener()
 		wantErr := errors.New(fake.Lorem().Sentence(10))
 
-		ociLBModel.EXPECT().reconcileBackendSet(t.Context(), mock.Anything).Return(nil).Once()
 		ociLBModel.EXPECT().
 			makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
 				grpcRoute:          route,
@@ -1573,6 +1572,43 @@ func TestGRPCRouteModelImpl(t *testing.T) {
 		})
 
 		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("programRoute does not reconcile backend sets when routing rule validation fails", func(t *testing.T) {
+		fake := faker.New()
+		deps := newMockDeps(t)
+		model := newGRPCRouteModel(deps)
+		ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+		backendRef := makeGRPCBackendRef()
+		route := makeGRPCRoute(func(route *gatewayv1.GRPCRoute) {
+			route.Spec.Rules = []gatewayv1.GRPCRouteRule{{BackendRefs: []gatewayv1.GRPCBackendRef{backendRef}}}
+		})
+		config := makeRandomGatewayConfig()
+		service := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: route.Namespace, Name: string(backendRef.Name)},
+		}
+		listener := makeRandomListener()
+		wantErr := fmt.Errorf("unsupported rule %s: %w", fake.Lorem().Word(), errUnsupportedMatch)
+
+		ociLBModel.EXPECT().
+			makeGRPCRoutingRule(t.Context(), makeGRPCRoutingRuleParams{
+				grpcRoute:          route,
+				grpcRouteRuleIndex: 0,
+				listenerPort:       listener.Port,
+			}).
+			Return(loadbalancer.RoutingRule{}, wantErr).
+			Once()
+
+		_, err := model.programRoute(t.Context(), programGRPCRouteParams{
+			config:        config,
+			grpcRoute:     route,
+			knownBackends: map[string]corev1.Service{service.Namespace + "/" + service.Name: service},
+			matchedListeners: []gatewayv1.Listener{
+				listener,
+			},
+		})
+
+		require.ErrorIs(t, err, errUnsupportedMatch)
 	})
 
 	t.Run("setProgrammed", func(t *testing.T) {

--- a/internal/app/httproute_controller.go
+++ b/internal/app/httproute_controller.go
@@ -120,6 +120,18 @@ func (r *HTTPRouteController) reconcileResolvedRoute(
 		knownBackends:    knownBackends,
 	})
 	if err != nil {
+		var statusErr httpRouteStatusError
+		if errors.As(err, &statusErr) {
+			return false, r.rejectResolvedRoute(ctx, resolvedData, *acceptedRoute, statusErr)
+		}
+		if errors.Is(err, errUnsupportedMatch) {
+			return false, r.rejectResolvedRoute(
+				ctx,
+				resolvedData,
+				*acceptedRoute,
+				newHTTPRouteUnsupportedValueStatusError(err.Error()),
+			)
+		}
 		if isParentGatewayStatusError(err) {
 			r.logger.InfoContext(ctx, "HTTPRoute parent Gateway is not programmable",
 				slog.String("httpRoute", resolvedData.httpRoute.Name),

--- a/internal/app/httproute_controller_test.go
+++ b/internal/app/httproute_controller_test.go
@@ -555,6 +555,74 @@ func TestHTTPRouteController(t *testing.T) {
 			assert.Equal(t, reconcile.Result{}, result)
 		})
 
+		t.Run("sets rejected status for programming status errors", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			controller := NewHTTPRouteController(deps)
+
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: fake.Internet().Domain(),
+					Name:      fake.Lorem().Word(),
+				},
+			}
+			wantResolvedData := resolvedRouteDetails{
+				httpRoute: makeRandomHTTPRoute(),
+				gatewayDetails: resolvedGatewayDetails{
+					gateway: *newRandomGateway(),
+					config:  makeRandomGatewayConfig(),
+				},
+			}
+			wantBackendRefs := make(map[string]v1.Service)
+			for range 3 {
+				svc := makeRandomService()
+				fullName := types.NamespacedName{
+					Namespace: svc.Namespace,
+					Name:      svc.Name,
+				}
+				wantBackendRefs[fullName.String()] = svc
+			}
+			wantAcceptedRoute := makeRandomHTTPRoute()
+			programErr := fmt.Errorf("failed to map http route matches to condition: %w", errUnsupportedMatch)
+
+			mockModel, _ := deps.HTTPRouteModel.(*MockhttpRouteModel)
+			mockModel.EXPECT().resolveRequest(
+				t.Context(),
+				req,
+			).Return(map[routeParentResultKey]resolvedRouteDetails{
+				gatewayParentResultKey(req.NamespacedName): wantResolvedData,
+			}, (error)(nil))
+			mockModel.EXPECT().isProgrammingRequired(wantResolvedData).Return(true, nil)
+			mockModel.EXPECT().acceptRoute(t.Context(), wantResolvedData).Return(&wantAcceptedRoute, nil)
+			expectPending(mockModel, wantResolvedData, wantAcceptedRoute)
+			mockModel.EXPECT().resolveBackendRefs(
+				t.Context(),
+				resolveBackendRefsParams{httpRoute: wantAcceptedRoute},
+			).Return(wantBackendRefs, nil)
+			mockModel.EXPECT().programRoute(
+				t.Context(),
+				programRouteParams{
+					gateway:       wantResolvedData.gatewayDetails.gateway,
+					config:        wantResolvedData.gatewayDetails.config,
+					httpRoute:     wantAcceptedRoute,
+					knownBackends: wantBackendRefs,
+				},
+			).Return(programRouteResult{}, programErr)
+			mockModel.EXPECT().setRejected(t.Context(), mock.MatchedBy(func(details resolvedRouteDetails) bool {
+				return details.httpRoute.Name == wantAcceptedRoute.Name &&
+					details.httpRoute.Namespace == wantAcceptedRoute.Namespace
+			}), mock.MatchedBy(func(statusErr httpRouteStatusError) bool {
+				return statusErr.conditionType == gatewayv1.RouteConditionAccepted &&
+					statusErr.reason == gatewayv1.RouteReasonUnsupportedValue &&
+					statusErr.message == programErr.Error()
+			})).Return(nil)
+
+			result, err := controller.Reconcile(t.Context(), req)
+
+			require.NoError(t, err)
+			assertDriftRequeue(t, result, controller.driftInterval)
+		})
+
 		t.Run("does not retry when parent Gateway rejects programming", func(t *testing.T) {
 			fake := faker.New()
 			deps := newMockDeps(t)

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -1219,18 +1219,18 @@ func programL7RoutePolicy(
 	ociLoadBalancerModel ociLoadBalancerModel,
 	params programL7RoutePolicyParams,
 ) ([]string, []string, error) {
+	if err := validateResolvedL7BackendRefs(params); err != nil {
+		return nil, nil, err
+	}
+
+	policyRulesByListener, policyRuleNames, buildErr := buildL7RoutingRulesByListener(params)
+	if buildErr != nil {
+		return nil, nil, buildErr
+	}
+
 	desiredBackendSets, reconcileErr := reconcileL7BackendSets(ctx, ociLoadBalancerModel, params)
 	if reconcileErr != nil {
 		return nil, nil, reconcileErr
-	}
-
-	policyRuleNames := make([]string, 0, params.ruleCount)
-	recordPolicyRuleName := func(rule loadbalancer.RoutingRule) {
-		ruleName := lo.FromPtr(rule.Name)
-		if ruleName == "" || lo.Contains(policyRuleNames, ruleName) {
-			return
-		}
-		policyRuleNames = append(policyRuleNames, ruleName)
 	}
 
 	prevRulesByListener := previousPolicyRulesByListener(params.previousPolicyRules, params.matchedListeners)
@@ -1242,26 +1242,11 @@ func programL7RoutePolicy(
 	)
 
 	for _, listener := range params.matchedListeners {
-		policyRules := make([]loadbalancer.RoutingRule, 0, params.ruleCount)
-		for ruleIndex := range params.ruleCount {
-			rule, err := params.makeRoutingRule(ruleIndex, listener.Port)
-			if err != nil {
-				return nil, nil, fmt.Errorf(
-					"failed to make routing rule %d for route %s: %w",
-					ruleIndex,
-					params.routeName,
-					err,
-				)
-			}
-			policyRules = append(policyRules, rule)
-			recordPolicyRuleName(rule)
-		}
-
 		listenerName := string(listener.Name)
 		err := ociLoadBalancerModel.commitRoutingPolicy(ctx, commitRoutingPolicyParams{
 			loadBalancerID:  params.loadBalancerID,
 			listenerName:    listenerName,
-			policyRules:     policyRules,
+			policyRules:     policyRulesByListener[listenerName],
 			prevPolicyRules: prevRulesByListener[listenerName],
 		})
 		if err != nil {
@@ -1295,6 +1280,57 @@ func programL7RoutePolicy(
 	return programmedHTTPRoutePolicyRulesAnnotation(params.matchedListeners, policyRuleNames),
 		programmedBackendSets,
 		nil
+}
+
+func buildL7RoutingRulesByListener(
+	params programL7RoutePolicyParams,
+) (map[string][]loadbalancer.RoutingRule, []string, error) {
+	policyRulesByListener := make(map[string][]loadbalancer.RoutingRule, len(params.matchedListeners))
+	policyRuleNames := make([]string, 0, params.ruleCount)
+	recordPolicyRuleName := func(rule loadbalancer.RoutingRule) {
+		ruleName := lo.FromPtr(rule.Name)
+		if ruleName == "" || lo.Contains(policyRuleNames, ruleName) {
+			return
+		}
+		policyRuleNames = append(policyRuleNames, ruleName)
+	}
+
+	for _, listener := range params.matchedListeners {
+		listenerName := string(listener.Name)
+		policyRules := make([]loadbalancer.RoutingRule, 0, params.ruleCount)
+		for ruleIndex := range params.ruleCount {
+			rule, err := params.makeRoutingRule(ruleIndex, listener.Port)
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"failed to make routing rule %d for route %s: %w",
+					ruleIndex,
+					params.routeName,
+					err,
+				)
+			}
+			policyRules = append(policyRules, rule)
+			recordPolicyRuleName(rule)
+		}
+		policyRulesByListener[listenerName] = policyRules
+	}
+
+	return policyRulesByListener, policyRuleNames, nil
+}
+
+func validateResolvedL7BackendRefs(params programL7RoutePolicyParams) error {
+	processedBackendRefs := make(map[string]struct{})
+	for _, backendRef := range params.backendRefs {
+		key := l7BackendRefKey(backendRef, params.routeNamespace)
+		if _, ok := processedBackendRefs[key]; ok {
+			continue
+		}
+		serviceName := backendObjectRefName(backendRef.BackendObjectReference, params.routeNamespace).String()
+		if _, ok := params.knownBackends[serviceName]; !ok {
+			return fmt.Errorf("resolved backend service %s not found", serviceName)
+		}
+		processedBackendRefs[key] = struct{}{}
+	}
+	return nil
 }
 
 func programL7Route(

--- a/internal/app/httproute_model.go
+++ b/internal/app/httproute_model.go
@@ -297,6 +297,14 @@ func newHTTPRouteBackendNotFoundStatusError(message string) httpRouteStatusError
 	}
 }
 
+func newHTTPRouteUnsupportedValueStatusError(message string) httpRouteStatusError {
+	return httpRouteStatusError{
+		conditionType: gatewayv1.RouteConditionAccepted,
+		reason:        gatewayv1.RouteReasonUnsupportedValue,
+		message:       message,
+	}
+}
+
 // parentRefSameTarget checks if two parent references target the same resource.
 // It ignores the section name and port.
 func parentRefSameTarget(a, b gatewayv1.ParentReference) bool {

--- a/internal/app/httproute_model_test.go
+++ b/internal/app/httproute_model_test.go
@@ -2533,6 +2533,9 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 
+			rule := makeRandomOCIRoutingRule()
+			ociLBModel.EXPECT().makeRoutingRule(t.Context(), mock.Anything).Return(rule, nil)
+
 			wantErr := errors.New(fake.Lorem().Sentence(10))
 
 			// First service reconciliation fails
@@ -2576,9 +2579,6 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 
 			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
 
-			// Backend set reconciliation succeeds
-			ociLBModel.EXPECT().reconcileBackendSet(t.Context(), mock.Anything).Return(nil)
-
 			wantErr := errors.New(fake.Lorem().Sentence(10))
 
 			// Making routing rule fails
@@ -2587,6 +2587,43 @@ func TestHTTPRouteModelImpl(t *testing.T) {
 			_, err := model.programRoute(t.Context(), params)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("does not reconcile backend sets when routing rule validation fails", func(t *testing.T) {
+			fake := faker.New()
+			deps := newMockDeps(t)
+			model := newHTTPRouteModel(deps)
+
+			gateway := newRandomGateway()
+			config := makeRandomGatewayConfig()
+			backendRef := makeRandomBackendRef()
+			httpRoute := makeRandomHTTPRoute(
+				randomHTTPRouteWithRulesOpt(
+					makeRandomHTTPRouteRule(randomHTTPRouteRuleWithRandomBackendRefsOpt(backendRef)),
+				),
+			)
+			service := makeRandomService(randomServiceFromBackendRef(backendRef, &httpRoute))
+			services := map[string]corev1.Service{
+				types.NamespacedName{Namespace: service.Namespace, Name: service.Name}.String(): service,
+			}
+			listener := makeRandomListener()
+			wantErr := fmt.Errorf("unsupported rule %s: %w", fake.Lorem().Word(), errUnsupportedMatch)
+
+			ociLBModel, _ := deps.OciLBModel.(*MockociLoadBalancerModel)
+			ociLBModel.EXPECT().
+				makeRoutingRule(t.Context(), mock.Anything).
+				Return(loadbalancer.RoutingRule{}, wantErr).
+				Once()
+
+			_, err := model.programRoute(t.Context(), programRouteParams{
+				gateway:          *gateway,
+				config:           config,
+				httpRoute:        httpRoute,
+				knownBackends:    services,
+				matchedListeners: []gatewayv1.Listener{listener},
+			})
+
+			require.ErrorIs(t, err, errUnsupportedMatch)
 		})
 
 		t.Run("fails when commitRoutingPolicyV2 fails", func(t *testing.T) {

--- a/internal/app/oci_load_balancer_model_test.go
+++ b/internal/app/oci_load_balancer_model_test.go
@@ -4274,6 +4274,56 @@ func TestOciLoadBalancerModelImpl(t *testing.T) {
 			ociLoadBalancerClient.AssertNotCalled(t, "UpdateRoutingPolicy")
 		})
 
+		t.Run("updates routing policy when rule condition changes", func(t *testing.T) {
+			fake := faker.New()
+			deps := makeMockDeps(t)
+			model := newOciLoadBalancerModel(deps)
+			ociLoadBalancerClient, _ := deps.OciClient.(*MockociLoadBalancerClient)
+			workRequestsWatcher, _ := deps.WorkRequestsWatcher.(*MockworkRequestsWatcher)
+
+			loadBalancerID := fake.UUID().V4()
+			listenerName := fake.UUID().V4()
+			policyName := listenerPolicyName(listenerName)
+			ruleName := "http-" + fake.Lorem().Word()
+			existingRule := loadbalancer.RoutingRule{
+				Name:      new(ruleName),
+				Condition: new(`http.request.headers[(i 'Host')][0] sw (i 'old-prefix.')`),
+			}
+			desiredRule := loadbalancer.RoutingRule{
+				Name:      new(ruleName),
+				Condition: new(`http.request.headers[(i 'Host')][0] sw (i 'new-prefix.')`),
+			}
+
+			ociLoadBalancerClient.EXPECT().GetRoutingPolicy(t.Context(), loadbalancer.GetRoutingPolicyRequest{
+				RoutingPolicyName: new(policyName),
+				LoadBalancerId:    &loadBalancerID,
+			}).Return(loadbalancer.GetRoutingPolicyResponse{
+				RoutingPolicy: loadbalancer.RoutingPolicy{
+					Name:                     new(policyName),
+					Rules:                    []loadbalancer.RoutingRule{existingRule},
+					ConditionLanguageVersion: loadbalancer.RoutingPolicyConditionLanguageVersionV1,
+				},
+			}, nil)
+
+			workRequestID := fake.UUID().V4()
+			ociLoadBalancerClient.EXPECT().UpdateRoutingPolicy(t.Context(), mock.MatchedBy(
+				func(req loadbalancer.UpdateRoutingPolicyRequest) bool {
+					assert.Equal(t, []loadbalancer.RoutingRule{desiredRule}, req.UpdateRoutingPolicyDetails.Rules)
+					return true
+				},
+			)).Return(loadbalancer.UpdateRoutingPolicyResponse{
+				OpcWorkRequestId: &workRequestID,
+			}, nil)
+			workRequestsWatcher.EXPECT().WaitFor(t.Context(), workRequestID).Return(nil)
+
+			err := model.commitRoutingPolicy(t.Context(), commitRoutingPolicyParams{
+				loadBalancerID: loadBalancerID,
+				listenerName:   listenerName,
+				policyRules:    []loadbalancer.RoutingRule{desiredRule},
+			})
+			require.NoError(t, err)
+		})
+
 		t.Run("fail when get routing policy fails", func(t *testing.T) {
 			fake := faker.New()
 			deps := makeMockDeps(t)

--- a/internal/app/oci_load_balancer_routing_rules.go
+++ b/internal/app/oci_load_balancer_routing_rules.go
@@ -3,7 +3,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/samber/lo"
@@ -12,36 +11,66 @@ import (
 
 var errUnsupportedMatch = errors.New("unsupported match type")
 
-// Allow alphanumeric characters, hyphens, underscores, and escaped dots.
-var startsWithExpression = regexp.MustCompile(`^\^([a-zA-Z0-9\-_\\\.]+?)(?:\.\*)?$`)
-
-// Allow alphanumeric characters, hyphens, underscores, and escaped dots.
-var endsWithExpression = regexp.MustCompile(`^([a-zA-Z0-9\-_\\\.]+?)\$$`)
-
-const expectedMatchesLength = 2
-
 // Returns the prefix and true if it matches, empty string and false otherwise.
 func parseRegexForStartsWith(pattern string) (string, bool) {
-	matches := startsWithExpression.FindStringSubmatch(pattern)
-	if len(matches) != expectedMatchesLength {
+	value, ok := strings.CutPrefix(pattern, "^")
+	if !ok {
 		return "", false
 	}
 
-	// Unescape dots in the prefix
-	prefix := strings.ReplaceAll(matches[1], "\\.", ".")
-	return prefix, true
+	value = strings.TrimSuffix(value, ".*$")
+	value = strings.TrimSuffix(value, ".*")
+	return parseRegexLiteral(value)
 }
 
 // Returns the suffix and true if it matches, empty string and false otherwise.
 func parseRegexForEndsWith(pattern string) (string, bool) {
-	matches := endsWithExpression.FindStringSubmatch(pattern)
-	if len(matches) != expectedMatchesLength {
+	value, ok := strings.CutSuffix(pattern, "$")
+	if !ok {
 		return "", false
 	}
 
-	// Unescape dots in the suffix
-	suffix := strings.ReplaceAll(matches[1], "\\.", ".")
-	return suffix, true
+	value = strings.TrimPrefix(value, ".*")
+	return parseRegexLiteral(value)
+}
+
+func parseRegexLiteral(value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+
+	var literal strings.Builder
+	for index := 0; index < len(value); index++ {
+		if value[index] != '\\' {
+			if isRegexMetaCharacter(value[index]) {
+				return "", false
+			}
+			literal.WriteByte(value[index])
+			continue
+		}
+
+		index++
+		if index >= len(value) {
+			return "", false
+		}
+		switch value[index] {
+		case '.', '/', '\\':
+			literal.WriteByte(value[index])
+		default:
+			return "", false
+		}
+	}
+
+	return literal.String(), true
+}
+
+func isRegexMetaCharacter(value byte) bool {
+	switch value {
+	case '.', '^', '$', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|':
+		return true
+	default:
+		return false
+	}
 }
 
 type ociLoadBalancerRoutingRulesMapper interface {
@@ -169,16 +198,20 @@ func mapHeaderMatchToCondition(headerMatch gatewayv1.HTTPHeaderMatch) (string, e
 }
 
 func mapRegexHeaderMatchToCondition(headerMatch gatewayv1.HTTPHeaderMatch) (string, error) {
-	if prefix, swMatched := parseRegexForStartsWith(headerMatch.Value); swMatched {
-		return fmt.Sprintf(`http.request.headers[(i '%s')][0] sw (i '%s')`, headerMatch.Name, prefix), nil
+	return mapRegexHeaderValueToCondition(string(headerMatch.Name), headerMatch.Value)
+}
+
+func mapRegexHeaderValueToCondition(headerName string, headerValue string) (string, error) {
+	if prefix, swMatched := parseRegexForStartsWith(headerValue); swMatched {
+		return fmt.Sprintf(`http.request.headers[(i '%s')][0] sw (i '%s')`, headerName, prefix), nil
 	}
-	if suffix, ewMatched := parseRegexForEndsWith(headerMatch.Value); ewMatched {
-		return fmt.Sprintf(`http.request.headers[(i '%s')][0] ew (i '%s')`, headerMatch.Name, suffix), nil
+	if suffix, ewMatched := parseRegexForEndsWith(headerValue); ewMatched {
+		return fmt.Sprintf(`http.request.headers[(i '%s')][0] ew (i '%s')`, headerName, suffix), nil
 	}
 	return "", fmt.Errorf(
 		"%w: regex header matching for header '%s'",
 		errUnsupportedMatch,
-		headerMatch.Name,
+		headerName,
 	)
 }
 
@@ -424,7 +457,13 @@ func mapGRPCHeaderMatchToCondition(headerMatch gatewayv1.GRPCHeaderMatch) (strin
 	if headerMatch.Type != nil {
 		headerType = *headerMatch.Type
 	}
-	if headerType != gatewayv1.GRPCHeaderMatchExact {
+
+	switch headerType {
+	case gatewayv1.GRPCHeaderMatchExact:
+		return fmt.Sprintf(`http.request.headers[(i '%s')] eq (i '%s')`, headerMatch.Name, headerMatch.Value), nil
+	case gatewayv1.GRPCHeaderMatchRegularExpression:
+		return mapRegexHeaderValueToCondition(string(headerMatch.Name), headerMatch.Value)
+	default:
 		return "", fmt.Errorf(
 			"%w: unsupported grpc header match type '%s' for header '%s'",
 			errUnsupportedMatch,
@@ -432,6 +471,4 @@ func mapGRPCHeaderMatchToCondition(headerMatch gatewayv1.GRPCHeaderMatch) (strin
 			headerMatch.Name,
 		)
 	}
-
-	return fmt.Sprintf(`http.request.headers[(i '%s')] eq (i '%s')`, headerMatch.Name, headerMatch.Value), nil
 }

--- a/internal/app/oci_load_balancer_routing_rules.go
+++ b/internal/app/oci_load_balancer_routing_rules.go
@@ -42,6 +42,9 @@ func parseRegexLiteral(value string) (string, bool) {
 	var literal strings.Builder
 	for index := 0; index < len(value); index++ {
 		if value[index] != '\\' {
+			if !isOCIConditionLiteralByte(value[index]) {
+				return "", false
+			}
 			if isRegexMetaCharacter(value[index]) {
 				return "", false
 			}
@@ -55,6 +58,9 @@ func parseRegexLiteral(value string) (string, bool) {
 		}
 		switch value[index] {
 		case '.', '/', '\\':
+			if !isOCIConditionLiteralByte(value[index]) {
+				return "", false
+			}
 			literal.WriteByte(value[index])
 		default:
 			return "", false
@@ -71,6 +77,10 @@ func isRegexMetaCharacter(value byte) bool {
 	default:
 		return false
 	}
+}
+
+func isOCIConditionLiteralByte(value byte) bool {
+	return value >= 0x20 && value != 0x7f && value != '\''
 }
 
 type ociLoadBalancerRoutingRulesMapper interface {

--- a/internal/app/oci_load_balancer_routing_rules.go
+++ b/internal/app/oci_load_balancer_routing_rules.go
@@ -85,6 +85,19 @@ func isOCIConditionLiteralByte(value byte) bool {
 	return value >= 0x20 && value != 0x7f && value != '\''
 }
 
+func validateOCIConditionLiteral(valueKind string, value string) error {
+	for index := range len(value) {
+		if !isOCIConditionLiteralByte(value[index]) {
+			return fmt.Errorf(
+				"%w: %s contains characters unsupported by OCI routing policy conditions",
+				errUnsupportedMatch,
+				valueKind,
+			)
+		}
+	}
+	return nil
+}
+
 type ociLoadBalancerRoutingRulesMapper interface {
 	// mapHTTPRouteMatchToCondition translates a Gateway API HTTPRouteMatch
 	// into an OCI Load Balancer condition string.
@@ -174,10 +187,14 @@ func mapPathMatchToCondition(pathMatch gatewayv1.HTTPPathMatch) (string, error) 
 
 	switch pathType {
 	case gatewayv1.PathMatchExact:
-		// TODO: Handle escaping single quotes in pathValue if necessary
+		if err := validateOCIConditionLiteral("path match value", pathValue); err != nil {
+			return "", err
+		}
 		return fmt.Sprintf(`http.request.url.path eq '%s'`, pathValue), nil
 	case gatewayv1.PathMatchPathPrefix:
-		// TODO: Handle escaping single quotes in pathValue if necessary
+		if err := validateOCIConditionLiteral("path match value", pathValue); err != nil {
+			return "", err
+		}
 		return fmt.Sprintf(`http.request.url.path sw '%s'`, pathValue), nil
 	case gatewayv1.PathMatchRegularExpression:
 		return "", fmt.Errorf("%w: regex path matching", errUnsupportedMatch)
@@ -194,9 +211,12 @@ func mapHeaderMatchToCondition(headerMatch gatewayv1.HTTPHeaderMatch) (string, e
 
 	switch headerType {
 	case gatewayv1.HeaderMatchExact:
-		// TODO: Handle escaping single quotes in headerMatch.Value if necessary
-		// Header names are case-insensitive in HTTP, but OCI conditions might be case-sensitive.
-		// Assuming case-sensitive match for now based on Gateway API spec.
+		if err := validateOCIConditionLiteral("header match name", string(headerMatch.Name)); err != nil {
+			return "", err
+		}
+		if err := validateOCIConditionLiteral("header match value", headerMatch.Value); err != nil {
+			return "", err
+		}
 		return fmt.Sprintf(`http.request.headers[(i '%s')] eq (i '%s')`, headerMatch.Name, headerMatch.Value), nil
 	case gatewayv1.HeaderMatchRegularExpression:
 		return mapRegexHeaderMatchToCondition(headerMatch)
@@ -214,6 +234,9 @@ func mapRegexHeaderMatchToCondition(headerMatch gatewayv1.HTTPHeaderMatch) (stri
 }
 
 func mapRegexHeaderValueToCondition(headerName string, headerValue string) (string, error) {
+	if err := validateOCIConditionLiteral("header match name", headerName); err != nil {
+		return "", err
+	}
 	if prefix, swMatched := parseRegexForStartsWith(headerValue); swMatched {
 		return fmt.Sprintf(`http.request.headers[(i '%s')][0] sw (i '%s')`, headerName, prefix), nil
 	}
@@ -548,6 +571,12 @@ func mapGRPCMethodMatchToCondition(methodMatch gatewayv1.GRPCMethodMatch) (strin
 
 	service := strings.TrimPrefix(lo.FromPtr(methodMatch.Service), ".")
 	method := lo.FromPtr(methodMatch.Method)
+	if err := validateOCIConditionLiteral("grpc service match value", service); err != nil {
+		return "", err
+	}
+	if err := validateOCIConditionLiteral("grpc method match value", method); err != nil {
+		return "", err
+	}
 	switch {
 	case service != "" && method != "":
 		return fmt.Sprintf(`http.request.url.path eq '/%s/%s'`, service, method), nil
@@ -568,6 +597,12 @@ func mapGRPCHeaderMatchToCondition(headerMatch gatewayv1.GRPCHeaderMatch) (strin
 
 	switch headerType {
 	case gatewayv1.GRPCHeaderMatchExact:
+		if err := validateOCIConditionLiteral("grpc header match name", string(headerMatch.Name)); err != nil {
+			return "", err
+		}
+		if err := validateOCIConditionLiteral("grpc header match value", headerMatch.Value); err != nil {
+			return "", err
+		}
 		return fmt.Sprintf(`http.request.headers[(i '%s')] eq (i '%s')`, headerMatch.Name, headerMatch.Value), nil
 	case gatewayv1.GRPCHeaderMatchRegularExpression:
 		return mapRegexHeaderValueToCondition(string(headerMatch.Name), headerMatch.Value)

--- a/internal/app/oci_load_balancer_routing_rules.go
+++ b/internal/app/oci_load_balancer_routing_rules.go
@@ -272,7 +272,7 @@ func (r *ociLoadBalancerRoutingRulesMapperImpl) mapHTTPRouteHostnamesAndMatchesT
 				continue
 			}
 			for _, matchCondition := range matchConditions {
-				conditions = append(conditions, "all("+hostCondition+", "+matchCondition+")")
+				conditions = append(conditions, allRoutingConditions(hostCondition, matchCondition))
 			}
 		}
 	}
@@ -343,9 +343,10 @@ func grpcContentTypeConditions() []string {
 }
 
 func allRoutingConditions(conditions ...string) string {
-	filteredConditions := lo.Filter(conditions, func(condition string, _ int) bool {
-		return condition != ""
-	})
+	filteredConditions := make([]string, 0, len(conditions))
+	for _, condition := range conditions {
+		filteredConditions = appendRoutingConditionParts(filteredConditions, condition)
+	}
 	if len(filteredConditions) == 0 {
 		return ""
 	}
@@ -353,6 +354,21 @@ func allRoutingConditions(conditions ...string) string {
 		return filteredConditions[0]
 	}
 	return "all(" + strings.Join(filteredConditions, ", ") + ")"
+}
+
+func appendRoutingConditionParts(conditions []string, condition string) []string {
+	if condition == "" {
+		return conditions
+	}
+	inner, ok := strings.CutPrefix(condition, "all(")
+	if !ok {
+		return append(conditions, condition)
+	}
+	inner, ok = strings.CutSuffix(inner, ")")
+	if !ok {
+		return append(conditions, condition)
+	}
+	return append(conditions, strings.Split(inner, ", ")...)
 }
 
 func (r *ociLoadBalancerRoutingRulesMapperImpl) mapGRPCRouteMatchesToCondition(

--- a/internal/app/oci_load_balancer_routing_rules.go
+++ b/internal/app/oci_load_balancer_routing_rules.go
@@ -11,6 +11,8 @@ import (
 
 var errUnsupportedMatch = errors.New("unsupported match type")
 
+const conditionArgumentSeparatorLength = len(", ")
+
 // Returns the prefix and true if it matches, empty string and false otherwise.
 func parseRegexForStartsWith(pattern string) (string, bool) {
 	value, ok := strings.CutPrefix(pattern, "^")
@@ -378,7 +380,87 @@ func appendRoutingConditionParts(conditions []string, condition string) []string
 	if !ok {
 		return append(conditions, condition)
 	}
-	return append(conditions, strings.Split(inner, ", ")...)
+	parts, ok := splitOCIConditionArguments(inner)
+	if !ok {
+		return append(conditions, condition)
+	}
+	return append(conditions, parts...)
+}
+
+func splitOCIConditionArguments(value string) ([]string, bool) {
+	if value == "" {
+		return nil, false
+	}
+
+	var parts []string
+	start := 0
+	depth := 0
+	inLiteral := false
+	for index := 0; index < len(value); index++ {
+		char := value[index]
+		if char == '\'' {
+			inLiteral = !inLiteral
+			continue
+		}
+		if inLiteral {
+			continue
+		}
+
+		nextDepth, ok := updateOCIConditionDepth(depth, char)
+		if !ok {
+			return nil, false
+		}
+		depth = nextDepth
+		if char != ',' || depth != 0 {
+			continue
+		}
+
+		if !hasOCIConditionArgumentSeparator(value, index) {
+			return nil, false
+		}
+		var part string
+		part, ok = trimOCIConditionArgument(value[start:index])
+		if !ok {
+			return nil, false
+		}
+		parts = append(parts, part)
+		start = index + conditionArgumentSeparatorLength
+		index++
+	}
+	if inLiteral || depth != 0 {
+		return nil, false
+	}
+
+	part, ok := trimOCIConditionArgument(value[start:])
+	if !ok {
+		return nil, false
+	}
+	parts = append(parts, part)
+	return parts, true
+}
+
+func updateOCIConditionDepth(depth int, value byte) (int, bool) {
+	switch value {
+	case '(':
+		return depth + 1, true
+	case ')':
+		depth--
+		return depth, depth >= 0
+	default:
+		return depth, true
+	}
+}
+
+func hasOCIConditionArgumentSeparator(value string, index int) bool {
+	return index+1 < len(value) && value[index+1] == ' '
+}
+
+func trimOCIConditionArgument(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+	return value, true
 }
 
 func (r *ociLoadBalancerRoutingRulesMapperImpl) mapGRPCRouteMatchesToCondition(

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -41,6 +41,16 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 				wantOK: false,
 			},
 			{
+				name:   "rejects single quote",
+				value:  `api'admin`,
+				wantOK: false,
+			},
+			{
+				name:   "rejects control character",
+				value:  "api\nadmin",
+				wantOK: false,
+			},
+			{
 				name:   "unescapes slash dot and backslash",
 				value:  `v1\/api\.example\\internal`,
 				want:   `v1/api.example\internal`,
@@ -421,6 +431,40 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
 								Name:  gatewayv1.HTTPHeaderName(headerName),
 								Value: "^[a-z]+$",
+							},
+						},
+					},
+					wantErrIs: errUnsupportedMatch,
+				}
+			},
+			func() testCase {
+				fake := faker.New()
+				headerName := "X-" + fake.Lorem().Word()
+				return testCase{
+					name: "regex header match - rejects single quote in translated prefix",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  gatewayv1.HTTPHeaderName(headerName),
+								Value: "^tenant'" + fake.Lorem().Word() + ".*",
+							},
+						},
+					},
+					wantErrIs: errUnsupportedMatch,
+				}
+			},
+			func() testCase {
+				fake := faker.New()
+				headerName := "X-" + fake.Lorem().Word()
+				return testCase{
+					name: "regex header match - rejects control character in translated suffix",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  gatewayv1.HTTPHeaderName(headerName),
+								Value: ".*tenant\n" + fake.Lorem().Word() + "$",
 							},
 						},
 					},
@@ -1245,6 +1289,30 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 								Type:  &headerType,
 								Name:  "Host",
 								Value: `^api-[0-9]+\.example\.com$`,
+							},
+						},
+					},
+				},
+			)
+
+			require.ErrorIs(t, err, errUnsupportedMatch)
+		})
+
+		t.Run("rejects unsafe regex header matching", func(t *testing.T) {
+			fake := faker.New()
+			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  gatewayv1.GRPCHeaderName("x-" + fake.Lorem().Word()),
+								Value: ".*tenant'" + fake.Lorem().Word() + "$",
 							},
 						},
 					},

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -372,6 +372,30 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 				}
 			},
 			func() testCase {
+				fake := faker.New()
+				headerName := "X-" + fake.Lorem().Word()
+				pathPrefix := fake.Lorem().Word()
+				pathSuffix := fake.Lorem().Word()
+				return testCase{
+					name: "regex header match - ends with escaped slash and backslash suffix",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  gatewayv1.HTTPHeaderName(headerName),
+								Value: fmt.Sprintf(`.*%s\/\\%s$`, pathPrefix, pathSuffix),
+							},
+						},
+					},
+					want: fmt.Sprintf(
+						`http.request.headers[(i '%s')][0] ew (i '%s/\%s')`,
+						headerName,
+						pathPrefix,
+						pathSuffix,
+					),
+				}
+			},
+			func() testCase {
 				return testCase{
 					name: "regex header match - rejects mixed prefix and suffix",
 					match: gatewayv1.HTTPRouteMatch{

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -13,6 +13,51 @@ import (
 )
 
 func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
+	t.Run("parseRegexLiteral", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			value  string
+			want   string
+			wantOK bool
+		}{
+			{
+				name:   "rejects empty value",
+				value:  "",
+				wantOK: false,
+			},
+			{
+				name:   "rejects dangling escape",
+				value:  `api\`,
+				wantOK: false,
+			},
+			{
+				name:   "rejects unsupported escape",
+				value:  `api\-`,
+				wantOK: false,
+			},
+			{
+				name:   "rejects regex metacharacter",
+				value:  `api+`,
+				wantOK: false,
+			},
+			{
+				name:   "unescapes slash dot and backslash",
+				value:  `v1\/api\.example\\internal`,
+				want:   `v1/api.example\internal`,
+				wantOK: true,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				got, ok := parseRegexLiteral(tc.value)
+
+				assert.Equal(t, tc.wantOK, ok)
+				assert.Equal(t, tc.want, got)
+			})
+		}
+	})
+
 	t.Run("mapHTTPRouteMatchToCondition", func(t *testing.T) {
 		type testCase struct {
 			name        string
@@ -263,6 +308,36 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 				}
 			},
 			func() testCase {
+				return testCase{
+					name: "regex header match - starts with host prefix from issue",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  "Host",
+								Value: `^community-manager-api\..*$`,
+							},
+						},
+					},
+					want: `http.request.headers[(i 'Host')][0] sw (i 'community-manager-api.')`,
+				}
+			},
+			func() testCase {
+				return testCase{
+					name: "regex header match - starts with slash prefix",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  "X-API-Version",
+								Value: `^v1\/`,
+							},
+						},
+					},
+					want: `http.request.headers[(i 'X-API-Version')][0] sw (i 'v1/')`,
+				}
+			},
+			func() testCase {
 				fake := faker.New()
 				headerName := "X-" + fake.Lorem().Word()
 				return testCase{
@@ -294,6 +369,21 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 						},
 					},
 					want: fmt.Sprintf(`http.request.headers[(i '%s')][0] ew (i 'foo.bar')`, headerName),
+				}
+			},
+			func() testCase {
+				return testCase{
+					name: "regex header match - rejects mixed prefix and suffix",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  "Host",
+								Value: `^api.*example\.com$`,
+							},
+						},
+					},
+					wantErrIs: errUnsupportedMatch,
 				}
 			},
 			func() testCase {
@@ -988,7 +1078,129 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 							{
 								Type:  &headerType,
 								Name:  gatewayv1.GRPCHeaderName("x-" + fake.Lorem().Word()),
-								Value: "^" + fake.Lorem().Word(),
+								Value: "^[a-z]+$",
+							},
+						},
+					},
+				},
+			)
+
+			require.ErrorIs(t, err, errUnsupportedMatch)
+		})
+
+		t.Run("maps regex host header matching", func(t *testing.T) {
+			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  "Host",
+								Value: `^community-manager-api\..*$`,
+							},
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			wantHeaderCondition := `http.request.headers[(i 'Host')][0] sw (i 'community-manager-api.')`
+			assert.Equal(t, fmt.Sprintf("any(%s)", grpcBranches(nil, wantHeaderCondition)), actual)
+		})
+
+		t.Run("maps regex non host header prefix matching", func(t *testing.T) {
+			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  "X-API-Version",
+								Value: `^v1\/`,
+							},
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			wantHeaderCondition := `http.request.headers[(i 'X-API-Version')][0] sw (i 'v1/')`
+			assert.Equal(t, fmt.Sprintf("any(%s)", grpcBranches(nil, wantHeaderCondition)), actual)
+		})
+
+		t.Run("maps regex non host header suffix matching", func(t *testing.T) {
+			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  "X-Tenant",
+								Value: `-prod$`,
+							},
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			wantHeaderCondition := `http.request.headers[(i 'X-Tenant')][0] ew (i '-prod')`
+			assert.Equal(t, fmt.Sprintf("any(%s)", grpcBranches(nil, wantHeaderCondition)), actual)
+		})
+
+		t.Run("rejects unsupported regex header matching", func(t *testing.T) {
+			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  "Host",
+								Value: `^api-[0-9]+\.example\.com$`,
+							},
+						},
+					},
+				},
+			)
+
+			require.ErrorIs(t, err, errUnsupportedMatch)
+		})
+
+		t.Run("rejects unknown header match type", func(t *testing.T) {
+			fake := faker.New()
+			headerType := gatewayv1.GRPCHeaderMatchType("Unknown")
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  gatewayv1.GRPCHeaderName("x-" + fake.Lorem().Word()),
+								Value: fake.Lorem().Word(),
 							},
 						},
 					},

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -809,6 +809,50 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			)
 			assert.Equal(t, want, actual)
 		})
+
+		t.Run("flattens hostname with path and regex header conditions", func(t *testing.T) {
+			fake := faker.New()
+			hostname := gatewayv1.Hostname("api-" + fake.Internet().Domain())
+			pathValue := "/" + fake.Lorem().Word()
+			headerPrefix := "beta-" + fake.Lorem().Word()
+			headerName := gatewayv1.HTTPHeaderName("x-" + fake.Lorem().Word())
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapHTTPRouteHostnamesAndMatchesToCondition(
+				[]gatewayv1.Hostname{hostname},
+				0,
+				[]gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  lo.ToPtr(gatewayv1.PathMatchPathPrefix),
+							Value: &pathValue,
+						},
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  headerName,
+								Value: "^" + headerPrefix + ".*",
+							},
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			want := fmt.Sprintf(
+				"any(all("+
+					"http.request.headers[(i 'host')] eq (i '%s'), "+
+					"http.request.url.path sw '%s', "+
+					"http.request.headers[(i '%s')][0] sw (i '%s')"+
+					"))",
+				hostname,
+				pathValue,
+				headerName,
+				headerPrefix,
+			)
+			assert.Equal(t, want, actual)
+			assert.NotContains(t, actual, "all(http.request.url.path")
+		})
 	})
 
 	t.Run("mapGRPCRouteHostnamesAndMatchesToCondition", func(t *testing.T) {
@@ -1184,6 +1228,52 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			)
 
 			require.ErrorIs(t, err, errUnsupportedMatch)
+		})
+
+		t.Run("flattens hostname with content type method and regex header conditions", func(t *testing.T) {
+			fake := faker.New()
+			hostname := gatewayv1.Hostname("grpc-" + fake.Internet().Domain())
+			service := "svc." + fake.Lorem().Word()
+			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
+			headerName := gatewayv1.GRPCHeaderName("x-" + fake.Lorem().Word())
+			headerPrefix := "grpc-" + fake.Lorem().Word()
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			actual, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				[]gatewayv1.Hostname{hostname},
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Method: &gatewayv1.GRPCMethodMatch{
+							Service: &service,
+						},
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  headerName,
+								Value: "^" + headerPrefix + ".*",
+							},
+						},
+					},
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Contains(
+				t,
+				actual,
+				fmt.Sprintf(
+					"all(http.request.headers[(i 'host')] eq (i '%s'), "+
+						"http.request.headers[(i 'content-type')][0] eq (i 'application/grpc'), "+
+						"http.request.url.path sw '/%s/', "+
+						"http.request.headers[(i '%s')][0] sw (i '%s'))",
+					hostname,
+					service,
+					headerName,
+					headerPrefix,
+				),
+			)
+			assert.NotContains(t, actual, "all(http.request.url.path")
 		})
 
 		t.Run("rejects unknown header match type", func(t *testing.T) {

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -108,6 +108,20 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			},
 			func() testCase {
 				fake := faker.New()
+				pathValue := "/" + fake.Lorem().Word() + "'bad"
+				return testCase{
+					name: "rejects path value with single quote",
+					match: gatewayv1.HTTPRouteMatch{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  lo.ToPtr(gatewayv1.PathMatchExact),
+							Value: &pathValue,
+						},
+					},
+					wantErrIs: errUnsupportedMatch,
+				}
+			},
+			func() testCase {
+				fake := faker.New()
 				headerName := "X-" + fake.Lorem().Word()
 				headerValue := fake.UUID().V4()
 				return testCase{
@@ -122,6 +136,39 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 						},
 					},
 					want: fmt.Sprintf(`http.request.headers[(i '%s')] eq (i '%s')`, headerName, headerValue),
+				}
+			},
+			func() testCase {
+				fake := faker.New()
+				return testCase{
+					name: "rejects exact header name with single quote",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchExact),
+								Name:  gatewayv1.HTTPHeaderName("x-" + fake.Lorem().Word() + "'bad"),
+								Value: fake.UUID().V4(),
+							},
+						},
+					},
+					wantErrIs: errUnsupportedMatch,
+				}
+			},
+			func() testCase {
+				fake := faker.New()
+				headerName := "X-" + fake.Lorem().Word()
+				return testCase{
+					name: "rejects exact header value with control character",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchExact),
+								Name:  gatewayv1.HTTPHeaderName(headerName),
+								Value: "tenant\n" + fake.Lorem().Word(),
+							},
+						},
+					},
+					wantErrIs: errUnsupportedMatch,
 				}
 			},
 			func() testCase {
@@ -465,6 +512,23 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
 								Name:  gatewayv1.HTTPHeaderName(headerName),
 								Value: ".*tenant\n" + fake.Lorem().Word() + "$",
+							},
+						},
+					},
+					wantErrIs: errUnsupportedMatch,
+				}
+			},
+			func() testCase {
+				fake := faker.New()
+				headerName := "X-" + fake.Lorem().Word()
+				return testCase{
+					name: "regex header match - rejects unsafe header name",
+					match: gatewayv1.HTTPRouteMatch{
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{
+								Type:  lo.ToPtr(gatewayv1.HeaderMatchRegularExpression),
+								Name:  gatewayv1.HTTPHeaderName(headerName + "'bad"),
+								Value: "^tenant" + fake.Lorem().Word() + ".*",
 							},
 						},
 					},
@@ -1343,6 +1407,26 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 			require.ErrorIs(t, err, errUnsupportedMatch)
 		})
 
+		t.Run("rejects unsafe exact method matching", func(t *testing.T) {
+			fake := faker.New()
+			service := "svc'" + fake.Lorem().Word()
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Method: &gatewayv1.GRPCMethodMatch{
+							Service: &service,
+						},
+					},
+				},
+			)
+
+			require.ErrorIs(t, err, errUnsupportedMatch)
+		})
+
 		t.Run("rejects regex header matching", func(t *testing.T) {
 			fake := faker.New()
 			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
@@ -1480,6 +1564,54 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 								Type:  &headerType,
 								Name:  gatewayv1.GRPCHeaderName("x-" + fake.Lorem().Word()),
 								Value: ".*tenant'" + fake.Lorem().Word() + "$",
+							},
+						},
+					},
+				},
+			)
+
+			require.ErrorIs(t, err, errUnsupportedMatch)
+		})
+
+		t.Run("rejects unsafe exact header matching", func(t *testing.T) {
+			fake := faker.New()
+			headerType := gatewayv1.GRPCHeaderMatchExact
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  gatewayv1.GRPCHeaderName("x-" + fake.Lorem().Word()),
+								Value: "tenant'" + fake.Lorem().Word(),
+							},
+						},
+					},
+				},
+			)
+
+			require.ErrorIs(t, err, errUnsupportedMatch)
+		})
+
+		t.Run("rejects unsafe regex header name", func(t *testing.T) {
+			fake := faker.New()
+			headerType := gatewayv1.GRPCHeaderMatchRegularExpression
+
+			rs := newOciLoadBalancerRoutingRulesMapper()
+			_, err := rs.mapGRPCRouteHostnamesAndMatchesToCondition(
+				nil,
+				0,
+				[]gatewayv1.GRPCRouteMatch{
+					{
+						Headers: []gatewayv1.GRPCHeaderMatch{
+							{
+								Type:  &headerType,
+								Name:  gatewayv1.GRPCHeaderName("x-" + fake.Lorem().Word() + "'bad"),
+								Value: "^tenant" + fake.Lorem().Word() + ".*",
 							},
 						},
 					},

--- a/internal/app/oci_load_balancer_routing_rules_test.go
+++ b/internal/app/oci_load_balancer_routing_rules_test.go
@@ -923,6 +923,173 @@ func TestOciLoadBalancerRoutingRulesMapper(t *testing.T) {
 		})
 	})
 
+	t.Run("allRoutingConditions", func(t *testing.T) {
+		fake := faker.New()
+		hostCondition := fmt.Sprintf(
+			"http.request.headers[(i 'host')] eq (i '%s')",
+			"api-"+fake.Internet().Domain(),
+		)
+		pathCondition := fmt.Sprintf("http.request.url.path sw '/%s'", fake.Lorem().Word())
+		headerCondition := fmt.Sprintf(
+			"http.request.headers[(i 'accept')] eq (i '%s, %s')",
+			"text/"+fake.Lorem().Word(),
+			"application/"+fake.Lorem().Word(),
+		)
+		nestedCondition := fmt.Sprintf(
+			"any(%s, %s)",
+			fmt.Sprintf("http.request.headers[(i 'x-first')] eq (i '%s')", fake.UUID().V4()),
+			fmt.Sprintf("http.request.headers[(i 'x-second')] eq (i '%s')", fake.UUID().V4()),
+		)
+
+		tests := []struct {
+			name       string
+			conditions []string
+			want       string
+		}{
+			{
+				name: "flattens simple all condition",
+				conditions: []string{
+					hostCondition,
+					fmt.Sprintf("all(%s, %s)", pathCondition, nestedCondition),
+				},
+				want: fmt.Sprintf("all(%s, %s, %s)", hostCondition, pathCondition, nestedCondition),
+			},
+			{
+				name: "does not split comma inside literal",
+				conditions: []string{
+					hostCondition,
+					fmt.Sprintf("all(%s, %s)", pathCondition, headerCondition),
+				},
+				want: fmt.Sprintf("all(%s, %s, %s)", hostCondition, pathCondition, headerCondition),
+			},
+			{
+				name: "does not split comma inside nested condition",
+				conditions: []string{
+					hostCondition,
+					fmt.Sprintf("all(%s, %s)", nestedCondition, pathCondition),
+				},
+				want: fmt.Sprintf("all(%s, %s, %s)", hostCondition, nestedCondition, pathCondition),
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, allRoutingConditions(tc.conditions...))
+			})
+		}
+	})
+
+	t.Run("appendRoutingConditionParts", func(t *testing.T) {
+		fake := faker.New()
+		pathCondition := fmt.Sprintf("http.request.url.path sw '/%s'", fake.Lorem().Word())
+		headerCondition := fmt.Sprintf(
+			"http.request.headers[(i 'accept')] eq (i '%s, %s')",
+			"text/"+fake.Lorem().Word(),
+			"application/"+fake.Lorem().Word(),
+		)
+		nestedCondition := fmt.Sprintf(
+			"any(%s, %s)",
+			fmt.Sprintf("http.request.headers[(i 'x-first')] eq (i '%s')", fake.UUID().V4()),
+			fmt.Sprintf("http.request.headers[(i 'x-second')] eq (i '%s')", fake.UUID().V4()),
+		)
+
+		tests := []struct {
+			name      string
+			condition string
+			want      []string
+		}{
+			{
+				name:      "flattens simple all condition",
+				condition: fmt.Sprintf("all(%s, %s)", pathCondition, headerCondition),
+				want:      []string{pathCondition, headerCondition},
+			},
+			{
+				name:      "does not split comma inside literal",
+				condition: fmt.Sprintf("all(%s, %s)", headerCondition, pathCondition),
+				want:      []string{headerCondition, pathCondition},
+			},
+			{
+				name:      "does not split comma inside nested condition",
+				condition: fmt.Sprintf("all(%s, %s)", nestedCondition, pathCondition),
+				want:      []string{nestedCondition, pathCondition},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, appendRoutingConditionParts(nil, tc.condition))
+			})
+		}
+	})
+
+	t.Run("splitOCIConditionArguments", func(t *testing.T) {
+		fake := faker.New()
+		firstCondition := fmt.Sprintf("http.request.url.path sw '/%s'", fake.Lorem().Word())
+		secondCondition := fmt.Sprintf(
+			"http.request.headers[(i 'x-%s')] eq (i '%s')",
+			fake.Lorem().Word(),
+			fake.UUID().V4(),
+		)
+
+		tests := []struct {
+			name   string
+			value  string
+			want   []string
+			wantOK bool
+		}{
+			{
+				name:   "splits top level arguments",
+				value:  fmt.Sprintf("%s, %s", firstCondition, secondCondition),
+				want:   []string{firstCondition, secondCondition},
+				wantOK: true,
+			},
+			{
+				name:   "rejects empty input",
+				value:  "",
+				wantOK: false,
+			},
+			{
+				name:   "rejects comma without following space",
+				value:  fmt.Sprintf("%s,%s", firstCondition, secondCondition),
+				wantOK: false,
+			},
+			{
+				name:   "rejects empty first argument",
+				value:  ", " + secondCondition,
+				wantOK: false,
+			},
+			{
+				name:   "rejects empty final argument",
+				value:  firstCondition + ", ",
+				wantOK: false,
+			},
+			{
+				name:   "rejects unmatched literal",
+				value:  fmt.Sprintf("%s, http.request.url.path sw '/%s", firstCondition, fake.Lorem().Word()),
+				wantOK: false,
+			},
+			{
+				name:   "rejects unbalanced open paren",
+				value:  fmt.Sprintf("any(%s, %s", firstCondition, secondCondition),
+				wantOK: false,
+			},
+			{
+				name:   "rejects unbalanced close paren",
+				value:  fmt.Sprintf("%s), %s", firstCondition, secondCondition),
+				wantOK: false,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				got, ok := splitOCIConditionArguments(tc.value)
+
+				assert.Equal(t, tc.wantOK, ok)
+				assert.Equal(t, tc.want, got)
+			})
+		}
+	})
+
 	t.Run("mapGRPCRouteHostnamesAndMatchesToCondition", func(t *testing.T) {
 		grpcBranches := func(prefix []string, suffix ...string) string {
 			branches := make([]string, 0, len(grpcContentTypeConditions()))


### PR DESCRIPTION
## Summary

Adds support for Gateway API RegularExpression header matches when they can be translated to OCI Load Balancer routing policy conditions.

Closes #34.

Supported regex forms:

- Prefix match: ^value or ^value.*
- Suffix match: value$ or .*value$
- Escaped literals for ., /, and \

Unsupported complex regex patterns are rejected with Accepted=False and reason UnsupportedValue instead of creating invalid OCI routing policy rules.

## `HTTPRoute` example
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: tenant-api
spec:
  parentRefs:
    - name: app-gateway
      sectionName: https
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
          headers:
            - name: Host
              type: RegularExpression
              value: '^api-.*'
      backendRefs:
        - name: tenant-api
          port: 8080
```

### Matching request:
```bash
curl -vk \
  --resolve api-prod.example.com:443:<LOAD_BALANCER_IP> \
  https://api-prod.example.com/
```

### Non-matching request:
```bash
curl -vk \
  --resolve web-prod.example.com:443:<LOAD_BALANCER_IP> \
  https://web-prod.example.com/
```

## `GRPCRoute` example:
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: GRPCRoute
metadata:
  name: tenant-grpc
spec:
  parentRefs:
    - name: app-gateway
      sectionName: https
  rules:
    - matches:
        - headers:
            - name: Host
              type: RegularExpression
              value: '^grpc-.*'
      backendRefs:
        - name: tenant-grpc
          port: 8080
```

### Matching request:
```bash
grpcurl -vv -insecure \
  -authority grpc-prod.example.com \
  <LOAD_BALANCER_IP>:443 list
```

### Non-matching request:
```bash
grpcurl -vv -insecure \
  -authority api-prod.example.com \
  <LOAD_BALANCER_IP>:443 list
```